### PR TITLE
Make ACL permissions extendable by plugins via event dispatching

### DIFF
--- a/config/forms/role.php
+++ b/config/forms/role.php
@@ -1,8 +1,6 @@
 <?php
 /** @var array $all_stations */
 
-$actions = App\Acl::listPermissions();
-
 $form_config = [
     'method' => 'post',
     'elements' => [

--- a/src/Controller/Admin/PermissionsController.php
+++ b/src/Controller/Admin/PermissionsController.php
@@ -11,10 +11,14 @@ use Psr\Http\Message\ResponseInterface;
 
 class PermissionsController extends AbstractAdminCrudController
 {
-    public function __construct(PermissionsForm $form)
+    protected Acl $acl;
+
+    public function __construct(PermissionsForm $form, Acl $acl)
     {
         parent::__construct($form);
+
         $this->csrf_namespace = 'admin_permissions';
+        $this->acl = $acl;
     }
 
     public function indexAction(ServerRequest $request, Response $response): ResponseInterface
@@ -30,7 +34,7 @@ class PermissionsController extends AbstractAdminCrudController
 
         $roles = [];
 
-        $actions = Acl::listPermissions();
+        $actions = $this->acl->listPermissions();
 
         foreach ($all_roles as $role) {
             $role['permissions_global'] = [];

--- a/src/Controller/Api/Admin/PermissionsController.php
+++ b/src/Controller/Api/Admin/PermissionsController.php
@@ -10,6 +10,13 @@ use Psr\Http\Message\ResponseInterface;
 
 class PermissionsController
 {
+    protected Acl $acl;
+
+    public function __construct(Acl $acl)
+    {
+        $this->acl = $acl;
+    }
+
     /**
      * @OA\Get(path="/admin/permissions",
      *   tags={"Administration: Roles"},
@@ -28,7 +35,7 @@ class PermissionsController
     public function __invoke(ServerRequest $request, Response $response): ResponseInterface
     {
         $permissions = [];
-        foreach (Acl::listPermissions() as $group => $actions) {
+        foreach ($this->acl->listPermissions() as $group => $actions) {
             foreach ($actions as $action_id => $action_name) {
                 $permissions[$group][] = [
                     'id' => $action_id,

--- a/src/Controller/Api/Admin/RolesController.php
+++ b/src/Controller/Api/Admin/RolesController.php
@@ -4,13 +4,29 @@ namespace App\Controller\Api\Admin;
 
 use App\Acl;
 use App\Entity;
+use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Annotations as OA;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class RolesController extends AbstractAdminApiCrudController
 {
     protected string $entityClass = Entity\Role::class;
     protected string $resourceRouteName = 'api:admin:role';
+
+    protected Acl $acl;
+
+    public function __construct(
+        EntityManagerInterface $em,
+        Serializer $serializer,
+        ValidatorInterface $validator,
+        Acl $acl
+    ) {
+        parent::__construct($em, $serializer, $validator);
+
+        $this->acl = $acl;
+    }
 
     /**
      * @OA\Get(path="/admin/roles",
@@ -110,7 +126,7 @@ class RolesController extends AbstractAdminApiCrudController
 
                         if (!empty($value['global'])) {
                             foreach ($value['global'] as $perm_name) {
-                                if (Acl::isValidPermission($perm_name, true)) {
+                                if ($this->acl->isValidPermission($perm_name, true)) {
                                     $perm_record = new Entity\RolePermission($record, null, $perm_name);
                                     $this->em->persist($perm_record);
                                     $perms->add($perm_record);
@@ -124,7 +140,7 @@ class RolesController extends AbstractAdminApiCrudController
 
                                 if ($station instanceof Entity\Station) {
                                     foreach ($station_perms as $perm_name) {
-                                        if (Acl::isValidPermission($perm_name, false)) {
+                                        if ($this->acl->isValidPermission($perm_name, false)) {
                                             $perm_record = new Entity\RolePermission($record, $station, $perm_name);
                                             $this->em->persist($perm_record);
                                             $perms->add($perm_record);

--- a/src/Event/BuildPermissions.php
+++ b/src/Event/BuildPermissions.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BuildPermissions extends Event
+{
+    protected array $permissions;
+
+    public function __construct(array $permissions)
+    {
+        $this->permissions = $permissions;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getPermissions(): array
+    {
+        return $this->permissions;
+    }
+
+    public function setPermissions(array $permissions): void
+    {
+        $this->permissions = $permissions;
+    }
+}

--- a/src/Form/PermissionsForm.php
+++ b/src/Form/PermissionsForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Form;
 
+use App\Acl;
 use App\Config;
 use App\Entity;
 use App\Http\ServerRequest;
@@ -21,10 +22,12 @@ class PermissionsForm extends EntityForm
         ValidatorInterface $validator,
         Config $config,
         Entity\Repository\StationRepository $stations_repo,
-        Entity\Repository\RolePermissionRepository $permissions_repo
+        Entity\Repository\RolePermissionRepository $permissions_repo,
+        Acl $acl
     ) {
         $form_config = $config->get('forms/role', [
             'all_stations' => $stations_repo->fetchArray(),
+            'actions' => $acl->listPermissions(),
         ]);
 
         parent::__construct($em, $serializer, $validator, $form_config);

--- a/src/Middleware/InjectAcl.php
+++ b/src/Middleware/InjectAcl.php
@@ -16,17 +16,17 @@ use Psr\Http\Server\RequestHandlerInterface;
 class InjectAcl implements MiddlewareInterface
 {
     protected RolePermissionRepository $rolePermRepo;
+    protected Acl $acl;
 
-    public function __construct(RolePermissionRepository $rolePermRepo)
+    public function __construct(RolePermissionRepository $rolePermRepo, Acl $acl)
     {
         $this->rolePermRepo = $rolePermRepo;
+        $this->acl = $acl;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $acl = new Acl($this->rolePermRepo);
-
-        $request = $request->withAttribute(ServerRequest::ATTR_ACL, $acl);
+        $request = $request->withAttribute(ServerRequest::ATTR_ACL, $this->acl);
 
         return $handler->handle($request);
     }


### PR DESCRIPTION
In order to secure pages / API endpoints added by plugins via AzuraCasts ACL system it needs to be extendable with new permissions so that new functionality from plugins doesn't have to misuse existing permissions for non-related stuff.

This PR adds this possibility by adding a new event for the event dispatcher.
Since the ACL is currently using static functions I've changed that to use the instance of the Acl class from the container.