### PR TITLE
Update master to main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -626,7 +626,7 @@ This release includes some infrastructural changes to the application, along wit
   leaving the main media manager page.
 
 - You can now customize even more of the AzuraCast Docker installation parameters by modifying configuration lines in
-  your local [azuracast.env](https://github.com/AzuraCast/AzuraCast/blob/master/azuracast.sample.env#L70-L80) file.
+  your local [azuracast.env](https://github.com/AzuraCast/AzuraCast/blob/main/azuracast.sample.env#L70-L80) file.
 
 ## Bug Fixes
 
@@ -958,7 +958,7 @@ features and bug fixes.
   are convenient and secure: just scan the provided QR code with an app on your smartphone (FreeOTP, Authy, or any other
   TOTP app) and it will generate a unique code every few seconds. You will be asked for this code any time you log in.
   If you lose access to your authenticator at any time, you can follow
-  the [password reset instructions](https://github.com/AzuraCast/AzuraCast/blob/master/SUPPORT.md#reset-an-account-password)
+  the [password reset instructions](https://github.com/AzuraCast/AzuraCast/blob/main/SUPPORT.md#reset-an-account-password)
   to recover your account.
 
 - **Automatically Send Error Reports**: Thanks to our friends at [Sentry](https://sentry.io/), we've added the ability

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,13 @@ A majority of our repositories come with an `.editorconfig` file in the root, wh
 If your IDE does not support EditorConfig, the most important standard to remember that we follow is the PHP Framework Interoperability Group's [PSR-12 Extended Coding Style](https://www.php-fig.org/psr/psr-12/) standard.
 
 Accessibility, security, and modern best practices are very important in AzuraCast's development. Any newly contributed code can, and should, take advantage of the full suite of new features made available in PHP 7.4 and newer.
- 
-Instructions for developing with AzuraCast locally are [available here](https://www.azuracast.com/developers). If you have questions about the guidelines above or about how to contribute to AzuraCast, please create a Github issue, join our [Discord server.](https://www.azuracast.com/discord) Please note that support is offered on an 'as available' basis. 
+
+Instructions for developing with AzuraCast locally are [available here](https://www.azuracast.com/developers). If you have questions about the guidelines above or about how to contribute to AzuraCast, please create a Github issue, join our [Discord server.](https://www.azuracast.com/discord) Please note that support is offered on an 'as available' basis.
 
 Contributions are also welcome in the supporting technologies used to make AzuraCast possible, such as:
 
  - Dockerfiles (see [our separate repositories](https://github.com/AzuraCast) for Docker containers)
- - [Ansible configuration](https://github.com/AzuraCast/AzuraCast/tree/master/util/ansible) for Ansible installs
+ - [Ansible configuration](https://github.com/AzuraCast/AzuraCast/tree/main/util/ansible) for Ansible installs
 
 ## Translating AzuraCast
 
@@ -44,14 +44,14 @@ While we appreciate everyone who is eager to contribute to this project and help
  - Please **do not e-mail the project developer directly** with questions or issues specific to AzuraCast, unless you were specifically requested to do so as part of an ongoing issue. Contacting me directly prevents me from tracking all outstanding issues in one place, and harms the transparency that is essential to FOSS development. If, however, you are e-mailing me to offer me a paying job...go nuts.
 
  - Please **do not create "this doesn't work" issues** that are just one sentence long and don't provide any insight into the scope of the issue, what changes might have triggered it, or what platform you're running on. At the very minimum, please fill out the template provided, as it gives us a lot of information to debug and provide you with support.
- 
+
  - Please **refer to existing Github issues** if you are curious about the status of outstanding bug reports or new enhancement requests. Always remember that this is a volunteer project primarily built and maintained by a single developer, and manage your expectations accordingly.
 
 ## Support AzuraCast
 
 ### Support us on GitHub Sponsors
 
-Donating through GitHub Sponsors is the best way to show your support for AzuraCast's development. You can change your pledge at any time through the Sponsors Page. GitHub will match every sponsor on our page so every donation counts. 
+Donating through GitHub Sponsors is the best way to show your support for AzuraCast's development. You can change your pledge at any time through the Sponsors Page. GitHub will match every sponsor on our page so every donation counts.
 
 [GitHub Sponsor Page][sponsor]
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/AzuraCast/AzuraCast/raw/master/resources/azuracast.png)
+![](https://github.com/AzuraCast/AzuraCast/raw/main/resources/azuracast.png)
 
 # AzuraCast: A Self-Hosted Web Radio Manager
 
@@ -77,7 +77,7 @@ Once installed and running, AzuraCast exposes an API that allows you to monitor 
 
 ## License
 
-AzuraCast is licensed under the [Apache license, version 2.0](https://github.com/AzuraCast/AzuraCast/blob/master/LICENSE.txt). This project is free and open-source software, and pull requests are always welcome.
+AzuraCast is licensed under the [Apache license, version 2.0](https://github.com/AzuraCast/AzuraCast/blob/main/LICENSE.txt). This project is free and open-source software, and pull requests are always welcome.
 
 ## Need Help?
 

--- a/src/Version.php
+++ b/src/Version.php
@@ -20,10 +20,10 @@ class Version
 
     // phpcs:disable Generic.Files.LineLength
     public const LATEST_COMPOSE_REVISION = 11;
-    public const LATEST_COMPOSE_URL = 'https://raw.githubusercontent.com/AzuraCast/AzuraCast/master/docker-compose.sample.yml';
+    public const LATEST_COMPOSE_URL = 'https://raw.githubusercontent.com/AzuraCast/AzuraCast/main/docker-compose.sample.yml';
 
     public const UPDATE_URL = 'https://www.azuracast.com/administration/system/updating.html';
-    public const CHANGELOG_URL = 'https://github.com/AzuraCast/AzuraCast/blob/master/CHANGELOG.md';
+    public const CHANGELOG_URL = 'https://github.com/AzuraCast/AzuraCast/blob/main/CHANGELOG.md';
     // phpcs:enable
 
     protected CacheInterface $cache;
@@ -124,7 +124,7 @@ class Version
             $details['tag'] = self::FALLBACK_VERSION;
         }
 
-        $details['branch'] = $this->runProcess(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], 'master');
+        $details['branch'] = $this->runProcess(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], 'main');
 
         return $details;
     }


### PR DESCRIPTION
Updates further references to the "master" branch to the renamed "main" branch.

I also note there are multiple "X-Crowdin-File" links and other translation files  which appear to be stored in the /resources/locale directory inside the "main" branch, so these may need to be updated by another developer. I don't have any knowledge of how these work.