### PR TITLE
Restrict files count to files of current station

### DIFF
--- a/src/Controller/Stations/Files/FilesController.php
+++ b/src/Controller/Stations/Files/FilesController.php
@@ -35,7 +35,9 @@ class FilesController extends FilesControllerAbstract
         $space_total = disk_total_space($media_dir);
         $space_used = $space_total - $space_free;
         
-        $files_count = $this->em->createQuery('SELECT COUNT(sm.id) FROM '.Entity\StationMedia::class.' sm')
+        $files_count = $this->em->createQuery('SELECT COUNT(sm.id) FROM '.Entity\StationMedia::class.' sm
+            WHERE sm.station_id = :station_id')
+            ->setParameter('station_id', $station_id)
             ->getSingleScalarResult();
 
         // Get list of custom fields.


### PR DESCRIPTION
The count of files is more useful when it's restricted to the files that belong to the current station. When AzuraCast is used to host stations for different people that don't belong together it would be quite confusing to see more files in the count than are available for the station.