### PR TITLE
Fix error in call to disconnectStreamer() in ServicesController - fixes #896

### DIFF
--- a/src/Controller/Api/Stations/ServicesController.php
+++ b/src/Controller/Api/Stations/ServicesController.php
@@ -157,7 +157,7 @@ class ServicesController
 
             case "disconnect":
                 if (method_exists($backend, 'disconnectStreamer')) {
-                    $backend->disconnectStreamer();
+                    $backend->disconnectStreamer($station);
                 }
 
                 return $response->withJson(new Entity\Api\Status(true, __('Streamer disconnected.')));


### PR DESCRIPTION
When calling the `POST` route `/station/{station_id}/backend/disconnect` the response is an error with the following message:

`Too few arguments to function App\Radio\Backend\Liquidsoap::disconnectStreamer(), 0 passed in /var/azuracast/www/src/Controller/Api/Stations/ServicesController.php on line 160 and exactly 1 expected`

This PR fixes this by adding the `$station` as parameter to the call to `disconnectStreamer()`.