### PR TITLE
Add configurable time range for duplicate prevention

### DIFF
--- a/config/forms/station.php
+++ b/config/forms/station.php
@@ -519,6 +519,7 @@ return [
                     [
                         'label' => __('Duplicate Prevention Time Range (Minutes)'),
                         'description' => __('This specifies the time range (in minutes) of the song history that the duplicate song prevention algorithm should take into account.'),
+                        'belongsTo' => 'backend_config',
                         'default' => StationBackendConfiguration::DEFAULT_DUPLICATE_PREVENTION_TIME_RANGE,
                         'min' => '0',
                         'max' => '1440',

--- a/config/forms/station.php
+++ b/config/forms/station.php
@@ -513,6 +513,18 @@ return [
                         'form_group_class' => 'col-md-6',
                     ],
                 ],
+
+                StationBackendConfiguration::DUPLICATE_PREVENTION_TIME_RANGE => [
+                    'number',
+                    [
+                        'label' => __('Duplicate Prevention Time Range (Minutes)'),
+                        'description' => __('This specifies the time range (in minutes) of the song history that the duplicate song prevention algorithm should take into account.'),
+                        'default' => StationBackendConfiguration::DEFAULT_DUPLICATE_PREVENTION_TIME_RANGE,
+                        'min' => '0',
+                        'max' => '1440',
+                        'form_group_class' => 'col-md-6',
+                    ],
+                ],
             ],
         ],
 

--- a/src/Entity/StationBackendConfiguration.php
+++ b/src/Entity/StationBackendConfiguration.php
@@ -174,4 +174,18 @@ class StationBackendConfiguration extends ArrayCollection
 
         return 0;
     }
+
+    public const DUPLICATE_PREVENTION_TIME_RANGE = 'duplicate_prevention_time_range';
+
+    public const DEFAULT_DUPLICATE_PREVENTION_TIME_RANGE = 120;
+
+    public function getDuplicatePreventionTimeRange(): int
+    {
+        return $this->get(self::DUPLICATE_PREVENTION_TIME_RANGE) ?? self::DEFAULT_DUPLICATE_PREVENTION_TIME_RANGE;
+    }
+
+    public function setDuplicatePreventionTimeRange(?int $duplicatePreventionTimeRange): void
+    {
+        $this->set(self::DUPLICATE_PREVENTION_TIME_RANGE, $duplicatePreventionTimeRange);
+    }
 }

--- a/src/Radio/AutoDJ/Queue.php
+++ b/src/Radio/AutoDJ/Queue.php
@@ -107,7 +107,7 @@ class Queue implements EventSubscriberInterface
         foreach ($recentSongHistoryForOncePerXSongs as $row) {
             $logOncePerXSongsSongHistory[] = [
                 'song' => $row['song']['text'],
-                'cued_at' => (string)(CarbonImmutable::createFromTimestamp($row['timestamp_cued'],
+                'cued_at' => (string)(CarbonImmutable::createFromTimestamp($row['timestamp_cued'] ?? $row['timestamp_start'],
                     $now->getTimezone())),
                 'duration' => $row['duration'],
                 'sent_to_autodj' => $row['sent_to_autodj'],
@@ -118,7 +118,7 @@ class Queue implements EventSubscriberInterface
         foreach ($recentSongHistoryForDuplicatePrevention as $row) {
             $logDuplicatePreventionSongHistory[] = [
                 'song' => $row['song']['text'],
-                'cued_at' => (string)(CarbonImmutable::createFromTimestamp($row['timestamp_cued'],
+                'cued_at' => (string)(CarbonImmutable::createFromTimestamp($row['timestamp_cued'] ?? $row['timestamp_start'],
                     $now->getTimezone())),
                 'duration' => $row['duration'],
                 'sent_to_autodj' => $row['sent_to_autodj'],
@@ -442,7 +442,7 @@ class Queue implements EventSubscriberInterface
             $songId = $history['song']['id'];
 
             if (!isset($latestSongIdsPlayed[$songId])) {
-                $latestSongIdsPlayed[$songId] = $history['timestamp_cued'];
+                $latestSongIdsPlayed[$songId] = $history['timestamp_cued'] ?? $history['timestamp_start'];
             }
         }
 

--- a/src/Radio/AutoDJ/Queue.php
+++ b/src/Radio/AutoDJ/Queue.php
@@ -66,7 +66,7 @@ class Queue implements EventSubscriberInterface
         $station = $event->getStation();
         $now = $event->getNow();
 
-        $song_history_count = 15;
+        $oncePerXSongHistoryCount = 15;
 
         // Pull all active, non-empty playlists and sort by type.
         $has_any_valid_playlists = false;
@@ -78,7 +78,7 @@ class Queue implements EventSubscriberInterface
                 $type = $playlist->getType();
 
                 if (Entity\StationPlaylist::TYPE_ONCE_PER_X_SONGS === $type) {
-                    $song_history_count = max($song_history_count, $playlist->getPlayPerSongs());
+                    $oncePerXSongHistoryCount = max($oncePerXSongHistoryCount, $playlist->getPlayPerSongs());
                 }
 
                 $subType = ($playlist->getScheduleItems()->count() > 0) ? 'scheduled' : 'unscheduled';
@@ -91,16 +91,32 @@ class Queue implements EventSubscriberInterface
             return;
         }
 
-        // Pull all recent cued songs for easy referencing below.
-        $cued_song_history = $this->historyRepo->getRecentlyPlayed(
+        $recentSongHistoryForOncePerXSongs = $this->historyRepo->getRecentlyPlayed(
             $station,
             $now,
-            $song_history_count
+            $oncePerXSongHistoryCount
         );
 
-        $logSongHistory = [];
-        foreach ($cued_song_history as $row) {
-            $logSongHistory[] = [
+        $recentSongHistoryForDuplicatePrevention = $this->historyRepo->getRecentlyPlayedByTimeRange(
+            $station,
+            $now,
+            $station->getBackendConfig()->getDuplicatePreventionTimeRange()
+        );
+
+        $logOncePerXSongsSongHistory = [];
+        foreach ($recentSongHistoryForOncePerXSongs as $row) {
+            $logOncePerXSongsSongHistory[] = [
+                'song' => $row['song']['text'],
+                'cued_at' => (string)(CarbonImmutable::createFromTimestamp($row['timestamp_cued'],
+                    $now->getTimezone())),
+                'duration' => $row['duration'],
+                'sent_to_autodj' => $row['sent_to_autodj'],
+            ];
+        }
+
+        $logDuplicatePreventionSongHistory = [];
+        foreach ($recentSongHistoryForDuplicatePrevention as $row) {
+            $logDuplicatePreventionSongHistory[] = [
                 'song' => $row['song']['text'],
                 'cued_at' => (string)(CarbonImmutable::createFromTimestamp($row['timestamp_cued'],
                     $now->getTimezone())),
@@ -110,7 +126,8 @@ class Queue implements EventSubscriberInterface
         }
 
         $this->logger->debug('AutoDJ recent song playback history', [
-            'history' => $logSongHistory,
+            'history_once_per_x_songs' => $logOncePerXSongsSongHistory,
+            'history_duplicate_prevention' => $logDuplicatePreventionSongHistory,
         ]);
 
         // Types of playlists that should play, sorted by priority.
@@ -134,7 +151,7 @@ class Queue implements EventSubscriberInterface
             $eligible_playlists = [];
             foreach ($playlists_by_type[$type] as $playlist_id => $playlist) {
                 /** @var Entity\StationPlaylist $playlist */
-                if ($this->scheduler->shouldPlaylistPlayNow($playlist, $now, $cued_song_history)) {
+                if ($this->scheduler->shouldPlaylistPlayNow($playlist, $now, $recentSongHistoryForOncePerXSongs)) {
                     $eligible_playlists[$playlist_id] = $playlist->getWeight();
                     $log_playlists[] = [
                         'id' => $playlist->getId(),
@@ -165,7 +182,7 @@ class Queue implements EventSubscriberInterface
 
                     if ($event->setNextSong($this->playSongFromPlaylist(
                         $playlist,
-                        $cued_song_history,
+                        $recentSongHistoryForDuplicatePrevention,
                         $now,
                         $allowDuplicates
                     ))) {


### PR DESCRIPTION
This PR implements a user configurable time range (in minutes) that the duplicate prevention algorithm should take into account.