### PR TITLE
Upgrade to our own fork of Icecast-KH

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -33,7 +33,7 @@ else
 fi
 
 APP_ENV="${APP_ENV:-production}"
-UPDATE_REVISION="${UPDATE_REVISION:-25}"
+UPDATE_REVISION="${UPDATE_REVISION:-26}"
 
 echo "Updating AzuraCast (Environment: $APP_ENV, Update revision: $UPDATE_REVISION)"
 

--- a/util/ansible/roles/azuracast-radio/tasks/x86.yml
+++ b/util/ansible/roles/azuracast-radio/tasks/x86.yml
@@ -1,5 +1,5 @@
 ---
-  - name: Install IceCast-KH Dependencies
+  - name: Install IceCast-KH-AC Dependencies
     apt: pkg="{{ item }}" install_recommends=no state=latest
     with_items:
      - libxml2
@@ -9,12 +9,12 @@
      - libcurl4-openssl-dev
      - pkg-config
 
-  - name: Download IceCast-KH Source
+  - name: Download IceCast-KH-AC Source
     get_url:
-      url: https://github.com/karlheyes/icecast-kh/archive/icecast-2.4.0-kh10.tar.gz
+      url: https://github.com/AzuraCast/icecast-kh-ac/archive/master.tar.gz
       dest: "{{ app_base }}/servers/icecast2/icecast2.tar.gz"
 
-  - name: Extract IceCast-KH Source
+  - name: Extract IceCast-KH-AC Source
     unarchive:
       src: "{{ app_base }}/servers/icecast2/icecast2.tar.gz"
       dest: "{{ app_base }}/servers/icecast2"
@@ -25,7 +25,7 @@
       group: "www-data"
       extra_opts: "--strip-components=1"
 
-  - name: Build IceCast-KH
+  - name: Build IceCast-KH-AC
     shell: "cd {{ app_base }}/servers/icecast2 && ./configure && make && make install"
     args:
       chdir: "{{ app_base }}/servers/icecast2"

--- a/util/ansible/update.yml
+++ b/util/ansible/update.yml
@@ -13,7 +13,7 @@
   roles:
     - init
     - azuracast-config
-    - { role: azuracast-radio, when: update_revision|int < 25 }
+    - { role: azuracast-radio, when: update_revision|int < 26 }
     - { role: supervisord, when: update_revision|int < 13 }
     - { role: mariadb, when: update_revision|int < 15 }
     - { role: nginx, when: update_revision|int < 23 }


### PR DESCRIPTION
I mentioned in #845 that the traditional install doesn't use our fork of Icecast because the changes were mostly for docker...


Unify the Icecast version we use anyway?