### PR TITLE
Fix station deletion issue 1495

### DIFF
--- a/src/Controller/Admin/StationsController.php
+++ b/src/Controller/Admin/StationsController.php
@@ -52,8 +52,6 @@ class StationsController extends AbstractAdminCrudController
 
     public function deleteAction(Request $request, Response $response, $id, $csrf_token): ResponseInterface
     {
-        $this->_doDelete($request, $id, $csrf_token);
-
         $request->getSession()->getCsrf()->verify($csrf_token, $this->csrf_namespace);
 
         $record = $this->record_repo->find((int)$id);


### PR DESCRIPTION
This PR fixes the station deletion problem from #1495. The call to `$record_repo->destroy($record);` already removes the entity after removing the other station related data so the call to `$this->_doDelete($request, $id, $csrf_token);` was interfering with the `destroy()` by removing the station too early.