### PR TITLE
Fix error due to JavaScript math uncertainty - fixes #923

### DIFF
--- a/web/static/js/radio.js
+++ b/web/static/js/radio.js
@@ -34,7 +34,7 @@ function setVolume(new_volume)
     $('.jp-volume-range').val(volume);
 
     // Set volume logarithmically based on original input.
-    player.volume = (Math.exp(volume/100)-1)/(Math.E-1);
+    player.volume = Math.min((Math.exp(volume/100)-1)/(Math.E-1), 1);
 
     if (store.enabled)
         store.set('player_volume', volume);


### PR DESCRIPTION
For some JavaScript engines the expression can return float values above 1. This PR wraps the expression in a `Math.min()` expression so that 1 is returned if the expression evaluates to above 1.