### PR TITLE
Change mentions of traditional to Bare-metal

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ Do not include your responses inside the "!--" comments. Add them outside these 
 -->
 
 **Installation method**
-<!-- Indicate whether you are using the "Docker" or "Traditional" installation method. -->
+<!-- Indicate whether you are using the "Docker" or "Bare-metal" installation method. -->
 
 **Host OS (for Docker installations)**
 <!-- Indicate what your host operating system is (i.e. Ubuntu 16.04, MacOS High Sierra, Windows 10), if you're using the Docker installation method. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We do our best to incorporate translation changes as frequently as possible, but
 
 Getting a project as large and complex as AzuraCast to work on many platforms is a huge effort, and is often far too complex for a single-developer project such as this.
 
-Thankfully, we've adopted support for Docker, a tool that allows us to create prebuilt images with all of our software stack properly configured and arranged, which you can then run on just about any host that will run the latest version of Docker. It's portable, it's cross-platform, and pulling down new updates are far easier than before; for these reasons, we heavily emphasize using Docker over our older, Ubuntu-specific "traditional" installation.
+Thankfully, we've adopted support for Docker, a tool that allows us to create prebuilt images with all of our software stack properly configured and arranged, which you can then run on just about any host that will run the latest version of Docker. It's portable, it's cross-platform, and pulling down new updates are far easier than before; for these reasons, we heavily emphasize using Docker over our older, Ubuntu-specific "Bare-metal" installation.
 
 Although we use Docker in local development and on our testing and demonstration servers, sometimes a problem will occur that stops a particular host from working with our application. If you're a user affected by such an issue, we encourage you to advise us by creating a Github issue, especially if there is a known solution to the issue that we can apply.
 
@@ -31,7 +31,7 @@ Accessibility, security, and modern best practices are very important in AzuraCa
 Contributions are also welcome in the supporting technologies used to make AzuraCast possible, such as:
 
  - Dockerfiles (see [our separate repositories](https://github.com/AzuraCast) for Docker containers)
- - [Ansible configuration](https://github.com/AzuraCast/AzuraCast/tree/master/util/ansible) for traditional installs and Docker installation/updates
+ - [Ansible configuration](https://github.com/AzuraCast/AzuraCast/tree/master/util/ansible) for Bare-metal installs and Docker installation/updates
  - Python for our auxiliary [station monitoring scripts](https://github.com/AzuraCast/station-watcher-python)
  
 Instructions for developing with AzuraCast locally are [available here](https://www.azuracast.com/developing.html).
@@ -44,7 +44,7 @@ While we appreciate everyone who is eager to contribute to this project and help
 
  - Please **do not e-mail the project developer directly** with questions or issues specific to AzuraCast, unless you were specifically requested to do so as part of an ongoing issue. Contacting me directly prevents me from tracking all outstanding issues in one place, and harms the transparency that is essential to FOSS development. If, however, you are e-mailing me to offer me a paying job...go nuts.
 
- - Please **do not create "this doesn't work" issues** that are just one sentence long and don't provide any insight into the scope of the issue, what changes might have triggered it, or what platform you're running on. At the very minimum, please always include what host OS you're using (i.e. Ubuntu 16.04), whether you're using the Docker or "traditional" installation, and whether the problem first occurred after a recent update. For visual issues, screenshots are also greatly appreciated.
+ - Please **do not create "this doesn't work" issues** that are just one sentence long and don't provide any insight into the scope of the issue, what changes might have triggered it, or what platform you're running on. At the very minimum, please always include what host OS you're using (i.e. Ubuntu 16.04), whether you're using the Docker or "Bare-metal" installation, and whether the problem first occurred after a recent update. For visual issues, screenshots are also greatly appreciated.
  
  - Please **refer to existing Github issues** if you are curious about the status of outstanding bug reports or new enhancement requests. Always remember that this is a volunteer project primarily built and maintained by a single developer, and manage your expectations accordingly.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Follow our **[installation guide](https://azuracast.com/install.html)** for inst
 
 ### What's Included
 
-Whether you're using the traditional installer or Docker containers, AzuraCast will automatically retrieve and install these components for you:
+Whether you're using the Bare-metal installer or Docker containers, AzuraCast will automatically retrieve and install these components for you:
 
 #### Radio Software
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -21,9 +21,9 @@ docker-compose logs -f
 
 This command will show you a running log of all containers. You can also get detailed logs by running `docker-compose logs -f service`, where "service" is one of `web`, `stations`, etc.
 
-#### Traditional
+#### Bare-metal
 
-Since the Traditional installation interacts directly with your host server, its logs are in various locations across the system.
+Since the Bare-metal installation interacts directly with your host server, its logs are in various locations across the system.
 
 - AzuraCast: `/var/azuracast/www_tmp/azuracast.log`
 - Nginx Access: `/var/azuracast/www_tmp/access.log`
@@ -55,7 +55,7 @@ Replace `YOUREMAILADDRESS` with the e-mail address whose password you intend to 
 ./docker.sh cli azuracast:account:reset-password YOUREMAILADDRESS
 ``` 
 
-##### Traditional
+##### Bare-metal
 
 ```bash
 php /var/azuracast/www/bin/azuracast.php azuracast:account:reset-password YOUREMAILADDRESS
@@ -70,7 +70,7 @@ date, and they may cause errors. You can always flush all site-wide caches using
 ./docker.sh cli cache:clear
 ``` 
 
-##### Traditional
+##### Bare-metal
 
 ```bash
 php /var/azuracast/www/bin/azuracast.php cache:clear
@@ -102,13 +102,13 @@ As long as you leave this script running, it will create a connection that you c
 
 If you intend to leave this script running for long term periods, you must change the password to something more secure.
 
-### Force a Full Update (Traditional Installations)
+### Force a Full Update (Bare-metal Installations)
 
-Normally, the traditional installer's update script only updates the portion of the system that have been modified since
+Normally, the Bare-metal installer's update script only updates the portion of the system that have been modified since
 your last update. If an update was interrupted or otherwise is causing trouble, you can force the update script to process
 all components, which can often fix any issues:
 
-##### Traditional
+##### Bare-metal
 
 ```bash
 ./update.sh --full
@@ -136,7 +136,7 @@ You will need to recycle your Docker containers using `docker-compose down`, the
 
 To override more complex functionality in your Docker installation, see the "Customizing Docker" section below.
 
-#### Traditional
+#### Bare-metal
 
 To modify the port your web application runs on, modify the configuration file in `/etc/nginx/sites-available/00-azuracast`.
 Note that some updates may overwrite this file.

--- a/docker-migrate.sh
+++ b/docker-migrate.sh
@@ -45,9 +45,9 @@ sudo chmod +x /usr/local/bin/docker-compose
 sudo sh -c "curl -L https://raw.githubusercontent.com/docker/compose/${COMPOSE_VERSION}/contrib/completion/bash/docker-compose > /etc/bash_completion.d/docker-compose"
 
 # Pull Docker images
-read -n 1 -s -r -p "Docker installed. Press any key to continue (Uninstall Traditional AzuraCast)..."
+read -n 1 -s -r -p "Docker installed. Press any key to continue (Uninstall Bare-metal AzuraCast)..."
 
-# Run traditional uninstaller
+# Run Bare-metal uninstaller
 chmod a+x uninstall.sh
 ./uninstall.sh
 

--- a/src/Radio/Backend/Liquidsoap.php
+++ b/src/Radio/Backend/Liquidsoap.php
@@ -555,7 +555,7 @@ class Liquidsoap extends AbstractBackend implements EventSubscriberInterface
                 $command .= ' --form ' . $param_key . '="^quote(' . $param_val . ')^"';
             }
         } else {
-            // Traditional shell-script call.
+            // Bare-metal shell-script call.
             $shell_path = '/usr/bin/php '.APP_INCLUDE_ROOT.'/bin/azuracast';
 
             $shell_args = [];

--- a/templates/main.phtml
+++ b/templates/main.phtml
@@ -147,7 +147,7 @@ echo $assets->js();
 </section>
 
 <footer id="footer" <?php if (empty($sidebar)): ?>class="footer-alt"<?php endif; ?> role="contentinfo">
-    <?=__('Powered by %s', '<a href="https://www.azuracast.com/" target="_blank">'.$settings['name'].'</a> &bull; '.$version->getVersionText().' &bull; '.(APP_INSIDE_DOCKER ? 'Docker' : 'Traditional').' &bull; PHP '.\PHP_MAJOR_VERSION.'.'.\PHP_MINOR_VERSION) ?><br>
+    <?=__('Powered by %s', '<a href="https://www.azuracast.com/" target="_blank">'.$settings['name'].'</a> &bull; '.$version->getVersionText().' &bull; '.(APP_INSIDE_DOCKER ? 'Docker' : 'Bare-metal').' &bull; PHP '.\PHP_MAJOR_VERSION.'.'.\PHP_MINOR_VERSION) ?><br>
     <?=__('Like our software? <a href="%s" target="_blank">Donate to support AzuraCast!</a>', 'https://www.azuracast.com/donate.html') ?>
 </footer>
 

--- a/templates/partials/log_help_card.phtml
+++ b/templates/partials/log_help_card.phtml
@@ -6,7 +6,7 @@
 
         <p><?=__('If you\'re experiencing a bug or error, you can submit a GitHub issue using the link below.') ?></p>
 
-        <p><?=__('Your current installation type is <b>%s</b>. Be sure to include this when creating a new issue.', (APP_INSIDE_DOCKER ? 'Docker' : 'Traditional')) ?></p>
+        <p><?=__('Your current installation type is <b>%s</b>. Be sure to include this when creating a new issue.', (APP_INSIDE_DOCKER ? 'Docker' : 'Bare-metal')) ?></p>
     </div>
     <div class="card-actions">
         <a class="btn btn-outline-primary" role="button" href="https://github.com/AzuraCast/AzuraCast/issues/new/choose" target="_blank">


### PR DESCRIPTION
I've changed all mentions of `traditional` installations to `Bare-metal` since we are not recommending using this installation method as the standard way to install AzuraCast and the previous naming was causing some confusion for new users on what they should use.