### PR TITLE
Revert weighted shuffle algorithm change

### DIFF
--- a/src/Radio/AutoDJ/Queue.php
+++ b/src/Radio/AutoDJ/Queue.php
@@ -228,18 +228,21 @@ class Queue implements EventSubscriberInterface
     {
         $new = $original;
 
+        $max = 1.0 / mt_getrandmax();
+
         array_walk(
             $new,
-            function (&$v, $k): void {
-                $v = random_int(1, $v);
+            function (&$value, $key) use ($max): void {
+                $value = (mt_rand() * $max) ** (1.0 / $value);
             }
         );
 
         arsort($new);
+
         array_walk(
             $new,
-            function (&$v, $k) use ($original): void {
-                $v = $original[$k];
+            function (&$value, $key) use ($original): void {
+                $value = $original[$key];
             }
         );
 


### PR DESCRIPTION
This PR reverts the change of the weighted shuffle algorithm from commit https://github.com/AzuraCast/AzuraCast/commit/c81a0a9c8e8c4cafeb964d49cf92c9aa89317305

While testing the probability distribution with the changed algorithm I noticed that it behaves non-linear which is very unintuitive.

What I've found is that the current weighting algo produces a pretty strange distribution that could lead to some playlists being very unlikely to be played.

Given the following array of playlists with their weight:

```php
$playlists = [
    'A' => 1,
    'B' => 2,
    'C' => 4,
    'D' => 8,
    'E' => 16,
];
```

with 100000 iterations the first playlist in the shuffled array were:

```
A =    78 times
B =   383 times
C =  5589 times
D = 23784 times
E = 70166 times
```

After seeing this I have checked what the old algo produces:

```
A =  3206 times
B =  6542 times
C = 12954 times
D = 25717 times
E = 51581 times
```

The old algo seems to double the probability for a playlist to be picked when the weight is doubled which seems quite intuitive to me.

I couldn't confirm the issue that caused this algo change (weights seemed to work inverted #3735) which leads me to the conclusion that this change should be reverted.