### PR TITLE
change OPUS vbr="constrained" to improve sound quality

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -971,7 +971,7 @@ class ConfigWriter implements EventSubscriberInterface
                 break;
 
             case Entity\StationMountInterface::FORMAT_OPUS:
-                return '%opus(samplerate=48000, bitrate=' . $bitrate . ', vbr="none", application="audio", channels=2, signal="music", complexity=10, max_bandwidth="full_band")';
+                return '%opus(samplerate=48000, bitrate=' . $bitrate . ', vbr="constrained", application="audio", channels=2, signal="music", complexity=10, max_bandwidth="full_band")';
                 break;
 
             case Entity\StationMountInterface::FORMAT_MP3:


### PR DESCRIPTION
Is there a reason this was set to "none"? That will result in poorer quality sound and is only exists for special use-cases. Constrained mode is the default in libopus and the RFC says it is equivelent to "CBR" mode in MP3 (both maintain a bit reservoir to help with complex moments in the audio.)

References:
https://tools.ietf.org/html/rfc6716#section-2.1.8
https://www.opus-codec.org/docs/opus_api-1.2/group__opus__encoderctls.html#ga34d09ae06cab7e1a6c49876249b67892