### PR TITLE
Fix Advanced Play Single Track problem

### DIFF
--- a/src/Entity/StationPlaylist.php
+++ b/src/Entity/StationPlaylist.php
@@ -508,7 +508,7 @@ class StationPlaylist
      */
     public function isPlayable(): bool
     {
-        // Any "advanced" settings are not managed by AzuraCast AutoDJ.  *** FIXED BUG: MISSING $this->backendPlaySingleTrack() ***
+        // Any "advanced" settings are not managed by AzuraCast AutoDJ.
         if (!$this->is_enabled || $this->backendInterruptOtherSongs() || $this->backendMerge() || $this->backendLoopPlaylistOnce() || $this->backendPlaySingleTrack()) {
             return false;
         }

--- a/src/Entity/StationPlaylist.php
+++ b/src/Entity/StationPlaylist.php
@@ -508,8 +508,8 @@ class StationPlaylist
      */
     public function isPlayable(): bool
     {
-        // Any "advanced" settings are not managed by AzuraCast AutoDJ.
-        if (!$this->is_enabled || $this->backendInterruptOtherSongs() || $this->backendMerge() || $this->backendLoopPlaylistOnce()) {
+        // Any "advanced" settings are not managed by AzuraCast AutoDJ.  *** FIXED BUG: MISSING $this->backendPlaySingleTrack() ***
+        if (!$this->is_enabled || $this->backendInterruptOtherSongs() || $this->backendMerge() || $this->backendLoopPlaylistOnce() || $this->backendPlaySingleTrack()) {
             return false;
         }
 


### PR DESCRIPTION
Fixed bug for advanced setting PLAY_SINGLE_TRACK not working with scheduled playlists. Missing $this->backendPlaySingleTrack() added.