### PR TITLE
Fixes automatic backup not running

### DIFF
--- a/src/Sync/Task/Backup.php
+++ b/src/Sync/Task/Backup.php
@@ -90,8 +90,8 @@ class Backup extends AbstractTask
      */
     public function run($force = false): void
     {
-        $logging_enabled = (bool)$this->settings_repo->getSetting(Entity\Settings::BACKUP_ENABLED, 0);
-        if (!$logging_enabled) {
+        $backup_enabled = (bool)$this->settings_repo->getSetting(Entity\Settings::BACKUP_ENABLED, 0);
+        if (!$backup_enabled) {
             $this->logger->debug('Automated backups disabled; skipping...');
             return;
         }
@@ -105,7 +105,7 @@ class Backup extends AbstractTask
             // Check if the backup time matches (if it's set).
             $backup_timecode = (int)$this->settings_repo->getSetting(Entity\Settings::BACKUP_TIME);
             if (0 !== $backup_timecode) {
-                $current_timecode = $now_utc->format('Hi');
+                $current_timecode = (int)$now_utc->format('Hi');
 
                 if ($backup_timecode !== $current_timecode) {
                     return;


### PR DESCRIPTION
This PR fixes the issue from #1637 that prevented the backups from being run. The timestamp comparison always failed because one of them was a string and one an integer. In addition this PR also fixes the naming of the variable for `Entity\Settings::BACKUP_ENABLED`.