### PR TITLE
Fix issues with Ansible upgrade on Icecast

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -33,7 +33,7 @@ else
 fi
 
 APP_ENV="${APP_ENV:-production}"
-UPDATE_REVISION="${UPDATE_REVISION:-26}"
+UPDATE_REVISION="${UPDATE_REVISION:-27}"
 
 echo "Updating AzuraCast (Environment: $APP_ENV, Update revision: $UPDATE_REVISION)"
 

--- a/util/ansible/roles/azuracast-radio/tasks/x86.yml
+++ b/util/ansible/roles/azuracast-radio/tasks/x86.yml
@@ -13,13 +13,13 @@
     get_url:
       url: https://github.com/AzuraCast/icecast-kh-ac/archive/master.tar.gz
       dest: "{{ app_base }}/servers/icecast2/icecast2.tar.gz"
+      force: yes
 
   - name: Extract IceCast-KH-AC Source
     unarchive:
       src: "{{ app_base }}/servers/icecast2/icecast2.tar.gz"
       dest: "{{ app_base }}/servers/icecast2"
       remote_src: yes
-      creates: "{{ app_base }}/servers/icecast2/configure"
       mode: "u=rwx,g=rx,o=rx"
       owner: "azuracast"
       group: "www-data"
@@ -29,7 +29,6 @@
     shell: "cd {{ app_base }}/servers/icecast2 && ./configure && make && make install"
     args:
       chdir: "{{ app_base }}/servers/icecast2"
-      creates: "/usr/local/bin/icecast"
 
   - name: Install OPAM
     apt: pkg="opam" install_recommends=yes state=latest

--- a/util/ansible/update.yml
+++ b/util/ansible/update.yml
@@ -13,7 +13,7 @@
   roles:
     - init
     - azuracast-config
-    - { role: azuracast-radio, when: update_revision|int < 26 }
+    - { role: azuracast-radio, when: update_revision|int < 27 }
     - { role: supervisord, when: update_revision|int < 13 }
     - { role: mariadb, when: update_revision|int < 15 }
     - { role: nginx, when: update_revision|int < 23 }


### PR DESCRIPTION
Fixes #845

A list of things:
* Without force, `get_url` won't download a new .tar.gz because it already exists.
* `unarchive` with `creates` will not unarchive the new .tar.gz
* `shell` with `creates` will not compile the source because the icecast binary is already installed.
* Bump the version number to force a recompilation from people that already upgraded to 26 (otherwise we need to ask everyone to manually run `UPDATE_REVISION=25 ./update.sh`)

Also: multiline comments suck on Windows Git CLI, otherwise I'd include all of this in the commit message. 

![Shrug](https://i.imgur.com/phbLmea.png)