### PR TITLE
Implement audio file moving

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -333,6 +333,9 @@ return function(\Slim\App $app)
             $this->map(['GET', 'POST'], '/list', Controller\Stations\Files\FilesController::class.':listAction')
                 ->setName('stations:files:list');
 
+            $this->map(['GET', 'POST'], '/directories', Controller\Stations\Files\FilesController::class.':listDirectoriesAction')
+                ->setName('stations:files:directories');
+
             $this->map(['GET', 'POST'], '/batch', Controller\Stations\Files\FilesController::class.':batchAction')
                 ->setName('stations:files:batch');
 

--- a/resources/templates/stations/files/index.js.phtml
+++ b/resources/templates/stations/files/index.js.phtml
@@ -29,6 +29,25 @@ $(function() {
         }
     });
 
+    var appMoveFilesModal = new Vue({
+        el: '#mdl-move-file',
+        data: {
+            selected_files: 0,
+            move_dir: '',
+            dir_history: [],
+            directory_grid: null
+        },
+        methods: {
+            pageBack: function(e) {
+                e.preventDefault();
+
+                this.dir_history.pop();
+                this.move_dir = this.dir_history.join("/");
+                this.directory_grid.bootgrid("reload");
+            }
+        }
+    });
+
     var grid = $("#file-table").bootgrid({
         ajax: true,
         selection: true,
@@ -107,6 +126,65 @@ $(function() {
             grid.bootgrid("clear").bootgrid("search", $(this).data('term'));
             return false;
         });
+
+        appMoveFilesModal.selected_files = getSelectedFiles().length;
+    }).on("selected.rs.jquery.bootgrid", function(e, columns, row) {
+        appMoveFilesModal.selected_files = getSelectedFiles().length;
+    }).on("deselected.rs.jquery.bootgrid", function(e, columns, row) {
+        appMoveFilesModal.selected_files = getSelectedFiles().length;
+    });
+
+    appMoveFilesModal.directory_grid = $("#directory-table").bootgrid({
+        ajax: true,
+        navigation: 0,
+        selection: false,
+        rowSelect: false,
+        caseSensitive: false,
+        url: "<?=$router->fromHere('stations:files:directories')  ?>",
+        post: function() {
+            return {
+                'csrf': CSRF,
+                'file': appMoveFilesModal.move_dir
+            };
+        },
+        formatters: {
+            "directory": function(column, row) {
+                $icon = '<span class="file-icon"><i class="material-icons">folder</i></span> ';
+
+                return '<div class="is_dir">'+$icon + row.name +'</div>';
+            },
+            "commands": function(column, row) {
+                return '<a class="btn btn-sm btn-primary btn-select" href="#" data-path="'+window.btoa(appMoveFilesModal.move_dir.length ? appMoveFilesModal.move_dir + '/' + row.path : row.path)+'"><?=__('Select') ?></a>';
+            }
+        }
+    }).on("loaded.rs.jquery.bootgrid", function() {
+        /* Handle directory selection */
+        appMoveFilesModal.directory_grid.find(".btn-select").on("click", function(e) {
+            e.preventDefault();
+
+            var $files = getSelectedFiles();
+            $files.length && $.post('<?=$router->fromHere('stations:files:batch') ?>',{
+                'do': 'move',
+                'files': $files.join('|'),
+                'csrf': CSRF,
+                'directory': window.atob($(this).data('path'))
+            },function(data){
+                list();
+                $('#mdl-move-file').modal('hide');
+            },'json');
+
+            return false;
+        });
+    }).on("click.rs.jquery.bootgrid", function(e, columns, row) {
+        appMoveFilesModal.dir_history.push(row.path);
+        appMoveFilesModal.move_dir = appMoveFilesModal.dir_history.join("/");
+        appMoveFilesModal.directory_grid.bootgrid("reload");
+    });
+
+    $('#mdl-move-file').on('show.bs.modal', function (e) {
+        appMoveFilesModal.dir_history = [];
+        appMoveFilesModal.move_dir = '';
+        appMoveFilesModal.directory_grid.bootgrid("reload");
     });
 
     // Check if initial URL has a hash.
@@ -252,8 +330,7 @@ $(function() {
         $('#file-table').bootgrid("reload");
     }
 
-    function getUrlHash()
-    {
+    function getUrlHash() {
         var url_hash = decodeURIComponent(window.location.hash.substr(1).replace(/\+/g, "%20"));
 
         if (url_hash.substr(0, 9) === 'playlist:') {
@@ -265,8 +342,7 @@ $(function() {
         return url_hash;
     }
 
-    function getSelectedFiles()
-    {
+    function getSelectedFiles() {
         $files = [];
         $('#file-table').find('tr.active').each(function() {
             $files.push($(this).data('row-id'));

--- a/resources/templates/stations/files/index.phtml
+++ b/resources/templates/stations/files/index.phtml
@@ -69,6 +69,7 @@ $assets
                                 <li><a href="#" class="dropdown-item btn-new-playlist" data-toggle="modal" data-target="#mdl-create-playlist"><?=__('Create new...') ?></a></li>
                             </ul>
                         </div>
+                        <a href="#" class="btn btn-default" data-toggle="modal" data-target="#mdl-move-file"><i class="material-icons">open_with</i> <?=__('Move') ?></a>
                         <button type="button" class="btn btn-warning" v-on:click="doBatch" data-action="clear"><i class="material-icons">clear_all</i> <?=__('Clear Playlists') ?></button>
                         <button type="button" class="btn btn-danger" v-on:click="doBatch" data-action="delete"><i class="material-icons">delete</i> <?=__('Delete') ?></button>
                     </div>
@@ -142,6 +143,46 @@ $assets
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     <button type="submit" id="btn-create-new-playlist" class="btn btn-primary"><?=__('Create Directory') ?></button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="modal fade" id="mdl-move-file" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <form id="frm-move-file">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="exampleModalLabel"><?=__('Move {{ selected_files }} File(s) to') ?></h4>
+                </div>
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <button type="button" class="btn btn-primary" v-on:click="pageBack" v-bind:disabled="dir_history.length == 0"><i class="material-icons">chevron_left</i> <?=__('Back') ?></button>
+                            <span>&nbsp;{{ move_dir }}</span>
+                            <br/><br/>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <table class="data-table table table-striped table-hover" id="directory-table">
+                                <thead>
+                                    <tr>
+                                        <th data-column-id="directory" data-formatter="directory" data-sortable="false"><?=__('Directory') ?></th>
+                                        <th data-column-id="commands" data-formatter="commands" data-align="right" data-sortable="false"><?=__('Actions') ?></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
         </form>


### PR DESCRIPTION
This PR implements a basic file moving function for the audio files. Currently this feature can only move files and not directories but it should be possible to extend this in the future to add the moving of whole directories.

~~I've also already rebuilt the static assets like it's shown in the documentation.~~ <- Wasn't needed

Should close the following issues: #740, #315 and maybe #575 (I don't really understand what "maps" means in that issue so I assume it means directories)