### PR TITLE
Fixes for file playtime detection

### DIFF
--- a/src/Service/Flow.php
+++ b/src/Service/Flow.php
@@ -140,7 +140,7 @@ class Flow
      */
     protected function _createFileFromChunks($chunkBaseDir, $chunkIdentifier, $originalFileName, $numChunks)
     {
-        $finalPath = sys_get_temp_dir().'/'.$chunkIdentifier.'_complete';
+        $finalPath = sys_get_temp_dir().'/'.$originalFileName;
 
         $fp = fopen($finalPath, 'w+');
 


### PR DESCRIPTION
StationMediaRepository.php:  sometimes getID3 will report an error in a file
due to a slightly mangled header but can still get an accurate playtime length
and some other info. In the loadFromFile function removed the condition that
there are no errors prior to checking playtime so that we can still get that info,
and instead sent any detected errors to the php log.

Flow.php: In _createFileFromChunks function changed final filename to use actual
filename uploaded instead of putting _complete at the end so that getID3 can
use the file extension as a fallback identifier if the standard mp3 header is
slightly mangled. That fallback occurs in GetFileFormat() in
/var/azuracast/www/vendor/james-heinrich/getid3/getid3/getid3.php

Note: there might be a better way to do the logging, I went the way I'm familiar with using php's error_log but this might be better done with Monolog