### PR TITLE
Fix parser warnings for empty mount elements in IceCast log

### DIFF
--- a/src/Radio/Frontend/Icecast.php
+++ b/src/Radio/Frontend/Icecast.php
@@ -163,12 +163,20 @@ class Icecast extends AbstractFrontend
                 '@type' => 'normal',
                 'mount-name' => $mount_row->getName(),
                 'charset' => 'UTF8',
-
                 'stream-name' => $station->getName(),
-                'stream-description' => $station->getDescription(),
-                'stream-url' => $station->getUrl(),
-                'genre' => $station->getGenre(),
             ];
+
+            if (!empty($station->getDescription())) {
+                $mount['stream-description'] = $station->getDescription();
+            }
+
+            if (!empty($station->getUrl())) {
+                $mount['stream-url'] = $station->getUrl();
+            }
+
+            if (!empty($station->getGenre())) {
+                $mount['genre'] = $station->getGenre();
+            }
 
             if (!$mount_row->isVisibleOnPublicPages()) {
                 $mount['hidden'] = 1;


### PR DESCRIPTION
This PR fixes the issue of the icecast log showing the following parser warnings if the fields `stream-description`, `stream-url` or `genre` are empty on a mount:

```
[2021-02-04  18:39:59] WARN xml/parsing warning: 
[2021-02-04  18:39:59] WARN xml/parsing skipping element "stream-description" parsing "mount" at line 35
[2021-02-04  18:39:59] WARN xml/parsing warning: 
[2021-02-04  18:39:59] WARN xml/parsing skipping element "stream-url" parsing "mount" at line 36
[2021-02-05  05:30:21] WARN xml/parsing warning: 
[2021-02-05  05:30:21] WARN xml/parsing skipping element "genre" parsing "mount" at line 33
```