### PR TITLE
Add possibility to register message queue message handlers for plugins

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -313,7 +313,8 @@ return [
         App\MessageQueue\QueueManager $queueManager,
         Symfony\Component\Lock\LockFactory $lockFactory,
         Monolog\Logger $logger,
-        ContainerInterface $di
+        ContainerInterface $di,
+        App\Plugins $plugins
     ) {
         // Configure message sending middleware
         $sendMessageMiddleware = new Symfony\Component\Messenger\Middleware\SendMessageMiddleware($queueManager);
@@ -322,6 +323,9 @@ return [
         // Configure message handling middleware
         $handlers = [];
         $receivers = require __DIR__ . '/messagequeue.php';
+
+        // Register plugin-provided message queue receivers
+        $receivers = $plugins->registerMessageQueueReceivers($receivers);
 
         foreach ($receivers as $messageClass => $handlerClass) {
             $handlers[$messageClass][] = function ($message) use ($handlerClass, $di) {

--- a/src/Plugins.php
+++ b/src/Plugins.php
@@ -78,4 +78,23 @@ class Plugins
             }
         }
     }
+
+    /**
+     * @param mixed[] $receivers
+     *
+     * @return mixed[]
+     */
+    public function registerMessageQueueReceivers(array $receivers): array
+    {
+        foreach ($this->plugins as $plugin) {
+            $pluginPath = $plugin['path'];
+
+            if (file_exists($pluginPath . '/messagequeue.php')) {
+                $pluginReceivers = include $pluginPath . '/messagequeue.php';
+                $receivers = array_merge($receivers, $pluginReceivers);
+            }
+        }
+
+        return $receivers;
+    }
 }


### PR DESCRIPTION
This PR adds the possibility to register message queue handlers from plugins analogous to how they are registered in the core AzuraCast application via a `messagequeue.php` file.