### PR TITLE
Use correct column name in analytics entity index annotation

### DIFF
--- a/src/Entity/Analytics.php
+++ b/src/Entity/Analytics.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Table(name="analytics", indexes={
- *   @ORM\Index(name="search_idx", columns={"type", "timestamp"})
+ *   @ORM\Index(name="search_idx", columns={"type", "moment"})
  * })
  * @ORM\Entity
  */


### PR DESCRIPTION
The migration already uses the updated name for the column previously called `timestamp` in the index creation but the annotation on the entity was still pointing to the old one. This was causing issues when running the `migrations:diff` command. This PR fixes this.