### PR TITLE
Improve listener csv export with streamed response

### DIFF
--- a/src/Controller/Api/Stations/ListenersAction.php
+++ b/src/Controller/Api/Stations/ListenersAction.php
@@ -54,15 +54,6 @@ class ListenersAction
      *   @OA\Response(response=403, description="Access denied"),
      *   security={{"api_key": {}}},
      * )
-     *
-     * @param ServerRequest $request
-     * @param Response $response
-     * @param EntityManagerInterface $em
-     * @param Entity\Repository\StationMountRepository $mountRepo
-     * @param Entity\Repository\StationRemoteRepository $remoteRepo
-     * @param IpGeolocation $geoLite
-     * @param DeviceDetector $deviceDetector
-     *
      */
     public function __invoke(
         ServerRequest $request,
@@ -147,7 +138,6 @@ class ListenersAction
      * @param Response $response
      * @param Entity\Api\Listener[] $listeners
      * @param string $filename
-     *
      */
     public function exportReportAsCsv(
         Response $response,
@@ -225,12 +215,6 @@ class ListenersAction
         return SimpleBatchIteratorAggregate::fromQuery($query, 100);
     }
 
-    /**
-     * @param mixed $params
-     * @param Station $station
-     *
-     * @return SimpleBatchIteratorAggregate
-     */
     protected function createTimeRangeListenersBatchIterator(
         int $startTimestamp,
         int $endTimestamp,
@@ -251,6 +235,9 @@ class ListenersAction
         return SimpleBatchIteratorAggregate::fromQuery($query, 100);
     }
 
+    /**
+     * @return mixed[]
+     */
     protected function buildListenersByHashArray(
         SimpleBatchIteratorAggregate $listenersIterator,
         Entity\Station $station,

--- a/src/Controller/Api/Stations/ListenersAction.php
+++ b/src/Controller/Api/Stations/ListenersAction.php
@@ -11,6 +11,7 @@ use App\Service\IpGeolocation;
 use Carbon\CarbonImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use DoctrineBatchUtils\BatchProcessing\SimpleBatchIteratorAggregate;
+use GuzzleHttp\Psr7\Stream;
 use League\Csv\Writer;
 use OpenApi\Annotations as OA;
 use Psr\Http\Message\ResponseInterface;
@@ -225,8 +226,8 @@ class ListenersAction
         array $listeners,
         string $filename
     ): ResponseInterface {
-        $tempFile = new \SplTempFileObject();
-        $csv = Writer::createFromFileObject($tempFile);
+        $tempFile = tmpfile();
+        $csv = Writer::createFromStream($tempFile);
 
         $csv->insertOne(
             [
@@ -277,6 +278,8 @@ class ListenersAction
             $csv->insertOne($export_row);
         }
 
-        return $response->renderStringAsFile($csv->getContent(), 'text/csv', $filename);
+        $stream = new Stream($tempFile);
+
+        return $response->renderStreamAsFile($stream, 'text/csv', $filename);
     }
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -3,6 +3,7 @@
 namespace App\Http;
 
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 final class Response extends \Slim\Http\Response
 {
@@ -125,6 +126,37 @@ final class Response extends \Slim\Http\Response
         }
 
         $response->getBody()->write($file_data);
+
+        return new static($response, $this->streamFactory);
+    }
+
+    /**
+     * Write a stream to the response as if it is a file for download.
+     *
+     * @param StreamInterface $fileStream
+     * @param string $content_type
+     * @param string|null $file_name
+     *
+     * @return static
+     */
+    public function renderStreamAsFile(
+        StreamInterface $fileStream,
+        string $contentType,
+        ?string $fileName = null
+    ) {
+        set_time_limit(600);
+
+        $response = $this->response
+            ->withHeader('Pragma', 'public')
+            ->withHeader('Expires', '0')
+            ->withHeader('Cache-Control', 'must-revalidate, post-check=0, pre-check=0')
+            ->withHeader('Content-Type', $contentType);
+
+        if ($fileName !== null) {
+            $response = $response->withHeader('Content-Disposition', 'attachment; filename=' . $fileName);
+        }
+
+        $response = $response->withBody($fileStream);
 
         return new static($response, $this->streamFactory);
     }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -134,8 +134,8 @@ final class Response extends \Slim\Http\Response
      * Write a stream to the response as if it is a file for download.
      *
      * @param StreamInterface $fileStream
-     * @param string $content_type
-     * @param string|null $file_name
+     * @param string $contentType
+     * @param string|null $fileName
      *
      * @return static
      */


### PR DESCRIPTION
This PR further improves the API `ListenerAction` by using a streamed response to download the temporary file instead of loading the whole file into memory and streaming that as a string.

The `renderStreamAsFile` method has a `set_time_limit(600);` in it to have it match what `renderFile` is doing.

Additionally I have separated the code a bit to improve the readability.

Regarding timeouts I think we really need to make the `proxy_read_timeout` more configurable for users. At the moment our `nginx_proxy` is using the default 60s timeout without that being easily overridable. So even if a user increases the php execution time via the env var they will still run into the proxy timeout after 60s.