### PR TITLE
Fix user based locale not working bug

### DIFF
--- a/src/Customization.php
+++ b/src/Customization.php
@@ -34,10 +34,10 @@ class Customization
         $this->settingsRepo = $settingsRepo;
         $this->instanceName = (string)$this->settingsRepo->getSetting(Entity\Settings::INSTANCE_NAME, '');
 
-        $this->locale = $this->initLocale($request);
-
         // Register current user
         $this->user = $request->getAttribute(ServerRequest::ATTR_USER);
+
+        $this->locale = $this->initLocale($request);
 
         // Register current theme
         $queryParams = $request->getQueryParams();


### PR DESCRIPTION
This PR fixes the bug where a user defined locale setting is not working anymore.

The Customization Class is using the `$this->user` property to set the user locale in this line: https://github.com/AzuraCast/AzuraCast/blob/ffa6d6b4fc26499cfc531af34cc9270688bc856e/src/Customization.php#L89-L92

The problem is that `$this->user` is initialized after `initLocale()` is called here: https://github.com/AzuraCast/AzuraCast/blob/ffa6d6b4fc26499cfc531af34cc9270688bc856e/src/Customization.php#L37-L40

This issue was introduced in commit 6f66ff072b2217317dc43f6ddf2c4745f14bcc03

The PR closes #3148