### PR TITLE
Improve memory usage of file list API and media manager

### DIFF
--- a/src/Controller/Api/Stations/Files/ListAction.php
+++ b/src/Controller/Api/Stations/Files/ListAction.php
@@ -62,7 +62,29 @@ class ListAction
                 : $currentDir . '/%';
 
             $mediaQueryBuilder = $em->createQueryBuilder()
-                ->select(['sm', 'spm', 'sp', 'smcf'])
+                ->select([
+                    'sm.song_id',
+                    'sm.title',
+                    'sm.artist',
+                    'sm.album',
+                    'sm.genre',
+                    'sm.length',
+                    'sm.length_text',
+                    'sm.art_updated_at',
+                    'sm.unique_id',
+                    'sm.path',
+                ])
+                ->addSelect([
+                    'spm.id',
+                ])
+                ->addSelect([
+                    'sp.id',
+                    'sp.name',
+                ])
+                ->addSelect([
+                    'smcf.field_id',
+                    'smcf.value',
+                ])
                 ->from(Entity\StationMedia::class, 'sm')
                 ->leftJoin('sm.custom_fields', 'smcf')
                 ->leftJoin('sm.playlists', 'spm')
@@ -76,7 +98,7 @@ class ListAction
             // Apply searching
             $foldersInDirQuery = $em->createQuery(
                 <<<'DQL'
-                    SELECT spf, sp
+                    SELECT spf.path, sp.id, sp.name
                     FROM App\Entity\StationPlaylistFolder spf
                     JOIN spf.playlist sp
                     WHERE spf.station = :station
@@ -87,7 +109,7 @@ class ListAction
 
             $unprocessableMediaQuery = $em->createQuery(
                 <<<'DQL'
-                    SELECT upm
+                    SELECT upm.path, upm.error
                     FROM App\Entity\UnprocessableMedia upm
                     WHERE upm.storage_location = :storageLocation
                     AND upm.path LIKE :path


### PR DESCRIPTION
This PR fixes the memory usage issue from #4009

Due to the removal of partial selects in adc7122afce4ea69e2cc0385d3f40005f54b2d5d the queries in the `ListAction` are selecting too much data. Especially the `$mediaQuery` has been selecting a lot of unnecessary data for each row like for example the entire internal queue of the playlists associated to it.

When I was debugging this problem on the installation that was provided to me in the issue mentioned above I ran the SQL that Doctrine generates with some changes to calculate the size of the returned data in bytes (query for this posted below) and got around 217mb of data as a result. Just by removing the `s3_.queue` (s3_ is the station_playlists table) from the generated SQL this was reduced to a mere 0.46mb.

I have changed the query to now only select the data that is actually used in the ListAction which reduced the amount of data for the `$mediaQuery` to 0.29mb.

Query I used to get the sum amount of bytes returned:

```
SELECT SUM(row_size)
FROM (
       SELECT IFNULL(LENGTH(s0_.id), 0) +
              IFNULL(LENGTH(s0_.storage_location_id), 0) +
              IFNULL(LENGTH(s0_.album), 0) +
              IFNULL(LENGTH(s0_.genre), 0) +
              IFNULL(LENGTH(s0_.lyrics), 0) +
              IFNULL(LENGTH(s0_.isrc), 0) +
              IFNULL(LENGTH(s0_.length), 0) +
              IFNULL(LENGTH(s0_.length_text), 0) +
              IFNULL(LENGTH(s0_.path), 0) +
              IFNULL(LENGTH(s0_.mtime), 0) +
              IFNULL(LENGTH(s0_.amplify), 0) +
              IFNULL(LENGTH(s0_.fade_overlap), 0) +
              IFNULL(LENGTH(s0_.fade_in), 0) +
              IFNULL(LENGTH(s0_.fade_out), 0) +
              IFNULL(LENGTH(s0_.cue_in), 0) +
              IFNULL(LENGTH(s0_.cue_out), 0) +
              IFNULL(LENGTH(s0_.art_updated_at), 0) +
              IFNULL(LENGTH(s0_.unique_id), 0) +
              IFNULL(LENGTH(s0_.song_id), 0) +
              IFNULL(LENGTH(s0_.text), 0) +
              IFNULL(LENGTH(s0_.artist), 0) +
              IFNULL(LENGTH(s0_.title), 0) +
              IFNULL(LENGTH(s1_.id), 0) +
              IFNULL(LENGTH(s1_.media_id), 0) +
              IFNULL(LENGTH(s1_.field_id), 0) +
              IFNULL(LENGTH(s1_.field_value), 0) +
              IFNULL(LENGTH(s2_.id), 0) +
              IFNULL(LENGTH(s2_.playlist_id), 0) +
              IFNULL(LENGTH(s2_.media_id), 0) +
              IFNULL(LENGTH(s2_.weight), 0) +
              IFNULL(LENGTH(s2_.last_played), 0) +
              IFNULL(LENGTH(s3_.id), 0) +
              IFNULL(LENGTH(s3_.station_id), 0) +
              IFNULL(LENGTH(s3_.name), 0) +
              IFNULL(LENGTH(s3_.type), 0) +
              IFNULL(LENGTH(s3_.source), 0) +
              IFNULL(LENGTH(s3_.playback_order), 0) +
              IFNULL(LENGTH(s3_.remote_url), 0) +
              IFNULL(LENGTH(s3_.remote_type), 0) +
              IFNULL(LENGTH(s3_.remote_timeout), 0) +
              IFNULL(LENGTH(s3_.is_enabled), 0) +
              IFNULL(LENGTH(s3_.is_jingle), 0) +
              IFNULL(LENGTH(s3_.play_per_songs), 0) +
              IFNULL(LENGTH(s3_.play_per_minutes), 0) +
              IFNULL(LENGTH(s3_.play_per_hour_minute), 0) +
              IFNULL(LENGTH(s3_.weight), 0) +
              IFNULL(LENGTH(s3_.include_in_requests), 0) +
              IFNULL(LENGTH(s3_.include_in_on_demand), 0) +
              IFNULL(LENGTH(s3_.include_in_automation), 0) +
              IFNULL(LENGTH(s3_.backend_options), 0) +
              IFNULL(LENGTH(s3_.avoid_duplicates), 0) +
              IFNULL(LENGTH(s3_.played_at), 0) +
              IFNULL(LENGTH(s3_.queue), 0) +
              IFNULL(LENGTH(s0_.storage_location_id), 0) +
              IFNULL(LENGTH(s1_.media_id), 0) +
              IFNULL(LENGTH(s1_.field_id), 0) +
              IFNULL(LENGTH(s2_.playlist_id), 0) +
              IFNULL(LENGTH(s2_.media_id), 0) +
              IFNULL(LENGTH(s3_.station_id), 0)
              AS row_size
       FROM station_media s0_
       LEFT JOIN station_media_custom_field s1_ ON s0_.id = s1_.media_id
       LEFT JOIN station_playlist_media s2_ ON s0_.id = s2_.media_id
       LEFT JOIN station_playlists s3_ ON s2_.playlist_id = s3_.id
       AND (s3_.station_id = 1)
       WHERE s0_.storage_location_id = 2
         AND s0_.path LIKE 'Geral-internacional/%'
         AND s0_.path NOT LIKE 'Geral-internacional/%/%'
) AS tbl1
```