### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -159,7 +159,7 @@ return [
         'files' => [
             'js' => [
                 [
-                    'src' => 'dist/lib/sweetalert/sweetalert.min.js',
+                    'src' => 'dist/lib/sweetalert2/sweetalert2.all.min.js',
                     'defer' => true,
                 ],
                 [

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -48,10 +48,10 @@ var jsFiles = {
       'node_modules/bootstrap-notify/bootstrap-notify.min.js'
     ]
   },
-  'sweetalert': {
-    base: 'node_modules/sweetalert/dist',
+  'sweetalert2': {
+    base: 'node_modules/sweetalert2/dist',
     files: [
-      'node_modules/sweetalert/dist/sweetalert.min.js'
+      'node_modules/sweetalert2/dist/sweetalert2.all.min.js'
     ]
   },
   'autosize': {

--- a/frontend/js/inc/confirm-danger.js
+++ b/frontend/js/inc/confirm-danger.js
@@ -19,10 +19,12 @@ function confirmDangerousAction (el) {
   // https://stackoverflow.com/questions/8624592/how-to-get-only-direct-text-without-tags-with-jquery-in-html
   let buttonText = $el.clone().children().remove().end().text();
 
-  return swal({
+  return Swal.fire({
     title: confirmTitle,
-    buttons: [true, buttonText],
-    dangerMode: dangerMode
+    confirmButtonText: buttonText,
+    confirmButtonColor: dangerMode ? '#e64942' : '#3085d6',
+    showCancelButton: true,
+    focusCancel: dangerMode
   });
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3315,11 +3315,6 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
-    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -16285,11 +16280,6 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
-    "promise-polyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
-      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc="
-    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -17423,14 +17413,10 @@
         "es6-symbol": "^3.1.1"
       }
     },
-    "sweetalert": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/sweetalert/-/sweetalert-2.1.2.tgz",
-      "integrity": "sha512-iWx7X4anRBNDa/a+AdTmvAzQtkN1+s4j/JJRWlHpYE8Qimkohs8/XnFcWeYHH2lMA8LRCa5tj2d244If3S/hzA==",
-      "requires": {
-        "es6-object-assign": "^1.1.0",
-        "promise-polyfill": "^6.0.2"
-      }
+    "sweetalert2": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-10.3.5.tgz",
+      "integrity": "sha512-8XBQvW2frWVn0Xs80qyraRXcb3Mg/aKG+9sdVPlzViDIYJfLhMeda3pRuyGzyvrPXbBQ3KRjs+66xKH3kz8/og=="
     },
     "tapable": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "roboto-fontface": "^0.10.0",
     "sortablejs": "^1.10.2",
     "store": "^1.3.20",
-    "sweetalert": "^2.1.2",
+    "sweetalert2": "^10.3.5",
     "vue": "^2.6.12",
     "vue-gettext": "^2.1.10",
     "vuedraggable": "^2.24.1",

--- a/frontend/vue/StationPlaylists.vue
+++ b/frontend/vue/StationPlaylists.vue
@@ -249,10 +249,12 @@
                 let buttonText = this.$gettext('Delete');
                 let buttonConfirmText = this.$gettext('Delete playlist?');
 
-                swal({
+                Swal.fire({
                     title: buttonConfirmText,
-                    buttons: [true, buttonText],
-                    dangerMode: true
+                    confirmButtonText: buttonText,
+                    confirmButtonColor: '#e64942',
+                    showCancelButton: true,
+                    focusCancel: true
                 }).then((value) => {
                     if (value) {
                         axios.delete(url).then((resp) => {

--- a/frontend/vue/StationStreamers.vue
+++ b/frontend/vue/StationStreamers.vue
@@ -119,10 +119,12 @@
                 let buttonText = this.$gettext('Delete');
                 let buttonConfirmText = this.$gettext('Delete streamer?');
 
-                swal({
+                Swal.fire({
                     title: buttonConfirmText,
-                    buttons: [true, buttonText],
-                    dangerMode: true
+                    confirmButtonText: buttonText,
+                    confirmButtonColor: '#e64942',
+                    showCancelButton: true,
+                    focusCancel: true
                 }).then((value) => {
                     if (value) {
                         axios.delete(url).then((resp) => {

--- a/frontend/vue/station_media/MediaToolbar.vue
+++ b/frontend/vue/station_media/MediaToolbar.vue
@@ -114,10 +114,12 @@
                 let buttonText = this.$gettext('Delete');
                 let buttonConfirmText = this.$gettext('Delete %{ num } media file(s)?');
 
-                swal({
+                Swal.fire({
                     title: this.$gettextInterpolate(buttonConfirmText, { num: this.selectedFiles.length }),
-                    buttons: [true, buttonText],
-                    dangerMode: true
+                    confirmButtonText: buttonText,
+                    confirmButtonColor: '#e64942',
+                    showCancelButton: true,
+                    focusCancel: true
                 }).then((value) => {
                     if (value) {
                         this.doBatch('delete', this.$gettext('Files removed:'));

--- a/frontend/vue/station_streamers/StreamerBroadcastsModal.vue
+++ b/frontend/vue/station_streamers/StreamerBroadcastsModal.vue
@@ -128,10 +128,12 @@
                 let buttonText = this.$gettext('Delete');
                 let buttonConfirmText = this.$gettext('Delete broadcast?');
 
-                swal({
+                Swal.fire({
                     title: buttonConfirmText,
-                    buttons: [true, buttonText],
-                    dangerMode: true
+                    confirmButtonText: buttonText,
+                    confirmButtonColor: '#e64942',
+                    showCancelButton: true,
+                    focusCancel: true
                 }).then((value) => {
                     if (value) {
                         axios.delete(url).then((resp) => {


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2020, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

4. SweetAlert2 is far more popular and battle-tested that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)