### PR TITLE
Move client_max_body_size inside correct context

### DIFF
--- a/util/ansible/roles/nginx/templates/default.j2
+++ b/util/ansible/roles/nginx/templates/default.j2
@@ -1,5 +1,3 @@
-client_max_body_size 50M;
-
 server {
     listen 80;
     listen 443 default_server ssl;
@@ -18,6 +16,8 @@ server {
 
     access_log {{ app_base }}/www_tmp/access.log;
     error_log {{ app_base }}/www_tmp/error.log;
+    
+    client_max_body_size 50M;
 
     location / {
         try_files $uri @clean_url;


### PR DESCRIPTION
This prevents nginx from whining in combination with other configurations, making the same mistake (setting it outside of context, a second time)
The [documentation](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) states it can be used inside the following contexts: http, server, location.