### PR TITLE
Chunk switch() statements in Liquidsoap config to avoid hitting limit of scheduled switches

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -428,15 +428,20 @@ class ConfigWriter implements EventSubscriberInterface
         if (!empty($scheduleSwitches)) {
             $scheduleSwitches[] = '({true}, radio)';
 
-            $event->appendLines(
-                [
-                    '# Standard Schedule Switches',
-                    sprintf(
-                        'radio = switch(id="schedule_switch", track_sensitive=true, [ %s ])',
-                        implode(', ', $scheduleSwitches)
-                    ),
-                ]
-            );
+            $event->appendLines(['# Standard Schedule Switches']);
+
+            // Chunk scheduled switches to avoid hitting the max amount of playlists in a switch()
+            $chunkedScheduleSwitches = array_chunk($scheduleSwitches, 168, true);
+            foreach ($chunkedScheduleSwitches as $scheduleSwitchesChunk) {
+                $event->appendLines(
+                    [
+                        sprintf(
+                            'radio = switch(id="schedule_switch", track_sensitive=true, [ %s ])',
+                            implode(', ', $scheduleSwitchesChunk)
+                        ),
+                    ]
+                );
+            }
         }
 
         // Add in special playlists if necessary.

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -426,13 +426,13 @@ class ConfigWriter implements EventSubscriberInterface
         );
 
         if (!empty($scheduleSwitches)) {
-            $scheduleSwitches[] = '({true}, radio)';
-
             $event->appendLines(['# Standard Schedule Switches']);
 
             // Chunk scheduled switches to avoid hitting the max amount of playlists in a switch()
             $chunkedScheduleSwitches = array_chunk($scheduleSwitches, 168, true);
             foreach ($chunkedScheduleSwitches as $scheduleSwitchesChunk) {
+                $scheduleSwitchesChunk[] = '({true}, radio)';
+
                 $event->appendLines(
                     [
                         sprintf(


### PR DESCRIPTION
This PR fixes a limitation in Liquidsoap's `switch()` statement. When there are too many scheduled switches inside of one statement Liquidsoap can't handle this anymore and (in my case) has been unable to update the streams metadata.

I have chosen the chunk size of 168 to represent 1 scheduled switch per 24 hours for 7 days.
When testing with this size Liquidsoap still behaves normally.

For most users this will still just generate 1 switch statement but for the cases where this size is exceeded it will prevent users from having issues due to that.