### PR TITLE
Fix issue with media processing due to missing song id when external album art is enabled

### DIFF
--- a/src/Entity/StationMedia.php
+++ b/src/Entity/StationMedia.php
@@ -551,6 +551,8 @@ class StationMedia implements SongInterface, ProcessableMediaInterface, PathAwar
         if (isset($tags['isrc'])) {
             $this->setIsrc($tags['isrc']);
         }
+
+        $this->updateSongId();
     }
 
     public function toMetadata(): Metadata


### PR DESCRIPTION
This PR fixes the bug reported in #3690

Due to the `RemoteAlbumArt` needing to check the song ids to see if a song is the "Offline" song in order to prevent tracks from hitting the external APIs it is accessing the song id before it was ever initialized on newly created/uploaded media files.

Normally the `updateSongId` method is called at the end of `loadFromFile` but the value is already needed in `getMetadata` at the beginning of the `loadFromFile` method.