### PR TITLE
Made migration scripts more tolerant to "incremental runs"

### DIFF
--- a/src/Entity/Migration/Version20200816092130.php
+++ b/src/Entity/Migration/Version20200816092130.php
@@ -26,12 +26,12 @@ final class Version20200816092130 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE station_queue (id INT AUTO_INCREMENT NOT NULL, song_id VARCHAR(50) NOT NULL, station_id INT DEFAULT NULL, playlist_id INT DEFAULT NULL, media_id INT DEFAULT NULL, request_id INT DEFAULT NULL, sent_to_autodj TINYINT(1) NOT NULL, autodj_custom_uri VARCHAR(255) DEFAULT NULL, timestamp_cued INT NOT NULL, duration INT DEFAULT NULL, INDEX IDX_277B0055A0BDB2F3 (song_id), INDEX IDX_277B005521BDB235 (station_id), INDEX IDX_277B00556BBD148 (playlist_id), INDEX IDX_277B0055EA9FDD75 (media_id), INDEX IDX_277B0055427EB8A5 (request_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_general_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B0055A0BDB2F3 FOREIGN KEY (song_id) REFERENCES songs (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B005521BDB235 FOREIGN KEY (station_id) REFERENCES station (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B00556BBD148 FOREIGN KEY (playlist_id) REFERENCES station_playlists (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B0055EA9FDD75 FOREIGN KEY (media_id) REFERENCES station_media (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B0055427EB8A5 FOREIGN KEY (request_id) REFERENCES station_requests (id) ON DELETE CASCADE');
+        $this->addSql('CREATE TABLE IF NOT EXISTS station_queue (id INT AUTO_INCREMENT NOT NULL, song_id VARCHAR(50) NOT NULL, station_id INT DEFAULT NULL, playlist_id INT DEFAULT NULL, media_id INT DEFAULT NULL, request_id INT DEFAULT NULL, sent_to_autodj TINYINT(1) NOT NULL, autodj_custom_uri VARCHAR(255) DEFAULT NULL, timestamp_cued INT NOT NULL, duration INT DEFAULT NULL, INDEX IDX_277B0055A0BDB2F3 (song_id), INDEX IDX_277B005521BDB235 (station_id), INDEX IDX_277B00556BBD148 (playlist_id), INDEX IDX_277B0055EA9FDD75 (media_id), INDEX IDX_277B0055427EB8A5 (request_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_general_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B0055A0BDB2F3 FOREIGN KEY IF NOT EXISTS (song_id) REFERENCES songs (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B005521BDB235 FOREIGN KEY IF NOT EXISTS (station_id) REFERENCES station (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B00556BBD148 FOREIGN KEY IF NOT EXISTS (playlist_id) REFERENCES station_playlists (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B0055EA9FDD75 FOREIGN KEY IF NOT EXISTS (media_id) REFERENCES station_media (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B0055427EB8A5 FOREIGN KEY IF NOT EXISTS (request_id) REFERENCES station_requests (id) ON DELETE CASCADE');
         $this->addSql('DROP INDEX idx_timestamp_cued ON song_history');
         $this->addSql('ALTER TABLE song_history DROP timestamp_cued, DROP sent_to_autodj, DROP autodj_custom_uri');
     }

--- a/src/Entity/Migration/Version20200818010817.php
+++ b/src/Entity/Migration/Version20200818010817.php
@@ -23,7 +23,7 @@ final class Version20200818010817 extends AbstractMigration
         $this->addSql('ALTER TABLE settings CHANGE setting_value setting_value LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
         $this->addSql('ALTER TABLE song_history CHANGE delta_points delta_points LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
         $this->addSql('ALTER TABLE station CHANGE frontend_config frontend_config LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\', CHANGE backend_config backend_config LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\', CHANGE automation_settings automation_settings LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
-        $this->addSql('ALTER TABLE station_queue ADD log LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\', CHANGE station_id station_id INT NOT NULL');
+        $this->addSql('ALTER TABLE station_queue ADD IF NOT EXISTS log LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\', CHANGE station_id station_id INT NOT NULL');
         $this->addSql('ALTER TABLE station_webhooks CHANGE triggers triggers LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\', CHANGE config config LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\', CHANGE metadata metadata LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
     }
 

--- a/src/Entity/Migration/Version20201003021913.php
+++ b/src/Entity/Migration/Version20201003021913.php
@@ -25,9 +25,9 @@ final class Version20201003021913 extends AbstractMigration
         // Avoid "data truncated" errors with really long titles/artists.
         $this->addSql('UPDATE station_media SET artist=SUBSTRING(artist, 1, 150), title=SUBSTRING(title, 1, 150)');
 
-        $this->addSql('ALTER TABLE song_history ADD `text` VARCHAR(150) DEFAULT NULL, ADD artist VARCHAR(150) DEFAULT NULL, ADD title VARCHAR(150) DEFAULT NULL');
-        $this->addSql('ALTER TABLE station_media ADD `text` VARCHAR(150) DEFAULT NULL, CHANGE title title VARCHAR(150) DEFAULT NULL, CHANGE artist artist VARCHAR(150) DEFAULT NULL');
-        $this->addSql('ALTER TABLE station_queue ADD `text` VARCHAR(150) DEFAULT NULL, ADD artist VARCHAR(150) DEFAULT NULL, ADD title VARCHAR(150) DEFAULT NULL');
+        $this->addSql('ALTER TABLE song_history ADD IF NOT EXISTS `text` VARCHAR(150) DEFAULT NULL, ADD IF NOT EXISTS artist VARCHAR(150) DEFAULT NULL, ADD IF NOT EXISTS title VARCHAR(150) DEFAULT NULL');
+        $this->addSql('ALTER TABLE station_media ADD IF NOT EXISTS `text` VARCHAR(150) DEFAULT NULL, CHANGE title title VARCHAR(150) DEFAULT NULL, CHANGE artist artist VARCHAR(150) DEFAULT NULL');
+        $this->addSql('ALTER TABLE station_queue ADD IF NOT EXISTS `text` VARCHAR(150) DEFAULT NULL, ADD IF NOT EXISTS artist VARCHAR(150) DEFAULT NULL, ADD IF NOT EXISTS title VARCHAR(150) DEFAULT NULL');
 
         $this->addSql('UPDATE song_history sh JOIN songs s ON sh.song_id = s.id SET sh.text=s.text, sh.artist=s.artist, sh.title=s.title');
         $this->addSql('UPDATE station_queue sq JOIN songs s ON sq.song_id = s.id SET sq.text=s.text, sq.artist=s.artist, sq.title=s.title');

--- a/src/Entity/Migration/Version20201027130404.php
+++ b/src/Entity/Migration/Version20201027130404.php
@@ -17,18 +17,18 @@ final class Version20201027130404 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE TABLE storage_location (id INT AUTO_INCREMENT NOT NULL, type VARCHAR(50) NOT NULL, adapter VARCHAR(50) NOT NULL, path VARCHAR(255) DEFAULT NULL, s3_credential_key VARCHAR(255) DEFAULT NULL, s3_credential_secret VARCHAR(255) DEFAULT NULL, s3_region VARCHAR(150) DEFAULT NULL, s3_version VARCHAR(150) DEFAULT NULL, s3_bucket VARCHAR(255) DEFAULT NULL, s3_endpoint VARCHAR(255) DEFAULT NULL, storage_quota BIGINT DEFAULT NULL, storage_used BIGINT DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_general_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE IF NOT EXISTS storage_location(id INT AUTO_INCREMENT NOT NULL, type VARCHAR(50) NOT NULL, adapter VARCHAR(50) NOT NULL, path VARCHAR(255) DEFAULT NULL, s3_credential_key VARCHAR(255) DEFAULT NULL, s3_credential_secret VARCHAR(255) DEFAULT NULL, s3_region VARCHAR(150) DEFAULT NULL, s3_version VARCHAR(150) DEFAULT NULL, s3_bucket VARCHAR(255) DEFAULT NULL, s3_endpoint VARCHAR(255) DEFAULT NULL, storage_quota BIGINT DEFAULT NULL, storage_used BIGINT DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_general_ci` ENGINE = InnoDB');
 
-        $this->addSql('ALTER TABLE station ADD media_storage_location_id INT DEFAULT NULL, ADD recordings_storage_location_id INT DEFAULT NULL');
-        $this->addSql('ALTER TABLE station ADD CONSTRAINT FK_9F39F8B1C896ABC5 FOREIGN KEY (media_storage_location_id) REFERENCES storage_location (id) ON DELETE SET NULL');
-        $this->addSql('ALTER TABLE station ADD CONSTRAINT FK_9F39F8B15C7361BE FOREIGN KEY (recordings_storage_location_id) REFERENCES storage_location (id) ON DELETE SET NULL');
-        $this->addSql('CREATE INDEX IDX_9F39F8B1C896ABC5 ON station (media_storage_location_id)');
-        $this->addSql('CREATE INDEX IDX_9F39F8B15C7361BE ON station (recordings_storage_location_id)');
+        $this->addSql('ALTER TABLE station ADD IF NOT EXISTS media_storage_location_id INT DEFAULT NULL, ADD IF NOT EXISTS recordings_storage_location_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE station ADD CONSTRAINT FK_9F39F8B1C896ABC5 FOREIGN KEY IF NOT EXISTS (media_storage_location_id) REFERENCES storage_location (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE station ADD CONSTRAINT FK_9F39F8B15C7361BE FOREIGN KEY IF NOT EXISTS (recordings_storage_location_id) REFERENCES storage_location (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IF NOT EXISTS IDX_9F39F8B1C896ABC5 ON station (media_storage_location_id)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS IDX_9F39F8B15C7361BE ON station (recordings_storage_location_id)');
 
         $this->addSql('ALTER TABLE station_media DROP FOREIGN KEY FK_32AADE3A21BDB235');
         $this->addSql('DROP INDEX IDX_32AADE3A21BDB235 ON station_media');
         $this->addSql('DROP INDEX path_unique_idx ON station_media');
-        $this->addSql('ALTER TABLE station_media ADD storage_location_id INT NOT NULL');
+        $this->addSql('ALTER TABLE station_media ADD IF NOT EXISTS storage_location_id INT NOT NULL');
     }
 
     public function down(Schema $schema): void

--- a/src/Entity/Migration/Version20201208185538.php
+++ b/src/Entity/Migration/Version20201208185538.php
@@ -18,7 +18,7 @@ final class Version20201208185538 extends AbstractMigration
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE api_keys CHANGE user_id user_id INT DEFAULT NULL');
-        $this->addSql('ALTER TABLE storage_location ADD dropbox_auth_token VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE storage_location ADD IF NOT EXISTS dropbox_auth_token VARCHAR(255) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
We had the issue that the migration script didnt run through after we restored a backup.
We received a couple errors that column and some keys were already existing, so i added some "IF NOT EXISTS" statements to handle that.
Those were the files that were necessary for us to restore the backup, i dont know if there are more.