### PR TITLE
Support custom mount names when proxying Liquidsoap input

### DIFF
--- a/util/docker/web/nginx/azuracast.conf
+++ b/util/docker/web/nginx/azuracast.conf
@@ -127,7 +127,7 @@ server {
         proxy_send_timeout        21600;
         proxy_read_timeout        21600;
 
-        proxy_pass http://stations:$1/;
+        proxy_pass http://stations:$1/$3;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
Hi! Found a small bug in the reverse proxy for Liquidsoap harbor inputs.

* Initially I ran into this because we've extended our Liquidsoap config to expose additional named mounts for remote DJ sources and a test stream, and then found we couldn't make Webcaster connections from the browser to those mounts.
* On investigation, I found that I also couldn't use the Webcaster client against a clean station config after configuring a custom DJ/stream mount name for the default autoDJ stream.
* I think I've traced it here to the `nginx` config here, where it appears you're not passing the mount name through to Liquidsoap, so websocket connections are always mounting `/`
* This patch just alters to match the configuration for the listening ports config above it, and now passes through the `$3` capture to the backend.

Thanks so much. Azuracast has been a blessing for our little community radio station during these shelter-in-place days.