### PR TITLE
Fix bug where Music Files list fails to load on S3 storage locations due to missing MTime metadata

### DIFF
--- a/src/Controller/Api/Stations/Files/ListAction.php
+++ b/src/Controller/Api/Stations/Files/ListAction.php
@@ -279,7 +279,7 @@ class ListAction
                 }
                 $row->path_short = $shortname;
 
-                $row->timestamp = $meta['timestamp'];
+                $row->timestamp = $meta['timestamp'] ?? 0;
                 $row->size = $meta['size'];
                 $row->is_dir = ('dir' === $meta['type']);
 


### PR DESCRIPTION
This PR fixes #3640

As I've written in the issue I have no idea when/why an S3 provider returns metadata without a `Last Modified` time in the `HeadObject` API request. The S3 Flysystem Adapter is aware of this however and explicitly checks if this is set in the response so it seems to be something that is accounted for in the Adapter (which basically just means not setting this metadata to the flysystem metadata array).

I'm a bit concerned about this since this could probably also lead to problems with other parts of AzuraCast like for example the `CheckMediaTask` in [this](https://github.com/AzuraCast/AzuraCast/blob/master/src/Sync/Task/CheckMediaTask.php#L209) and [this](https://github.com/AzuraCast/AzuraCast/blob/master/src/Sync/Task/CheckMediaTask.php#L245) line (maybe also other parts where S3 locations are used, like for example backups).

What do you think about this @SlvrEagle23 ?