### PR TITLE
Fixed duplicate dB suffix for amplify annotation

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -507,10 +507,6 @@ class ConfigWriter implements EventSubscriberInterface
 
             $annotations_str = [];
             foreach ($mediaAnnotations as $annotation_key => $annotation_val) {
-                if ('liq_amplify' === $annotation_key) {
-                    $annotations_str[] = $annotation_key . '="' . $annotation_val . '"';
-                    continue;
-                }
                 $annotations_str[] = $annotation_key . '="' . $annotation_val . '"';
             }
 

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -508,7 +508,7 @@ class ConfigWriter implements EventSubscriberInterface
             $annotations_str = [];
             foreach ($mediaAnnotations as $annotation_key => $annotation_val) {
                 if ('liq_amplify' === $annotation_key) {
-                    $annotations_str[] = $annotation_key . '="' . $annotation_val . 'dB"';
+                    $annotations_str[] = $annotation_key . '="' . $annotation_val . '"';
                     continue;
                 }
                 $annotations_str[] = $annotation_key . '="' . $annotation_val . '"';


### PR DESCRIPTION
Before this change, playlists were generated like this:
```
annotate:title="XXX",artist="XXXX",duration="2.",song_id="XXXX",liq_amplify="0.dBdB",liq_cross_duration="0.30",is_jingle_mode="true":/var/azuracast/stations/azuratest_radio/media/XXX.mp3
```

The duplicate dB suffix has been fixed and now results in:
```
annotate:title="XXX",artist="XXXX",duration="2.",song_id="XXXX",liq_amplify="0.dB",liq_cross_duration="0.30",is_jingle_mode="true":/var/azuracast/stations/azuratest_radio/media/XXX.mp3
```