### PR TITLE
Fix Acl error on actions without a user like internal API calls

### DIFF
--- a/src/Acl.php
+++ b/src/Acl.php
@@ -132,10 +132,6 @@ class Acl
      */
     public function isAllowed($action, $stationId = null): bool
     {
-        if (!isset($this->user)) {
-            throw new \RuntimeException('Cannot check permission with no user set.');
-        }
-
         return $this->userAllowed($this->user, $action, $stationId);
     }
 


### PR DESCRIPTION
This PR fixes #3653

In the recent commit that refactored the Acl to be part of the request lifecycle a new method was added to the `Acl` class called [`isAllowed`](https://github.com/AzuraCast/AzuraCast/blob/master/src/Acl.php#L133). This method contains a [check](https://github.com/AzuraCast/AzuraCast/blob/master/src/Acl.php#L135-L137) that throws a `RuntimeException` if the method is called when the `Acl` class does not contain a `User` entity.

All calls that are now using `isAllowed` were previously using [`userAllowed`](https://github.com/AzuraCast/AzuraCast/blob/master/src/Acl.php#L149) from the `Acl` class. This method is also internally called by `isAllowed` with `$this->user` which can be `null`. Since `userAllowed` does not fail or throw errors/exceptions and has always been accepting calls with a `null` user and returning `false` if no user is given there is no reason to explicitly check if a user is set in `isAllowed` and throwing an exception.