### PR TITLE
Change default webDJ bitrate to 320kbps

### DIFF
--- a/frontend/vue/webcaster/settings.vue
+++ b/frontend/vue/webcaster/settings.vue
@@ -153,7 +153,7 @@
                 'isStreaming': false,
                 'djUsername': '',
                 'djPassword': '',
-                'bitrate': 320,
+                'bitrate': 256,
                 'samplerate': 44100,
                 'encoder': 'mp3',
                 'asynchronous': true,

--- a/frontend/vue/webcaster/settings.vue
+++ b/frontend/vue/webcaster/settings.vue
@@ -153,7 +153,7 @@
                 'isStreaming': false,
                 'djUsername': '',
                 'djPassword': '',
-                'bitrate': 128,
+                'bitrate': 320,
                 'samplerate': 44100,
                 'encoder': 'mp3',
                 'asynchronous': true,


### PR DESCRIPTION
By default webdj encodes audio using libshine at 128kbps, liquidsoap then decodes and re-encodes it in the format of whatever mountpoints you have. libshine is a fast but not high-quality MP3 encoder (it's webpage says it does not have any Psychoacoustic Model!). libshine produces worse quality MP3s at 128kbps than LAME, which is what liquidsoap uses to encode the final stream. I can hear the difference. The result is that webDJ livebroadcasts will sound worse than autoDJ or Butt live broadcasts, even though it look like it's all the same bitrate.

I suggest changing the default to 320kbps to improve quality; this will just increase bandwidth between DJ and azuracast, not from azuracast to listeners. It seems like good practice to keep source audio as high quality a possible until it is finally encoded to send to listeners.