### PR TITLE
Add frontend test case to check if user based locale is working correctly

### DIFF
--- a/src/Customization.php
+++ b/src/Customization.php
@@ -79,9 +79,6 @@ class Customization
     protected function initLocale(?Request $request = null): string
     {
         $settings = Settings::getInstance();
-        if ($settings->isTesting()) {
-            return self::DEFAULT_LOCALE;
-        }
 
         $supported_locales = $settings['locale']['supported'];
         $try_locales = [];

--- a/src/Customization.php
+++ b/src/Customization.php
@@ -65,7 +65,6 @@ class Customization
         $translator->register();
 
         // Register translation superglobal functions
-        putenv('LANG=' . $this->locale);
         setlocale(LC_ALL, $this->locale);
     }
 
@@ -103,6 +102,8 @@ class Customization
         if (!empty($env_locale)) {
             $try_locales[] = substr($env_locale, 0, 5) . '.UTF-8';
         }
+
+        Logger::getInstance()->debug('Locales', ['locales' => $try_locales]);
 
         foreach ($try_locales as $exact_locale) {
             // Prefer exact match.

--- a/src/Customization.php
+++ b/src/Customization.php
@@ -34,10 +34,10 @@ class Customization
         $this->settingsRepo = $settingsRepo;
         $this->instanceName = (string)$this->settingsRepo->getSetting(Entity\Settings::INSTANCE_NAME, '');
 
-        $this->locale = $this->initLocale($request);
-
         // Register current user
         $this->user = $request->getAttribute(ServerRequest::ATTR_USER);
+
+        $this->locale = $this->initLocale($request);
 
         // Register current theme
         $queryParams = $request->getQueryParams();

--- a/tests/functional/A01_Frontend_ProfileCest.php
+++ b/tests/functional/A01_Frontend_ProfileCest.php
@@ -25,4 +25,24 @@ class A01_Frontend_ProfileCest extends CestAbstract
         $I->seeCurrentUrlEquals('/profile');
         $I->see('Français');
     }
+
+    /**
+     * @before setupComplete
+     * @before login
+     */
+    public function changeProfileLocale(FunctionalTester $I)
+    {
+        $I->wantTo('Use a specific locale for a user.');
+
+        $I->amOnPage('/profile/edit');
+        $I->see('Edit Profile', '.card-title');
+
+        $I->submitForm('.form', [
+            'locale' => 'de_DE.UTF-8',
+        ]);
+
+        $I->seeCurrentUrlEquals('/profile');
+        $I->see('Deutsch');
+        $I->seeInTitle('Mein Account');
+    }
 }

--- a/tests/functional/CestAbstract.php
+++ b/tests/functional/CestAbstract.php
@@ -71,6 +71,7 @@ abstract class CestAbstract
         $user->setEmail($this->login_username);
         $user->setNewPassword($this->login_password);
         $user->getRoles()->add($role);
+        $user->setLocale('en_US.UTF-8');
 
         $this->em->persist($user);
         $this->em->flush();

--- a/tests/functional/CestAbstract.php
+++ b/tests/functional/CestAbstract.php
@@ -130,6 +130,6 @@ abstract class CestAbstract
             'password' => $this->login_password,
         ]);
 
-        $I->seeInSource('Logged in');
+        $I->seeInSource($this->login_username);
     }
 }


### PR DESCRIPTION
This PR provides a frontend test case that checks if the locale that a user has set for them is working correctly in order to prevent issue #3148 from happening again.

As mentioned in the original PR #3149  for the bugfix this test still has some issues that need to be resolved before we can merge it:

---

For some reason when I run the tests after doing that the Step `See in source "Logged in"` from the `@before login` starts to fail. (I've added my test to the `A01_Frontend_ProfileCest` so I'm only running that one atm).

What's weird is that the second test does not fail on that step and I'm a bit stumped why that might be since both of them have the `@before setupComplete` and `@before login` annotations.

Here the output from running the tests:

```
- A01_Frontend_ProfileCest: Set a user profile.
✖ A01_Frontend_ProfileCest: Log in to the application. (4.82s)
- A01_Frontend_ProfileCest: Use a specific locale for a user.
✔ A01_Frontend_ProfileCest: Use a specific locale for a user. (1.58s)
```

```
1) A01_Frontend_ProfileCest: Log in to the application.
 Test  tests/functional/A01_Frontend_ProfileCest.php:setProfileInfo
 Step  See in source "Logged in"
 Fail  Failed asserting that  on page /dashboard
--> <!DOCTYPE html>
<html>
<head>
    <meta charset="utf-8">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1">

    <title>(Testing) Dashboard - AzuraCast</title>

    <link rel="apple-touch-icon" sizes="180x180" href="/sta
[Content too long to display. See complete response in '/var/azuracast/www/tests/_output/' directory]
--> contains "Logged in".

Scenario Steps:

 4. $I->seeInSource("Logged in") at tests/functional/CestAbstract.php:133
 3. $I->submitForm("#login-form",{"username":"azuracast@azuracast.com","password":"AzuraCastFunctionalTests!"}) at tests/functional/CestAbstract.php:130
 2. $I->seeInCurrentUrl("/login") at tests/functional/CestAbstract.php:126
 1. $I->amOnPage("/") at tests/functional/CestAbstract.php:125
```