### PR TITLE
Fix text color for memory and disk space status on admin page

### DIFF
--- a/templates/admin/index/index.phtml
+++ b/templates/admin/index/index.phtml
@@ -67,7 +67,7 @@ $assets
                     <span class="sr-only"><?=$memory_percent?>%</span>
                 </div>
             </div>
-            <h3 class="text-white"><small><?=__('%s of %s Used', $memory_used, $memory_total)?></small></h3>
+            <h3><small><?=__('%s of %s Used', $memory_used, $memory_total)?></small></h3>
         </div>
     </div>
 
@@ -81,7 +81,7 @@ $assets
                     <span class="sr-only"><?=$space_percent?>%</span>
                 </div>
             </div>
-            <h3 class="text-white"><small><?=__('%s of %s Used', $space_used, $space_total)?></small></h3>
+            <h3><small><?=__('%s of %s Used', $space_used, $space_total)?></small></h3>
         </div>
     </div>
 </div>


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/13745863/99191726-d9451080-276e-11eb-95e3-23ee5f96fa5f.png)

![image](https://user-images.githubusercontent.com/13745863/99191724-cfbba880-276e-11eb-9951-0ec157bbfe60.png)

# After

![image](https://user-images.githubusercontent.com/13745863/99191737-eb26b380-276e-11eb-9502-801cda5591e9.png)

![image](https://user-images.githubusercontent.com/13745863/99191756-00034700-276f-11eb-9ed6-c22b9a02d9ac.png)

