### PR TITLE
Increase worker connections in web container

### DIFF
--- a/util/docker/web/nginx/nginx.conf
+++ b/util/docker/web/nginx/nginx.conf
@@ -1,5 +1,6 @@
 user  azuracast;
 worker_processes  auto;
+worker_rlimit_nofile 65000;
 
 error_log  /dev/stderr warn;
 pid        /var/run/nginx.pid;
@@ -7,7 +8,7 @@ pid        /var/run/nginx.pid;
 include /etc/nginx/modules-enabled/*.conf;
 
 events {
-    worker_connections 4096;
+    worker_connections 65000;
 }
 
 http {
@@ -31,10 +32,10 @@ http {
 
     client_max_body_size 50M;
     client_body_temp_path /tmp/azuracast_nginx_client 1 1;
-    
+
     fastcgi_temp_path /tmp/azuracast_fastcgi_temp 1 1;
 
     proxy_max_temp_file_size 0;
-    
+
     include /etc/nginx/conf.d/*.conf;
 }

--- a/util/docker/web/nginx/nginx.conf
+++ b/util/docker/web/nginx/nginx.conf
@@ -9,6 +9,7 @@ include /etc/nginx/modules-enabled/*.conf;
 
 events {
     worker_connections 65000;
+    multi_accept on;
 }
 
 http {


### PR DESCRIPTION
This PR increases the `worker_connections` and `worker_rlimit_nofile` as well as sets the `multi_accept` in the web docker container to match the nginx config from the `nginx_proxy`, `azura_relay` as well as the web nginx of ansible.

This should fix the issue of not being able to handle large amount of listeners through the proxy: https://github.com/AzuraCast/AzuraCast/issues/3702

Since all other nginx instances in our application stack have already set these limits to 65k I think this is the root of the problem of not being able to handle that many listeners. 