### PR TITLE
#3552 Fixes Sound Exchange Media Query

### DIFF
--- a/tests/functional/C04_Station_ReportsCest.php
+++ b/tests/functional/C04_Station_ReportsCest.php
@@ -42,5 +42,15 @@ class C04_Station_ReportsCest extends CestAbstract
 
         $I->seeResponseCodeIs(200);
         $I->see('Listeners');
+
+        $I->amOnPage('/station/' . $station_id . '/reports/soundexchange');
+        $I->seeResponseCodeIs(200);
+        $I->see('SoundExchange Report');
+
+        $I->submitForm(
+            'form#azuraforms_form',
+            ['azuraforms_form_start_date' => '11/01/2020', 'azuraforms_form_end_date' => '11/30/2020']
+        );
+        $I->seeResponseCodeIs(200);
     }
 }


### PR DESCRIPTION
fixes #3552 

This feature is in a completely broken state. This PR fixes the `all_media` query as well as fixes an issue where the album titles weren't being properly populated.