### PR TITLE
Remove unnecessary prefix from path - Fixes #1918

### DIFF
--- a/src/Controller/Stations/Files/EditController.php
+++ b/src/Controller/Stations/Files/EditController.php
@@ -100,8 +100,7 @@ class EditController extends FilesControllerAbstract
 
             // Detect rename.
             if ($data['path'] !== $media->getPath()) {
-                $path_full = 'media://' . $data['path'];
-                $fs->rename($media->getPathUri(), $path_full);
+                $fs->rename($media->getPathUri(), $data['path']);
             }
 
             if (!empty($custom_fields)) {


### PR DESCRIPTION
This PR fixes the rename issue from #1918.

The prefix for the Flysystem operation `rename` is already determined by the prefix from the old path. If the new path is given with a prefix this will be used directly by Flysystem without removing it from the path. This leads to the system creating a new directory with the prefix as the name and moving the file over to there.

See this snippet from Flysystem:
```
public function rename($path, $newpath)
{
    list($prefix, $path) = $this->getPrefixAndPath($path);

    return $this->getFilesystem($prefix)->rename($path, $newpath);
}
```