### PR TITLE
Update str_replace chars in LS annotateString method

### DIFF
--- a/src/Radio/Backend/Liquidsoap.php
+++ b/src/Radio/Backend/Liquidsoap.php
@@ -183,7 +183,7 @@ class Liquidsoap extends AbstractBackend
     public static function annotateString(string $str): string
     {
         $str = mb_convert_encoding($str, 'UTF-8');
-        return str_replace(['"', "\n", "\t", "\r", '|'], ["'", '', '', '', '-'], $str);
+        return str_replace(['"', "\n", "\t", "\r"], ['\"', '', '', ''], $str);
     }
 
     /**


### PR DESCRIPTION
I have been looking at the string replacements we do when annotating songs to Liquidsoap and reading up on recent AzuraCast issues involving album covers where the annotateString method was mentioned and that LS had problems with some chars in the annotated string.

Through that I found out that the issue with the `|` char has been fixed in LS 1.4.2 already (see https://github.com/savonet/liquidsoap/issues/1151). After removing this char from the `str_replace` and some manual testing on my local dev machine I would agree that this is fixed.

I haven't found any kind of information on the LS docs nor in their repos issues about double quotes being problematic which puzzled me a bit since I read that it was already unsuccessfully tested with escaping the `"` via `\"`.

To see what exactly happens when there is an `\"` in the annotated string I changed the `str_replace` to escape the double-quote and put songs into my playlist that contain double-quotes (both just with a single double-quote and multiple). I couldn't see any issues with that and the album covers were also showing correctly.

@SlvrEagle23 would you mind testing this PR on your machine too in order to double-check if I didn't overlook anything?