### PR TITLE
Disable deep normalization for station record on edit station form - Fixes #1224

### DIFF
--- a/src/Form/StationForm.php
+++ b/src/Form/StationForm.php
@@ -90,7 +90,7 @@ class StationForm extends EntityForm
         }
 
         if (null !== $record) {
-            $this->populate($this->_normalizeRecord($record));
+            $this->populate($this->_normalizeRecord($record, ['deep' => false]));
         }
 
         if ($request->isPost() && $this->isValid($request->getParsedBody())) {


### PR DESCRIPTION
This issue fixes the out of memory issue when opening the edit station profile page reported in issue #1224 