### PR TITLE
Added 2 more ID3 fields to lookup for artwork retrieval

### DIFF
--- a/src/Media/GetId3/GetId3MetadataManager.php
+++ b/src/Media/GetId3/GetId3MetadataManager.php
@@ -64,6 +64,10 @@ class GetId3MetadataManager implements MetadataManagerInterface
             $metadata->setArtwork($info['attached_picture'][0]['data']);
         } elseif (!empty($info['comments']['picture'][0])) {
             $metadata->setArtwork($info['comments']['picture'][0]['data']);
+        } elseif (!empty($info['id3v2']['APIC'][0]['data'])) {
+            $metadata->setArtwork($info['id3v2']['APIC'][0]['data']);
+        } elseif (!empty($info['id3v2']['PIC'][0]['data'])) {
+            $metadata->setArtwork($info['id3v2']['PIC'][0]['data']);
         }
 
         return $metadata;


### PR DESCRIPTION
As mentioned in #3673 there are 2 more fields in the ID3 data that we can look into when retrieving artworks of media files.

This PR adds those fields to the lookup.