### PR TITLE
Continue processing media when artwork can not be processed

### DIFF
--- a/src/Entity/Repository/StationMediaRepository.php
+++ b/src/Entity/Repository/StationMediaRepository.php
@@ -294,7 +294,18 @@ class StationMediaRepository extends Repository
 
         $artwork = $metadata->getArtwork();
         if (!empty($artwork)) {
-            $this->writeAlbumArt($media, $artwork);
+            try {
+                $this->writeAlbumArt($media, $artwork);
+            } catch (\Exception $exception) {
+                $this->logger->error(
+                    sprintf(
+                        'Album Artwork for "%s" could not be processed: "%s"',
+                        $filePath,
+                        $exception->getMessage()
+                    ),
+                    $exception->getTrace()
+                );
+            }
         }
 
         // Attempt to derive title and artist from filename.


### PR DESCRIPTION
This PR allows the media processing to continue if it encounters an error while processing / writing the album artwork. For example if the album artwork is in an unsupported image format.

Fixes #3724