### PR TITLE
Fix cue_out safety check when annotating media to Liquidsoap

### DIFF
--- a/src/Radio/Backend/Liquidsoap.php
+++ b/src/Radio/Backend/Liquidsoap.php
@@ -129,7 +129,7 @@ class Liquidsoap extends AbstractBackend
                 $annotation_types['liq_cue_out'] = max(0, $annotation_types['duration'] - $cue_out);
             }
         }
-        if (($annotation_types['liq_cue_in'] + $annotation_types['liq_cue_out']) > $annotation_types['duration']) {
+        if ($annotation_types['liq_cue_out'] > $annotation_types['duration']) {
             $annotation_types['liq_cue_out'] = null;
         }
         if ($annotation_types['liq_cue_in'] > $annotation_types['duration']) {


### PR DESCRIPTION
This PR fixes #3467

The safety check for the `cue_out` is not working as intended. As you can see it checks if `cue_in` + `cue_out` is bigger than the total duration of the media file. The logic of that check does not work with the value that is set for `cue_in` and `cue_out` since those are both durations from beginning of the file which can definitely add up to be more than the length of the file. This check does not need to take the `cue_in` into account.

To better illustrate this problem/mismatch here some excerpts from my test DB.

When I set the `cue_in` and `cue_out` as per the following screenshot I'm getting those values from the DB:
![image](https://user-images.githubusercontent.com/13745863/100400860-24f19700-3058-11eb-8302-1edc0586a077.png)

```
+--------+--------+---------+
| length | cue_in | cue_out |
+--------+--------+---------+
| 248.87 |   44.4 |   198.2 |
+--------+--------+---------+
```

And when I set them like this I get those values:
![image](https://user-images.githubusercontent.com/13745863/100400956-5ec29d80-3058-11eb-8da8-20bc6b622040.png)

```
+--------+--------+---------+
| length | cue_in | cue_out |
+--------+--------+---------+
| 248.87 |   44.4 |   217.7 |
+--------+--------+---------+
```

As can be seen the logic of adding `cue_in` to `cue_out` to check if that exceeds the total length of the media file doesn't work since they add up to be higher.