### PR TITLE
Add month and year dropdowns to live listener report custom range

### DIFF
--- a/templates/stations/reports/listeners.js.phtml
+++ b/templates/stations/reports/listeners.js.phtml
@@ -68,12 +68,13 @@ function setMapPoints(points) {
 }
 
 $(function() {
-    live_time = moment(0);
+    live_time = moment();
 
     $('#reportrange').daterangepicker({
         startDate: live_time,
         endDate: live_time,
         opens: "left",
+        showDropdowns: true,
         ranges: {
             <?=$this->escapeJs(__('Live Listeners')) ?>: [moment(0), moment(0)],
             <?=$this->escapeJs(__('Today')) ?>: [moment(), moment()],


### PR DESCRIPTION
Also sets the default date to now as it is more likely someone needs to view date ranges that fall into the current time. 😉 

Fixes issue #1578 