### PR TITLE
Fix ellipsis bug in Safari - fixes #869

### DIFF
--- a/web/static/scss/material/_card.scss
+++ b/web/static/scss/material/_card.scss
@@ -106,7 +106,7 @@
   .btn::after {
     content: "\0000a0";
     display: inline-block;
-    width: 0;
+    font-size: 0;
   }
 
   .dropdown-toggle::after {

--- a/web/static/scss/material/_card.scss
+++ b/web/static/scss/material/_card.scss
@@ -101,6 +101,13 @@
     padding-right: $card-action-inner-spacer-x;
     padding-left: $card-action-inner-spacer-x;
   }
+  
+  // Fix for "overflow: hidden" + "text-overflow: ellipsis" bug in Safari - see issue #869
+  .btn::after {
+    content: "\0000a0";
+    display: inline-block;
+    width: 0;
+  }
 
   .dropdown-toggle::after {
     margin-right: 0;


### PR DESCRIPTION
The bug described in issue #869 seems to be a common bug in Safari ([that is at least 2 years old](https://stackoverflow.com/questions/35012943/text-overflow-hides-text-when-it-shouldnt-in-safari)) when mixing `text-overflow: ellipsis;` with `overflow: hidden;` and can be fixed by adding an `::after` element with a non-breaking space or just a non-breaking space in the HTML after the text in the button. In order to keep the HTML clean and also effect every occurrence of that bug this PR implements the first solution to this and also sets the font-size of the added `::after` element to `0` so that this fix does not impact the visual style of the buttons.