### PR TITLE
Moved drop_metadata before cue_cut/audio_to_stereo in Liquidsoap configs

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -283,12 +283,12 @@ class ConfigWriter implements EventSubscriberInterface
                 }
             }
 
-            $playlistConfigLines[] = $playlistVarName . ' = audio_to_stereo(id="stereo_' . self::cleanUpString($playlistVarName) . '", ' . $playlistVarName . ')';
-            $playlistConfigLines[] = $playlistVarName . ' = cue_cut(id="cue_' . self::cleanUpString($playlistVarName) . '", ' . $playlistVarName . ')';
-
             if ($playlist->isJingle()) {
                 $playlistConfigLines[] = $playlistVarName . ' = drop_metadata(' . $playlistVarName . ')';
             }
+
+            $playlistConfigLines[] = $playlistVarName . ' = audio_to_stereo(id="stereo_' . self::cleanUpString($playlistVarName) . '", ' . $playlistVarName . ')';
+            $playlistConfigLines[] = $playlistVarName . ' = cue_cut(id="cue_' . self::cleanUpString($playlistVarName) . '", ' . $playlistVarName . ')';
 
             if (Entity\StationPlaylist::TYPE_ADVANCED === $playlist->getType()) {
                 $playlistConfigLines[] = 'ignore(' . $playlistVarName . ')';


### PR DESCRIPTION
In order to resolve an issue with custom crossfades, this should fix it according to Romain:

> When we finish a round of data producing, we "advance" the internal frame, which clears it and makes it ready to receive the next round of data, including metadata. The hack that we introduced years ago is to keep the last metadata at position -1, which is supposed to be used to replay the latest metadata when switching back to a source, very useful in most contexts. However, that introduces non-standard handling of metadata. Typically, the loop that we use to process metadata in map_metadata (the operator that is used to implement drop_metadata) does not process the metadata at position -1 (supposedly, it has been processed earlier)
> So it sticks around and is played in your transition
> The reason it's there to begin with is because cue_in accelerates a source to decode to the start point, which adds a metadata at position -1 that drop_metadata won't see
> But, if you place drop_metadata before cue_cut then they will be all dropped before the source is accelerated and everybody is happy face