### PR TITLE
Deactivate streamer on manual disconnect - implements #898

### DIFF
--- a/config/forms/station.php
+++ b/config/forms/station.php
@@ -284,6 +284,17 @@ return [
                         'step' => '0.1',
                     ]
                 ],
+                
+                'disconnect_deactivate_streamer' => [
+                    'number',
+                    [
+                        'label' => __('Deactivate Streamer on Disconnect (Seconds)'),
+                        'description' => __('Number of seconds to deactivate station streamer on manual disconnect. Set to 0 to disable deactivation completely.'),
+                        'default' => 0,
+                        'min' => '0',
+                        'step' => '1',
+                    ]
+                ],
 
                 'use_manual_autodj' => [
                     'radio',

--- a/src/Entity/Migration/Version20181025232600.php
+++ b/src/Entity/Migration/Version20181025232600.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add reactivate_at to station_streamers table
+ */
+final class Version20181025232600 extends AbstractMigration
+{
+	public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE station_streamers ADD reactivate_at INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE station_streamers DROP reactivate_at');
+    }
+}

--- a/src/Entity/Migration/Version20181025232600.php
+++ b/src/Entity/Migration/Version20181025232600.php
@@ -15,7 +15,7 @@ final class Version20181025232600 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-		$this->addSql('ALTER TABLE station ADD disconnect_deactivate_streamer INT DEFAULT 0');
+        $this->addSql('ALTER TABLE station ADD disconnect_deactivate_streamer INT DEFAULT 0');
         $this->addSql('ALTER TABLE station_streamers ADD reactivate_at INT DEFAULT NULL');
     }
 
@@ -25,6 +25,6 @@ final class Version20181025232600 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE station_streamers DROP reactivate_at');
-		$this->addSql('ALTER TABLE station DROP disconnect_deactivate_streamer');
+        $this->addSql('ALTER TABLE station DROP disconnect_deactivate_streamer');
     }
 }

--- a/src/Entity/Migration/Version20181025232600.php
+++ b/src/Entity/Migration/Version20181025232600.php
@@ -15,6 +15,7 @@ final class Version20181025232600 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
+		$this->addSql('ALTER TABLE station ADD disconnect_deactivate_streamer INT DEFAULT 0');
         $this->addSql('ALTER TABLE station_streamers ADD reactivate_at INT DEFAULT NULL');
     }
 
@@ -24,5 +25,6 @@ final class Version20181025232600 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE station_streamers DROP reactivate_at');
+		$this->addSql('ALTER TABLE station DROP disconnect_deactivate_streamer');
     }
 }

--- a/src/Entity/Repository/StationStreamerRepository.php
+++ b/src/Entity/Repository/StationStreamerRepository.php
@@ -34,4 +34,20 @@ class StationStreamerRepository extends BaseRepository
             ? $streamer
             : false;
     }
+
+    /**
+     * Fetch all streamers who are deactivated and have a reactivate at timestamp set
+     *
+     * @param int $reactivate_at
+     * @return Entity\StationStreamer[]
+     */
+    public function fetchDeactivatedStreamersWithReactivateAtLowerThan(int $reactivate_at)
+    {
+        return $this->createQueryBuilder('s')
+            ->where('s.is_active = 0')
+            ->andWhere('s.reactivate_at <= :reactivate_at')
+            ->setParameter('reactivate_at', $reactivate_at)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/src/Entity/Station.php
+++ b/src/Entity/Station.php
@@ -694,7 +694,7 @@ class Station
     /**
      * @return int
      */
-    public function getDisconnectDeactivateStreamer()
+    public function getDisconnectDeactivateStreamer(): int
     {
         return $this->disconnect_deactivate_streamer;
     }

--- a/src/Entity/Station.php
+++ b/src/Entity/Station.php
@@ -20,6 +20,7 @@ class Station
 {
     public const DEFAULT_REQUEST_DELAY = 5;
     public const DEFAULT_REQUEST_THRESHOLD = 15;
+    public const DEFAULT_DISCONNECT_DEACTIVATE_STREAMER = 0;
     public const DEFAULT_API_HISTORY_ITEMS = 5;
 
     use Traits\TruncateStrings;
@@ -145,6 +146,12 @@ class Station
      * @var int|null
      */
     protected $request_threshold = self::DEFAULT_REQUEST_THRESHOLD;
+
+    /**
+     * @Column(name="disconnect_deactivate_streamer", type="integer", nullable=false)
+     * @var int
+     */
+    protected $disconnect_deactivate_streamer = self::DEFAULT_DISCONNECT_DEACTIVATE_STREAMER;
 
     /**
      * @Column(name="enable_streamers", type="boolean", nullable=false)
@@ -682,6 +689,22 @@ class Station
     public function setRequestThreshold(int $request_threshold = null)
     {
         $this->request_threshold = $request_threshold;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDisconnectDeactivateStreamer()
+    {
+        return $this->disconnect_deactivate_streamer;
+    }
+
+    /**
+     * @param int $disconnect_deactivate_streamer
+     */
+    public function setDisconnectDeactivateStreamer(int $disconnect_deactivate_streamer)
+    {
+        $this->disconnect_deactivate_streamer = $disconnect_deactivate_streamer;
     }
 
     /**

--- a/src/Entity/StationStreamer.php
+++ b/src/Entity/StationStreamer.php
@@ -65,6 +65,12 @@ class StationStreamer
      */
     protected $is_active;
 
+	/**
+     * @Column(name="reactivate_at", type="integer", nullable=true)
+     * @var int|null
+     */
+    protected $reactivate_at;
+
     public function __construct(Station $station)
     {
         $this->station = $station;
@@ -168,5 +174,21 @@ class StationStreamer
     public function setIsActive(bool $is_active)
     {
         $this->is_active = $is_active;
+    }
+
+	/**
+     * @return int|null
+     */
+    public function getReactivateAt()
+    {
+        return $this->reactivate_at;
+    }
+
+    /**
+     * @param int|null $reactivate_at
+     */
+    public function setReactivateAt($reactivate_at)
+    {
+        $this->reactivate_at = $reactivate_at;
     }
 }

--- a/src/Entity/StationStreamer.php
+++ b/src/Entity/StationStreamer.php
@@ -179,7 +179,7 @@ class StationStreamer
 	/**
      * @return int|null
      */
-    public function getReactivateAt()
+    public function getReactivateAt(): ?int
     {
         return $this->reactivate_at;
     }
@@ -187,7 +187,7 @@ class StationStreamer
     /**
      * @param int|null $reactivate_at
      */
-    public function setReactivateAt($reactivate_at)
+    public function setReactivateAt(?int $reactivate_at)
     {
         $this->reactivate_at = $reactivate_at;
     }

--- a/src/Provider/SyncProvider.php
+++ b/src/Provider/SyncProvider.php
@@ -16,6 +16,7 @@ class SyncProvider implements ServiceProviderInterface
                 $di[\Monolog\Logger::class],
                 new \Pimple\ServiceIterator($di, [
                     Task\NowPlaying::class,
+                    Task\ReactivateStreamer::class,
                 ]),
                 new \Pimple\ServiceIterator($di, [
                     Task\RadioRequests::class,
@@ -46,6 +47,12 @@ class SyncProvider implements ServiceProviderInterface
 
         $di[Task\Media::class] = function($di) {
             return new Task\Media(
+                $di[\Doctrine\ORM\EntityManager::class]
+            );
+        };
+
+        $di[Task\ReactivateStreamer::class] = function($di) {
+            return new Task\ReactivateStreamer(
                 $di[\Doctrine\ORM\EntityManager::class]
             );
         };

--- a/src/Radio/Backend/Liquidsoap.php
+++ b/src/Radio/Backend/Liquidsoap.php
@@ -732,6 +732,17 @@ class Liquidsoap extends BackendAbstract implements EventSubscriberInterface
      */
     public function disconnectStreamer(Entity\Station $station)
     {
+        $current_streamer = $station->getCurrentStreamer();
+        $disconnect_deactivate_streamer = $station->getDisconnectDeactivateStreamer();
+
+        if ($current_streamer !== null && $disconnect_deactivate_streamer > 0) {
+            $current_streamer->setIsActive(false);
+            $current_streamer->setReactivateAt(time() + $disconnect_deactivate_streamer);
+
+            $this->em->persist($current_streamer);
+            $this->em->flush();
+        }
+
         return $this->command(
             $station,
             $this->_getVarName('input_streamer', $station).'.stop'

--- a/src/Sync/Task/ReactivateStreamer.php
+++ b/src/Sync/Task/ReactivateStreamer.php
@@ -1,0 +1,37 @@
+<?php
+namespace App\Sync\Task;
+
+use Cake\Chronos\Chronos;
+use Doctrine\ORM\EntityManager;
+use App\Entity;
+
+class ReactivateStreamer extends TaskAbstract
+{
+    /** @var EntityManager */
+    protected $em;
+
+    /**
+     * ReactivateStreamer constructor.
+     * @param EntityManager $em
+     */
+    public function __construct(EntityManager $em)
+    {
+        $this->em = $em;
+    }
+
+    public function run($force = false)
+    {
+        /** @var Entity\Repository\StationStreamerRepository $streamer_repo */
+        $streamer_repo = $this->em->getRepository(Entity\StationStreamer::class);
+
+        $deactivated_streamers = $streamer_repo->fetchDeactivatedStreamersWithReactivateAtLowerThan(time());
+
+        foreach ($deactivated_streamers as $streamer) {
+            $streamer->setIsActive(true);
+            $streamer->setReactivateAt(null);
+
+            $this->em->persist($streamer);
+            $this->em->flush();
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the feature requested in issue #898

The time that a streamer is deactivated for can be configured in seconds so that this feature is as flexible as possible but the `Task` that checks if a streamer can be reactivated will run in the 15s TaskRunner so that this check does not cost too much performance. This could be changed to a dedicated TaskRunner that executes every second to give a kind of realtime precision for this feature but I'm not sure if this is really necessary.

The dropdown mentioned by @SlvrEagle23 in this issue can be implemented rather easily on top of these changes. The `disconnectStreamer()` method parameters would need to be extended by an optional `int $seconds` parameter. If this parameter is set use this to determine the `reactivate_at` timestamp if not use the default from the station. The disconnect dropdown would then need to send the amount of seconds with the `POST` request to the backend action. You could define some pre-configured values for this dropdown and set the station default value as the default option of the dropdown. This would enable station owners to define a custom value to primarily use and also adds some easy to use options.