### PR TITLE
Add mime type x-m4a to processable types in mime-type check

### DIFF
--- a/src/Media/MimeType.php
+++ b/src/Media/MimeType.php
@@ -18,6 +18,7 @@ class MimeType
             'audio/ogg', // oga ogg spx
             'audio/x-aac', // aac
             'audio/x-flac', // flac
+            'audio/x-m4a', // m4a
             'audio/x-wav', // wav
         ];
     }


### PR DESCRIPTION
This PR add the missing `audio/x-m4a` mime-type as reported in Discord:

> Could not read source file for: A Very British Airline/A Very British Airline, E
 pisode 3.m4a - Cannot process media file at path "A Very British Airline, Episod
 e 3.m4a": MIME type "audio/x-m4a" is not processable.