### PR TITLE
Fix download of .m3u file - fixes #935

### DIFF
--- a/src/Controller/Frontend/PublicController.php
+++ b/src/Controller/Frontend/PublicController.php
@@ -45,14 +45,14 @@ class PublicController
         ]);
     }
 
-    public function playlistAction(Request $request, Response $response): Response
+    public function playlistAction(Request $request, Response $response, $station_id, $format = 'pls'): Response
     {
         $station = $request->getStation();
         $fa = $request->getStationFrontend();
 
         $stream_urls = $fa->getStreamUrls($station);
 
-        $format = strtolower($request->getParam('format', 'pls'));
+        $format = strtolower($format);
 
         switch ($format) {
             // M3U Playlist Format


### PR DESCRIPTION
This PR fixes the issue reported in #935.

The `format` is provided as a route argument but AzuraCast tries to load a `GET` or `POST` parameter named `format` and thus always falls back to the default `pls` making it impossible to download a `.m3u`