### PR TITLE
Show rich media info on the Song history modal

### DIFF
--- a/frontend/scss/pages/_public.scss
+++ b/frontend/scss/pages/_public.scss
@@ -70,4 +70,61 @@ body.page-minimal {
       word-break: break-all;
     }
   }
+
+  #station-history {
+    .song {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      width: 100%;
+      line-height: normal;
+      margin-bottom: 15px;
+
+      .order {
+        display: flex;
+        flex-direction: column;
+        width: 35px;
+        justify-content: center;
+        margin-right: 5px;
+        text-align: center;
+      }
+
+      .art {
+        width: 40px;
+        height: 40px;
+        border-radius: 4px;
+        margin-right: 5px;
+      }
+
+      .name {
+        display: flex;
+        flex-direction: column;
+        justify-content: center
+      }
+
+      .date-played {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        margin: 4px 0 0 40px;
+      }
+
+      .break {
+        flex-basis: 100%;
+        height: 0;
+      }
+
+      @media (min-width:576px) {
+        .date-played {
+          margin-left: auto;
+        }
+        .break {
+          display: none;
+        }
+      }
+    }
+    .song:last-child {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/frontend/scss/pages/_public.scss
+++ b/frontend/scss/pages/_public.scss
@@ -80,6 +80,10 @@ body.page-minimal {
       line-height: normal;
       margin-bottom: 15px;
 
+      &:last-child {
+        margin-bottom: 0;
+      }
+
       .order {
         display: flex;
         flex-direction: column;
@@ -98,8 +102,9 @@ body.page-minimal {
 
       .name {
         display: flex;
+        flex: 1;
         flex-direction: column;
-        justify-content: center
+        justify-content: center;
       }
 
       .date-played {
@@ -122,9 +127,6 @@ body.page-minimal {
           display: none;
         }
       }
-    }
-    .song:last-child {
-      margin-bottom: 0;
     }
   }
 }

--- a/templates/frontend/public/index.js.phtml
+++ b/templates/frontend/public/index.js.phtml
@@ -7,16 +7,37 @@ $(function () {
         {
           song: {
             title: '<?=__('Song Title') ?>',
-            artist: '<?=__('Song Artist') ?>'
+            artist: '<?=__('Song Artist') ?>',
+            album: '<?=__('Album') ?>',
+            played_at: '<?=__('Date Played') ?>'
           }
         }
       ]
     },
     mounted: function () {
       radio_player.$eventHub.$on('np_updated', function (np_new) {
+          console.log(np_new.song_history);
         songHistory.history = np_new.song_history;
       });
-    }
+    },
+      methods: {
+          unixTimestampToDate(timestamp) {
+              if(!timestamp) {
+                  return '';
+              }
+              const date = moment.unix(timestamp);
+              if(moment().diff(date, 'days', true) > 0.5) {
+                  return date.calendar();
+              }
+              return date.fromNow();
+          },
+          albumAndArtist(song) {
+              if(!song) {
+                  return [this.$data.history[0].song.album, this.$data.history[0].song.article].join(', ');
+              }
+              return [song.album, song.artist].filter(str => !!str).join(', ');
+          }
+      }
   });
 
   $('[data-fancybox]').fancybox({

--- a/templates/frontend/public/index.js.phtml
+++ b/templates/frontend/public/index.js.phtml
@@ -16,28 +16,27 @@ $(function () {
     },
     mounted: function () {
       radio_player.$eventHub.$on('np_updated', function (np_new) {
-          console.log(np_new.song_history);
         songHistory.history = np_new.song_history;
       });
     },
-      methods: {
-          unixTimestampToDate(timestamp) {
-              if(!timestamp) {
-                  return '';
-              }
-              const date = moment.unix(timestamp);
-              if(moment().diff(date, 'days', true) > 0.5) {
-                  return date.calendar();
-              }
-              return date.fromNow();
-          },
-          albumAndArtist(song) {
-              if(!song) {
-                  return [this.$data.history[0].song.album, this.$data.history[0].song.article].join(', ');
-              }
-              return [song.album, song.artist].filter(str => !!str).join(', ');
-          }
+    methods: {
+      unixTimestampToDate(timestamp) {
+        if (!timestamp) {
+          return '';
+        }
+        const date = moment.unix(timestamp);
+        if (moment().diff(date, 'days', true) > 0.5) {
+          return date.calendar();
+        }
+        return date.fromNow();
+      },
+      albumAndArtist(song) {
+        if (!song) {
+          return [this.$data.history[0].song.album, this.$data.history[0].song.article].join(', ');
+        }
+        return [song.album, song.artist].filter(str => !!str).join(', ');
       }
+    }
   });
 
   $('[data-fancybox]').fancybox({

--- a/templates/frontend/public/index.js.phtml
+++ b/templates/frontend/public/index.js.phtml
@@ -19,6 +19,11 @@ $(function () {
         songHistory.history = np_new.song_history;
       });
     },
+    computed: {
+      langNoRecords () {
+        return this.$gettext('No records to display.');
+      }
+    },
     methods: {
       unixTimestampToDate(timestamp) {
         if (!timestamp) {
@@ -31,9 +36,6 @@ $(function () {
         return date.fromNow();
       },
       albumAndArtist(song) {
-        if (!song) {
-          return [this.$data.history[0].song.album, this.$data.history[0].song.article].join(', ');
-        }
         return [song.album, song.artist].filter(str => !!str).join(', ');
       }
     }

--- a/templates/frontend/public/index.phtml
+++ b/templates/frontend/public/index.phtml
@@ -11,6 +11,7 @@ $assets
     ->load('vue')
     ->load('bootgrid')
     ->load('fancybox')
+    ->load('moment')
     ->addInlineJs($this->fetch('frontend/public/index.js', ['station' => $station]));
 ?>
 
@@ -54,20 +55,19 @@ $assets
             </div>
             <div class="modal-body">
                 <div id="station-history">
-                    <div style="  display: flex; flex-direction: row; flex-wrap: wrap; width: 100%; line-height: normal; margin-bottom: 5px" v-for="(row, index) in history">
-                        <div style="display: flex; flex-direction: column; flex: 1; justify-content: center; align-items: center; margin: 0; padding: 0">
-                            <h4>{{ index + 1 }}</h4>
+                    <div style="  display: flex; flex-direction: row; flex-wrap: wrap; width: 100%; line-height: normal; margin-bottom: 15px" v-for="(row, index) in history">
+                        <div style="display: flex; flex-direction: row; flex-wrap: wrap; width: 100%; line-height: normal; ">
+                            <strong style="display: flex; flex-direction: column; width: 26px; justify-content: center; margin-right: 4px;">
+                                {{ history.length - index }}
+                            </strong>
+                            <img v-bind:src=row.song.art style="width: 40px; height: 40px; border-radius: 4px; margin-right: .5rem;">
+                            <div style="display: flex; flex-direction: column; justify-content: center">
+                                <strong>{{ row.song.title }}</strong>
+                                <span v-html="albumAndArtist(row.song)"></span>
+                            </div>
                         </div>
-                        <div style="  display: flex; flex-direction: column; flex: 2.5; align-items:center; margin: 0; padding: 0">
-                            <img v-bind:src=row.song.art style="width: 40px; border-radius: 4px;">
-                        </div>
-                        <div style="display: flex; flex-direction: column;flex: 15; justify-content: center; margin: 0; padding: 0">
-                            <strong>{{ row.song.title }}</strong>
-                            <small>{{ row.song.artist }}</small>
-                            <small>{{ row }}</small>
-                        </div>
-                        <div style="  display: flex; flex-direction: column; flex: 1; justify-content: center;  margin: 0; padding: 0">
-                            asd
+                        <div style="display: flex; justify-content: center; text-align: left; margin: 4px 0 0 30px; padding: 0">
+                            <small class="text-muted"><span v-html="unixTimestampToDate(row.played_at)">{{ row.song.played_at }}</span></small>
                         </div>
                     </div>
                 </div>

--- a/templates/frontend/public/index.phtml
+++ b/templates/frontend/public/index.phtml
@@ -57,7 +57,7 @@ $assets
                 <div id="station-history">
                     <div style="  display: flex; flex-direction: row; flex-wrap: wrap; width: 100%; line-height: normal; margin-bottom: 15px" v-for="(row, index) in history">
                         <div style="display: flex; flex-direction: row; flex-wrap: wrap; width: 100%; line-height: normal; ">
-                            <strong style="display: flex; flex-direction: column; width: 26px; justify-content: center; margin-right: 4px;">
+                            <strong style="display: flex; flex-direction: column; width: 35px; justify-content: center; margin-right: 5px; text-align: center;">
                                 {{ history.length - index }}
                             </strong>
                             <img v-bind:src=row.song.art style="width: 40px; height: 40px; border-radius: 4px; margin-right: .5rem;">
@@ -65,10 +65,19 @@ $assets
                                 <strong>{{ row.song.title }}</strong>
                                 <span v-html="albumAndArtist(row.song)"></span>
                             </div>
+
+<!--                            <div style="flex-basis: 100%; height: 0;"></div>-->
+<!--                            <small class="text-muted" style="display: flex; flex-direction: column; justify-content: center; margin: 4px 0 0 40px;">-->
+<!--                                <span v-html="unixTimestampToDate(row.played_at)">{{ row.song.played_at }}</span>-->
+<!--                            </small>-->
+
+                            <small class="text-muted" style="display: flex; flex-direction: column; justify-content: center; margin-left: auto;">
+                                <span v-html="unixTimestampToDate(row.played_at)">{{ row.song.played_at }}</span>
+                            </small>
                         </div>
-                        <div style="display: flex; justify-content: center; text-align: left; margin: 4px 0 0 30px; padding: 0">
-                            <small class="text-muted"><span v-html="unixTimestampToDate(row.played_at)">{{ row.song.played_at }}</span></small>
-                        </div>
+<!--                        <div style="display: flex; justify-content: center; text-align: left; margin: 4px 0 0 30px; padding: 0">-->
+<!--                            <small class="text-muted"><span v-html="unixTimestampToDate(row.played_at)">{{ row.song.played_at }}</span></small>-->
+<!--                        </div>-->
                     </div>
                 </div>
             </div>

--- a/templates/frontend/public/index.phtml
+++ b/templates/frontend/public/index.phtml
@@ -48,21 +48,32 @@ $assets
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h4 class="modal-title" id="modal-history-label"><?= __('Song History') ?></h4>
+                <h4 class="modal-title" id="modal-history-label"><?=__('Song History')?></h4>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
-                <ol type="1" id="station-history">
-                    <li v-for="row in history">
-                        <b>{{ row.song.title }}</b><br>
-                        {{ row.song.artist }}
-                    </li>
-                </ol>
+                <div id="station-history">
+                    <div style="  display: flex; flex-direction: row; flex-wrap: wrap; width: 100%; line-height: normal; margin-bottom: 5px" v-for="(row, index) in history">
+                        <div style="display: flex; flex-direction: column; flex: 1; justify-content: center; align-items: center; margin: 0; padding: 0">
+                            <h4>{{ index + 1 }}</h4>
+                        </div>
+                        <div style="  display: flex; flex-direction: column; flex: 2.5; align-items:center; margin: 0; padding: 0">
+                            <img v-bind:src=row.song.art style="width: 40px; border-radius: 4px;">
+                        </div>
+                        <div style="display: flex; flex-direction: column;flex: 15; justify-content: center; margin: 0; padding: 0">
+                            <strong>{{ row.song.title }}</strong>
+                            <small>{{ row.song.artist }}</small>
+                            <small>{{ row }}</small>
+                        </div>
+                        <div style="  display: flex; flex-direction: column; flex: 1; justify-content: center;  margin: 0; padding: 0">
+                            asd
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
-</div>
 
 <div class="modal fade" id="modal-request" tabindex="-1" role="dialog" aria-labelledby="modal-request-label">
     <div class="modal-dialog modal-lg" role="document">

--- a/templates/frontend/public/index.phtml
+++ b/templates/frontend/public/index.phtml
@@ -55,6 +55,7 @@ $assets
             </div>
             <div class="modal-body">
                 <div id="station-history">
+                    <p v-if="history.length <= 0">{{ langNoRecords }}</p>
                     <div class="song" v-for="(row, index) in history">
                         <strong class="order">{{ history.length - index }}</strong>
                         <img class="art" v-bind:src=row.song.art>

--- a/templates/frontend/public/index.phtml
+++ b/templates/frontend/public/index.phtml
@@ -45,64 +45,6 @@ $assets
     </div>
 </div>
 
-<style lang="scss">
-    #station-history .song {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        width: 100%;
-        line-height: normal;
-        margin-bottom: 15px;
-    }
-
-    #station-history .song:last-child {
-        margin-bottom: 0;
-    }
-
-    #station-history .song .order {
-        display: flex;
-        flex-direction: column;
-        width: 35px;
-        justify-content: center;
-        margin-right: 5px;
-        text-align: center;
-    }
-
-    #station-history .song .art {
-        width: 40px;
-        height: 40px;
-        border-radius: 4px;
-        margin-right: 5px;
-    }
-
-    #station-history .song .name {
-        display: flex;
-        flex-direction: column;
-        justify-content: center
-    }
-
-    #station-history .song .date-played {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        margin: 4px 0 0 40px;
-    }
-
-    #station-history .song .break {
-        flex-basis: 100%;
-        height: 0;
-    }
-
-    @media (min-width:576px) {
-        #station-history .song .date-played {
-            margin-left: auto;
-        }
-        #station-history .song .break {
-            display: none;
-        }
-    }
-</style>
-
 <div class="modal fade" id="modal-history" tabindex="-1" role="dialog" aria-labelledby="modal-history-label">
     <div class="modal-dialog" role="document">
         <div class="modal-content">

--- a/templates/frontend/public/index.phtml
+++ b/templates/frontend/public/index.phtml
@@ -45,6 +45,64 @@ $assets
     </div>
 </div>
 
+<style lang="scss">
+    #station-history .song {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        width: 100%;
+        line-height: normal;
+        margin-bottom: 15px;
+    }
+
+    #station-history .song:last-child {
+        margin-bottom: 0;
+    }
+
+    #station-history .song .order {
+        display: flex;
+        flex-direction: column;
+        width: 35px;
+        justify-content: center;
+        margin-right: 5px;
+        text-align: center;
+    }
+
+    #station-history .song .art {
+        width: 40px;
+        height: 40px;
+        border-radius: 4px;
+        margin-right: 5px;
+    }
+
+    #station-history .song .name {
+        display: flex;
+        flex-direction: column;
+        justify-content: center
+    }
+
+    #station-history .song .date-played {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        margin: 4px 0 0 40px;
+    }
+
+    #station-history .song .break {
+        flex-basis: 100%;
+        height: 0;
+    }
+
+    @media (min-width:576px) {
+        #station-history .song .date-played {
+            margin-left: auto;
+        }
+        #station-history .song .break {
+            display: none;
+        }
+    }
+</style>
+
 <div class="modal fade" id="modal-history" tabindex="-1" role="dialog" aria-labelledby="modal-history-label">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -55,29 +113,17 @@ $assets
             </div>
             <div class="modal-body">
                 <div id="station-history">
-                    <div style="  display: flex; flex-direction: row; flex-wrap: wrap; width: 100%; line-height: normal; margin-bottom: 15px" v-for="(row, index) in history">
-                        <div style="display: flex; flex-direction: row; flex-wrap: wrap; width: 100%; line-height: normal; ">
-                            <strong style="display: flex; flex-direction: column; width: 35px; justify-content: center; margin-right: 5px; text-align: center;">
-                                {{ history.length - index }}
-                            </strong>
-                            <img v-bind:src=row.song.art style="width: 40px; height: 40px; border-radius: 4px; margin-right: .5rem;">
-                            <div style="display: flex; flex-direction: column; justify-content: center">
-                                <strong>{{ row.song.title }}</strong>
-                                <span v-html="albumAndArtist(row.song)"></span>
-                            </div>
-
-<!--                            <div style="flex-basis: 100%; height: 0;"></div>-->
-<!--                            <small class="text-muted" style="display: flex; flex-direction: column; justify-content: center; margin: 4px 0 0 40px;">-->
-<!--                                <span v-html="unixTimestampToDate(row.played_at)">{{ row.song.played_at }}</span>-->
-<!--                            </small>-->
-
-                            <small class="text-muted" style="display: flex; flex-direction: column; justify-content: center; margin-left: auto;">
-                                <span v-html="unixTimestampToDate(row.played_at)">{{ row.song.played_at }}</span>
-                            </small>
+                    <div class="song" v-for="(row, index) in history">
+                        <strong class="order">{{ history.length - index }}</strong>
+                        <img class="art" v-bind:src=row.song.art>
+                        <div class="name">
+                            <strong v-html="row.song.title"></strong>
+                            <span v-html="albumAndArtist(row.song)"></span>
                         </div>
-<!--                        <div style="display: flex; justify-content: center; text-align: left; margin: 4px 0 0 30px; padding: 0">-->
-<!--                            <small class="text-muted"><span v-html="unixTimestampToDate(row.played_at)">{{ row.song.played_at }}</span></small>-->
-<!--                        </div>-->
+                        <div class="break"></div>
+                        <small class="date-played text-muted">
+                            <span v-html="unixTimestampToDate(row.played_at)">{{ row.song.played_at }}</span>
+                        </small>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
It addresses #3218.

## Changes
- Display more song details:
    - Show song history indices as DESC (according to the already existing execution sorting)
    - Song art
    - Song title
    - Album, Artist
    - Date played
- Keep it responsive.
- Fallback text in case no records found.
- No new data fetched.

## Screenshots

### The **PREVIOUS** interface
![image](https://user-images.githubusercontent.com/849493/95659472-5685c180-0aef-11eb-9488-11ae8ab38c5d.png)

### The NEW interface
![image](https://user-images.githubusercontent.com/849493/95659218-859b3380-0aed-11eb-807c-c327bfd94e40.png)

### On small screens
![image](https://user-images.githubusercontent.com/849493/95659231-96e44000-0aed-11eb-98b6-b402eb0abec2.png)

### Example of localization in pt-br (only using pre-existing terms)
![image](https://user-images.githubusercontent.com/849493/95659534-ba0fef00-0aef-11eb-8c35-1d5266784868.png)

### Loading state
- No significant changes here;
- Still only showing placeholder texts.

![image](https://user-images.githubusercontent.com/849493/95659372-97c9a180-0aee-11eb-8e7a-33fdb6f08db0.png)

### Text in case of founding no data
![image](https://user-images.githubusercontent.com/849493/95659382-a617bd80-0aee-11eb-9ff1-3162f16a73a2.png)