### PR TITLE
Fix SHOUTcast logfile location issue

### DIFF
--- a/src/Radio/Frontend/SHOUTcast.php
+++ b/src/Radio/Frontend/SHOUTcast.php
@@ -214,7 +214,7 @@ class SHOUTcast extends AbstractFrontend
         return [
             'password' => Utilities::generatePassword(),
             'adminpassword' => Utilities::generatePassword(),
-            'logfile' => '/tmp/sc_serv.log',
+            'logfile' => $config_path . '/sc_serv.log',
             'w3clog' => $config_path . '/sc_w3c.log',
             'banfile' => $this->writeIpBansFile($station),
             'ripfile' => $config_path . '/sc_serv.rip',


### PR DESCRIPTION
This PR fixes the issue that all shoutcast stations share the same log file in `/tmp/sc_serv.log`

Closes #3137