### PR TITLE
Add possibility to add migrations from plugins via event dispatcher

### DIFF
--- a/src/Event/BuildDoctrineMappingPaths.php
+++ b/src/Event/BuildDoctrineMappingPaths.php
@@ -1,0 +1,31 @@
+<?php
+namespace App\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BuildDoctrineMappingPaths extends Event
+{
+    protected array $mappingClassesPaths;
+    protected string $baseDir;
+
+    public function __construct(array $mappingClassesPaths, string $baseDir)
+    {
+        $this->mappingClassesPaths = $mappingClassesPaths;
+        $this->baseDir = $baseDir;
+    }
+
+    public function getMappingClassesPaths(): array
+    {
+        return $this->mappingClassesPaths;
+    }
+
+    public function setMappingClassesPaths(array $mappingClassesPaths): void
+    {
+        $this->mappingClassesPaths = $mappingClassesPaths;
+    }
+
+    public function getBaseDir(): string
+    {
+        return $this->baseDir;
+    }
+}

--- a/src/Event/BuildMigrationConfigurationArray.php
+++ b/src/Event/BuildMigrationConfigurationArray.php
@@ -1,0 +1,31 @@
+<?php
+namespace App\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BuildMigrationConfigurationArray extends Event
+{
+    protected array $migrationConfigurations;
+    protected string $baseDir;
+
+    public function __construct(array $migrationConfigurations, string $baseDir)
+    {
+        $this->migrationConfigurations = $migrationConfigurations;
+        $this->baseDir = $baseDir;
+    }
+
+    public function getMigrationConfigurations(): array
+    {
+        return $this->migrationConfigurations;
+    }
+
+    public function setMigrationConfigurations(array $migrationConfigurations): void
+    {
+        $this->migrationConfigurations = $migrationConfigurations;
+    }
+
+    public function getBaseDir(): string
+    {
+        return $this->baseDir;
+    }
+}


### PR DESCRIPTION
This PR makes it possible to customize the configurations array that is passed to the `Doctrine\Migrations\Configuration\Migration\ConfigurationArray` so that plugins can register their own migrations.