### PR TITLE
Fix Liquidsoap error when starting AutoDJ for newly created stations

### DIFF
--- a/src/Entity/Repository/StationRepository.php
+++ b/src/Entity/Repository/StationRepository.php
@@ -166,6 +166,7 @@ class StationRepository extends Repository
         }
 
         $this->em->flush();
+        $this->em->refresh($station);
     }
 
     /**


### PR DESCRIPTION
When creating a new station the default mount point for that station is created by the `resetMounts()` method [here](https://github.com/AzuraCast/AzuraCast/blob/master/src/Entity/Repository/StationRepository.php#L202). After that method is called the Liquidsoap configuration is written through `$this->configuration->writeConfiguration($station, true);` [here](https://github.com/AzuraCast/AzuraCast/blob/master/src/Entity/Repository/StationRepository.php#L208).

Since the `Station` entity is not aware of those newly created mount points the `liquidsoap.liq` is written without entries for the `# Local Broadcasts` section which leads to an error when trying to start Liquidsoap. The workaround that most people have used was to simply let AzuraCast re-write the Liquidsoap config after creating the station.

This PR fixes this problem by refreshing the `Station` entity after resetting the mount points.

Closes #3280