### PR TITLE
Fix issue 2141

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -61,7 +61,7 @@ return function (App $app) {
             $group->map(['GET', 'POST'], '/run', Controller\Admin\BackupsController::class . ':runAction')
                 ->setName('admin:backups:run');
 
-            $group->get('/delete/{path}', Controller\Admin\BackupsController::class . ':downloadAction')
+            $group->get('/download/{path}', Controller\Admin\BackupsController::class . ':downloadAction')
                 ->setName('admin:backups:download');
 
             $group->get('/delete/{path}/{csrf}', Controller\Admin\BackupsController::class . ':deleteAction')

--- a/templates/admin/backups/index.phtml
+++ b/templates/admin/backups/index.phtml
@@ -108,7 +108,7 @@ $assets
                 <td>
                     <div class="btn-group btn-group-sm">
                         <a class="btn btn-sm btn-primary" href="<?=$router->fromHere('admin:backups:download',
-                            ['path' => base64_encode($row['path'])])?>"><?=__('Download')?></a>
+                            ['path' => base64_encode($row['path'])])?>" download="<?=$this->e($row['basename'])?>"><?=__('Download')?></a>
                         <a class="btn btn-sm btn-danger" href="<?=$router->fromHere('admin:backups:delete', [
                             'path' => base64_encode($row['path']),
                             'csrf' => $csrf,


### PR DESCRIPTION
This PR fixes issue #2141 

I've also noticed that the path for the download link action looks like this `/admin/backups/delete/dGVzdC56aXA=` which probably should have `download` instead of `delete` so I've added a commit to this PR to fix this too.

I've just briefly looked at the code that generates the filename for the `content-disposition` header and noticed that it does some regex to make sure it fits some ASCII range. I don't think this is necessary for the `download` attribute seeing as there is no mention about this on MDN so I've not added this here. If I've overlooked something there feel free to edit the PR.