### PR TITLE
Fix quota not being used for raw storage calculation on local storage locations

### DIFF
--- a/src/Entity/StorageLocation.php
+++ b/src/Entity/StorageLocation.php
@@ -389,6 +389,8 @@ class StorageLocation
             if (null === $quota || $quota->isGreaterThan($totalSpace)) {
                 return $totalSpace;
             }
+
+            return $quota;
         } elseif (null !== $quota) {
             return $quota;
         }


### PR DESCRIPTION
This PR fixes an issue where the set storage quota for local `StorageLocations` is not being used due to it not being returned by the `getRawStorageAvailable` method of the `StorageLocations`.

This should also fix #3574