### PR TITLE
Fix issue with mounting custom SSL certificates due to read-only volume mount

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,4 +32,4 @@ services:
     build:
       context: ../docker-azuracast-radio
     volumes:
-      - ./util/local_ssl:/etc/nginx/certs:ro
+      - ./util/local_ssl:/etc/nginx/certs

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -263,7 +263,7 @@ services:
     volumes:
       - station_data:/var/azuracast/stations
       - shoutcast2_install:/var/azuracast/servers/shoutcast2
-      - letsencrypt:/etc/nginx/certs:ro
+      - letsencrypt:/etc/nginx/certs
       - tmp_data:/var/azuracast/www_tmp
     networks:
       - frontend


### PR DESCRIPTION
This PR fixes the issue reported in #3595 of not being able to use the volume mounts for custom certificates described on our websites [documentation](https://www.azuracast.com/extending/modifying-docker.html#common-examples) due to the following error/s:

```
ERROR: for azuracast_stations  Cannot start service stations: OCI runtime create failed: container_linux.go:370: starting container process caused: process_linux.go:459: container init caused: rootfs_linux.go:59: mounting "/var/azuracast/azuracast_vaachar_de.key" to rootfs at "/var/lib/docker/overlay2/74c1a1f79907eb661d8f759fa31b6008627d91b9d0de92d918caa4d96f0e98a2/merged/etc/nginx/certs/azuracast.vaachar.de.key" caused: open /var/lib/docker/overlay2/74c1a1f79907eb661d8f759fa31b6008627d91b9d0de92d918caa4d96f0e98a2/merged/etc/nginx/certs/azuracast.vaachar.de.key: read-only file system: unknown

ERROR: for azuracast_stations  Cannot start service stations: OCI runtime create failed: container_linux.go:370: starting container process caused: process_linux.go:459: container init caused: rootfs_linux.go:59: mounting "/var/azuracast/azuracast_vaachar_de.crt" to rootfs at "/var/lib/docker/overlay2/6e3eeee9a7aca6eaabd7049bcbc73b18755b370e8cc44ae4968c46a62a368393/merged/etc/nginx/certs/azuracast.vaachar.de.crt" caused: open /var/lib/docker/overlay2/6e3eeee9a7aca6eaabd7049bcbc73b18755b370e8cc44ae4968c46a62a368393/merged/etc/nginx/certs/azuracast.vaachar.de.crt: read-only file system: unknown
```

