### PR TITLE
Update command for installing plugin dependencies according to the Composer V2 version

### DIFF
--- a/util/docker/web/scripts/azuracast_install
+++ b/util/docker/web/scripts/azuracast_install
@@ -20,7 +20,7 @@ echo "(Environment: $APPLICATION_ENV)"
 
 if [ "$APPLICATION_ENV" = "production" ]; then
     if bool "$COMPOSER_PLUGIN_MODE"; then
-        composer update --lock --no-dev --optimize-autoloader
+        composer update --no-dev --optimize-autoloader
     fi
 else
     if [ "$APPLICATION_ENV" = "testing" ]; then

--- a/util/docker/web/scripts/azuracast_restore
+++ b/util/docker/web/scripts/azuracast_restore
@@ -20,7 +20,7 @@ echo "(Environment: $APPLICATION_ENV)"
 
 if [ "$APPLICATION_ENV" = "production" ]; then
     if bool "$COMPOSER_PLUGIN_MODE"; then
-        composer update --lock --no-dev --optimize-autoloader
+        composer update --no-dev --optimize-autoloader
     fi
 else
     composer install


### PR DESCRIPTION
The command to install plugin dependencies via the `wikimedia/composer-merge-plugin` has been changed from `composer update --lock` to `composer update` in the Composer 2 version of the plugin.