### PR TITLE
Fix nowplaying webhooks not triggering

### DIFF
--- a/src/Sync/Task/NowPlaying.php
+++ b/src/Sync/Task/NowPlaying.php
@@ -190,11 +190,6 @@ class NowPlaying extends AbstractTask implements EventSubscriberInterface
 
             $np = ($this->nowPlayingApiGenerator)($station, $npResult);
 
-            $station->setNowplaying($np);
-
-            $this->em->persist($station);
-            $this->em->flush();
-
             // Trigger the dispatching of webhooks.
 
             /** @var Entity\Api\NowPlaying $np_event */
@@ -205,6 +200,10 @@ class NowPlaying extends AbstractTask implements EventSubscriberInterface
             $webhook_event = new SendWebhooks($station, $np_event, $standalone);
 
             $this->eventDispatcher->dispatch($webhook_event);
+
+            $station->setNowplaying($np);
+            $this->em->persist($station);
+            $this->em->flush();
 
             $logger->popProcessor();
 


### PR DESCRIPTION
This PR fixes the bug reported in issue #3314.

The now playing webhooks are currently not triggering because the `computeTriggers()` method in the `SendWebhooks` event retrieves the `$np_old` from the `$station` and compares it to the `NowPlaying` object that the class is initialized with from the `NowPlaying` task and both contain the same information since the np data in the station is updated before dispatching the `SendWebhooks` event.

This behaviour was introduced in the commit fff8124409ba715dc1ea6582103fcd98d16f1c0b around 3 days ago. Before that the `computeTriggers()` method was called manually from the `NowPlaying` task with the old now playing data as parameter (from before updating it in there) before dispatching the `SendWebhooks` event.

I've fixed this by moving the updating of the now playing data to after dispatching the `SendWebhooks` event so that the `computeTriggers()` method is able to pull the old now playing data from the station before it is updated.