### PR TITLE
Update dbip version to version 2020-03

### DIFF
--- a/util/docker/web/setup/dbip.sh
+++ b/util/docker/web/setup/dbip.sh
@@ -5,7 +5,7 @@ set -x
 
 cd /tmp
 
-wget --quiet -O dbip-city-lite.mmdb.gz https://download.db-ip.com/free/dbip-city-lite-2020-01.mmdb.gz
+wget --quiet -O dbip-city-lite.mmdb.gz https://download.db-ip.com/free/dbip-city-lite-2020-03.mmdb.gz
 gunzip dbip-city-lite.mmdb.gz
 
 mv dbip-city-lite.mmdb /var/azuracast/dbip/


### PR DESCRIPTION
While trying to build AzuraCast I encountered an error because of an 404 error from the dbip download. I've updated the version to the currently available version 2020-03 to fix this.