### PR TITLE
Update backup file path wording

### DIFF
--- a/config/forms/backup_run.php
+++ b/config/forms/backup_run.php
@@ -15,7 +15,7 @@ return [
             'text',
             [
                 'label' => __('Backup Filename'),
-                'description' => __('Path where the backup file should be located.'),
+                'description' => __('This will be the file name for your backup, include the file type (.zip or .rar) you wish to use.'),
             ],
         ],
 


### PR DESCRIPTION
This pull aims to resolve a issue raised in our Discord about a user who was unable to run a proper backup because he was missing the .zip or .rar file extension. I've updated the description string to be more clear about filepath names. 