### PR TITLE
Restricting blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
A small request:

The aim of this is to encourage users to follow the rules and to remove the 'blank' template option, requiring them to follow the current issue template.

Information came from here: https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository