### PR TITLE
Fix clearing of filesystem cache on SFTP upload

### DIFF
--- a/src/Console/Command/Internal/SftpUploadCommand.php
+++ b/src/Console/Command/Internal/SftpUploadCommand.php
@@ -78,7 +78,7 @@ class SftpUploadCommand extends CommandAbstract
     protected function flushCache(Entity\StorageLocation $storageLocation): void
     {
         $adapter = $storageLocation->getStorageAdapter();
-        $fs = $this->filesystem->getFilesystemForAdapter($adapter);
+        $fs = $this->filesystem->getFilesystemForAdapter($adapter, true);
         $fs->clearCache(false);
     }
 


### PR DESCRIPTION
The SFTP upload command currently calls the `clearCache` method on an adapter which was fetched without the flag for making it a `CachedAdapter`. This leads to the `clearCache` method not doing anything since the adapter has no cache when called with it.

This PR fixes this problem.