### PR TITLE
Fix writing metadata to files via getID3

### DIFF
--- a/src/Media/GetId3/GetId3MetadataManager.php
+++ b/src/Media/GetId3/GetId3MetadataManager.php
@@ -114,7 +114,12 @@ class GetId3MetadataManager implements MetadataManagerInterface
             $tags['comments']['picture'][0] = $tags['attached_picture'][0];
         }
 
-        $tagwriter->tag_data = $tags;
+        $tagData = [];
+        foreach ($tags as $tagKey => $tagValue) {
+            $tagData[$tagKey] = [$tagValue];
+        }
+
+        $tagwriter->tag_data = $tagData;
 
         return $tagwriter->WriteTags();
     }


### PR DESCRIPTION
This PR fixes the writing of metadata back to the media files.

The `getid3_writetags` class expects the tags that are set to the `$tag_data` variable to be in the format of:
```
[
    "title" => ["Song Title"]
]
```

Since the implementation of the abstract Metadata read/write interfaces and the `Metadata` class this functionality has been broken due to the values of the tags not being arrays.

I've fixed this in the `GetId3MetadataManager` and not in the `StationMedia::toMetadata` function since this is an implementation detail that is only relevant for the getID3 library.