### PR TITLE
Fix broadcasts not being marked as ended on DJ disconnect

### DIFF
--- a/src/Entity/Repository/StationStreamerRepository.php
+++ b/src/Entity/Repository/StationStreamerRepository.php
@@ -115,7 +115,7 @@ class StationStreamerRepository extends Repository
             $destPath = FilesystemManager::PREFIX_RECORDINGS . '://' . $broadcastPath;
 
             if ($fs->has($tempPath)) {
-                $fs->copy($tempPath, $destPath);
+                $fs->move($tempPath, $destPath);
             }
 
             $broadcast->setTimestampEnd(time());

--- a/src/Entity/StationStreamerBroadcast.php
+++ b/src/Entity/StationStreamerBroadcast.php
@@ -12,7 +12,7 @@ use OpenApi\Annotations as OA;
  * Each individual broadcast associated with a streamer.
  *
  * @ORM\Table(name="station_streamer_broadcasts")
- * @ORM\Entity(readOnly=true)
+ * @ORM\Entity()
  * @ORM\HasLifecycleCallbacks
  *
  * @OA\Schema(type="object")


### PR DESCRIPTION
Due to the `StationStreamerBroadcast` entity being marked as `@ORM\Entity(readOnly=true)` all changes to an instance of this entity are ignored. This caused the updating of the `timestamp_end` to be ignored when a DJ disconnects.

Further more I've changed the `$fs->copy()` to `$fs->move` in order to reduce wasted storage space.

This PR closes #3588