### PR TITLE
Prefer ID3v2 tags instead of ID3v1 when reading metadata from files

### DIFF
--- a/src/Media/GetId3/GetId3MetadataManager.php
+++ b/src/Media/GetId3/GetId3MetadataManager.php
@@ -38,7 +38,10 @@ class GetId3MetadataManager implements MetadataManagerInterface
         if (!empty($info['tags'])) {
             $metaTags = $metadata->getTags();
 
-            foreach ($info['tags'] as $tagType => $tagData) {
+            // Reverse array of tags to prefer ID3v2 tags instead of ID3v1
+            $infoTags = array_reverse($info['tags']);
+
+            foreach ($infoTags as $tagType => $tagData) {
                 foreach ($tagData as $tagName => $tagContents) {
                     if (!empty($tagContents[0]) && !$metaTags->containsKey($tagName)) {
                         $metaTags->set($tagName, $this->cleanUpString($tagContents[0]));


### PR DESCRIPTION
This PR fixes #3318 

Due to the recent changes to the ID3 metadata parsing the metadata tags where first set to the ID3v1 tags and then when it goes on to read the ID3v2 tags it ignores them since it already read the values from the v1.

This PR fixes this behaviour by reversing the tags array obtained from getId3 so that ID3v2 is read first.