### PR TITLE
Reimplement playlist queue to be attached to StationPlaylistMedia table.

### DIFF
--- a/src/Controller/Api/Stations/Playlists/DeleteQueueAction.php
+++ b/src/Controller/Api/Stations/Playlists/DeleteQueueAction.php
@@ -12,14 +12,12 @@ class DeleteQueueAction extends AbstractPlaylistsAction
     public function __invoke(
         ServerRequest $request,
         Response $response,
+        Entity\Repository\StationPlaylistMediaRepository $spmRepo,
         $id
     ): ResponseInterface {
         $record = $this->requireRecord($request->getStation(), $id);
 
-        $record->setQueue(null);
-        $this->em->persist($record);
-
-        $this->em->flush();
+        $spmRepo->resetQueue($record);
 
         return $response->withJson(
             new Entity\Api\Status(

--- a/src/Controller/Api/Stations/Playlists/GetQueueAction.php
+++ b/src/Controller/Api/Stations/Playlists/GetQueueAction.php
@@ -13,6 +13,7 @@ class GetQueueAction extends AbstractPlaylistsAction
     public function __invoke(
         ServerRequest $request,
         Response $response,
+        Entity\Repository\StationPlaylistMediaRepository $spmRepo,
         $id
     ): ResponseInterface {
         $record = $this->requireRecord($request->getStation(), $id);
@@ -25,7 +26,7 @@ class GetQueueAction extends AbstractPlaylistsAction
             throw new \InvalidArgumentException('This playlist is always shuffled and has no visible queue.');
         }
 
-        $queue = (array)$record->getQueue();
+        $queue = $spmRepo->getQueue($record);
         $paginator = Paginator::fromArray($queue, $request);
 
         return $paginator->write($response);

--- a/src/Controller/Api/Stations/Playlists/ReshuffleAction.php
+++ b/src/Controller/Api/Stations/Playlists/ReshuffleAction.php
@@ -9,13 +9,15 @@ use Psr\Http\Message\ResponseInterface;
 
 class ReshuffleAction extends AbstractPlaylistsAction
 {
-    public function __invoke(ServerRequest $request, Response $response, $id): ResponseInterface
-    {
+    public function __invoke(
+        ServerRequest $request,
+        Response $response,
+        Entity\Repository\StationPlaylistMediaRepository $spmRepo,
+        $id
+    ): ResponseInterface {
         $record = $this->requireRecord($request->getStation(), $id);
 
-        $record->setQueue(null);
-        $this->em->persist($record);
-        $this->em->flush();
+        $spmRepo->resetQueue($record);
 
         return $response->withJson(
             new Entity\Api\Status(

--- a/src/Entity/Api/StationPlaylistQueue.php
+++ b/src/Entity/Api/StationPlaylistQueue.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Entity\Api;
+
+class StationPlaylistQueue
+{
+    /**
+     * ID of the StationPlaylistMedia record associating this track with the playlist
+     *
+     * @OA\Property(example=1)
+     * @var int|null
+     */
+    public ?int $spm_id = null;
+
+    /**
+     * ID of the StationPlaylistMedia record associating this track with the playlist
+     *
+     * @OA\Property(example=1)
+     * @var int
+     */
+    public int $media_id;
+
+    /**
+     * The song's 32-character unique identifier hash
+     *
+     * @OA\Property(example="9f33bbc912c19603e51be8e0987d076b")
+     * @var string
+     */
+    public string $song_id;
+
+    /**
+     * The song artist.
+     *
+     * @OA\Property(example="Chet Porter")
+     * @var string
+     */
+    public string $artist = '';
+
+    /**
+     * The song title.
+     *
+     * @OA\Property(example="Aluko River")
+     * @var string
+     */
+    public string $title = '';
+}

--- a/src/Entity/Migration/Version20210416214621.php
+++ b/src/Entity/Migration/Version20210416214621.php
@@ -12,19 +12,19 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version20210416214621 extends AbstractMigration
 {
-    public function getDescription() : string
+    public function getDescription(): string
     {
         return 'Move playlist queue to station_playlist_media table.';
     }
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE station_playlist_media ADD is_queued TINYINT(1) NOT NULL');
         $this->addSql('ALTER TABLE station_playlists DROP queue');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE station_playlist_media DROP is_queued');

--- a/src/Entity/Migration/Version20210416214621.php
+++ b/src/Entity/Migration/Version20210416214621.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210416214621 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Move playlist queue to station_playlist_media table.';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE station_playlist_media ADD is_queued TINYINT(1) NOT NULL');
+        $this->addSql('ALTER TABLE station_playlists DROP queue');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE station_playlist_media DROP is_queued');
+        $this->addSql('ALTER TABLE station_playlists ADD queue LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_general_ci` COMMENT \'(DC2Type:array)\'');
+    }
+}

--- a/src/Entity/Repository/StationPlaylistMediaRepository.php
+++ b/src/Entity/Repository/StationPlaylistMediaRepository.php
@@ -72,10 +72,6 @@ class StationPlaylistMediaRepository extends Repository
             $record = new Entity\StationPlaylistMedia($playlist, $media);
             $record->setWeight($weight);
             $this->em->persist($record);
-
-            // Add the newly added song into the cached queue.
-            $playlist->addToQueue($media);
-            $this->em->persist($playlist);
         }
 
         return $weight;
@@ -124,10 +120,6 @@ class StationPlaylistMediaRepository extends Repository
 
         foreach ($playlists as $spmRow) {
             $playlist = $spmRow->getPlaylist();
-
-            $playlist->removeFromQueue($media);
-            $this->em->persist($playlist);
-
             $affectedPlaylists[$playlist->getId()] = $playlist;
 
             $this->queueRepo->clearForMediaAndPlaylist($media, $playlist);
@@ -159,43 +151,96 @@ class StationPlaylistMediaRepository extends Repository
             DQL
         )->setParameter('playlist_id', $playlist->getId());
 
-        foreach ($mapping as $id => $weight) {
-            $update_query->setParameter('id', $id)
-                ->setParameter('weight', $weight)
-                ->execute();
-        }
-
-        // Clear the playback queue.
-        $playlist->setQueue($this->getPlayableMedia($playlist));
-        $this->em->persist($playlist);
-        $this->em->flush();
+        $this->em->transactional(
+            function () use ($update_query, $mapping) {
+                foreach ($mapping as $id => $weight) {
+                    $update_query->setParameter('id', $id)
+                        ->setParameter('weight', $weight)
+                        ->execute();
+                }
+            }
+        );
     }
 
     /**
-     * @return mixed[]
+     * @return Entity\Api\StationPlaylistQueue[]
      */
-    public function getPlayableMedia(Entity\StationPlaylist $playlist): array
+    public function resetQueue(StationPlaylist $playlist): array
     {
-        $all_media = $this->em->createQuery(
-            <<<'DQL'
-                SELECT sm.id, sm.song_id, sm.artist, sm.title
-                FROM App\Entity\StationMedia sm
-                JOIN sm.playlists spm
-                WHERE spm.playlist_id = :playlist_id
-                ORDER BY spm.weight ASC
-            DQL
-        )->setParameter('playlist_id', $playlist->getId())
-            ->getArrayResult();
-
-        if ($playlist->getOrder() !== Entity\StationPlaylist::ORDER_SEQUENTIAL) {
-            shuffle($all_media);
+        if ($playlist::SOURCE_SONGS !== $playlist->getSource()) {
+            throw new \InvalidArgumentException('Playlist must contain songs.');
         }
 
-        $media_queue = [];
-        foreach ($all_media as $media_row) {
-            $media_queue[$media_row['id']] = $media_row;
+        if ($playlist::ORDER_SEQUENTIAL === $playlist->getOrder()) {
+            $this->em->createQuery(
+                <<<'DQL'
+                    UPDATE App\Entity\StationPlaylistMedia spm
+                    SET spm.is_queued = 1
+                    WHERE spm.playlist = :playlist
+                DQL
+            )->setParameter('playlist', $playlist)
+                ->execute();
+        } elseif ($playlist::ORDER_SHUFFLE === $playlist->getOrder()) {
+            $this->em->transactional(
+                function () use ($playlist) {
+                    $allSpmRecordsQuery = $this->em->createQuery(
+                        <<<'DQL'
+                            SELECT spm.id
+                            FROM App\Entity\StationPlaylistMedia spm
+                            WHERE spm.playlist = :playlist
+                            ORDER BY RAND()
+                        DQL
+                    )->setParameter('playlist', $playlist);
+
+                    $weight = 1;
+                    $allSpmRecords = $allSpmRecordsQuery->toIterable([], $allSpmRecordsQuery::HYDRATE_SCALAR);
+
+                    foreach ($allSpmRecords as $row) {
+                        var_dump($row);
+                        exit;
+                    }
+                }
+            );
         }
 
-        return $media_queue;
+        return $this->getQueue($playlist);
+    }
+
+    /**
+     * @return Entity\Api\StationPlaylistQueue[]
+     */
+    public function getQueue(StationPlaylist $playlist): array
+    {
+        if ($playlist::SOURCE_SONGS !== $playlist->getSource()) {
+            throw new \InvalidArgumentException('Playlist must contain songs.');
+        }
+
+        $queuedMediaQuery = $this->em->createQueryBuilder()
+            ->select(['spm.id AS spm_id', 'sm.id', 'sm.song_id', 'sm.artist', 'sm.title'])
+            ->from(Entity\StationMedia::class, 'sm')
+            ->join('sm.playlists', 'spm')
+            ->where('spm.playlist = :playlist')
+            ->setParameter('playlist', $playlist);
+
+        if ($playlist::ORDER_RANDOM === $playlist->getOrder()) {
+            $queuedMediaQuery = $queuedMediaQuery->orderBy('RAND()');
+        } else {
+            $queuedMediaQuery = $queuedMediaQuery->andWhere('spm.is_queued = 1')
+                ->orderBy('spm.weight', 'ASC');
+        }
+
+        $queuedMedia = $queuedMediaQuery->getQuery()->getArrayResult();
+
+        return array_map(
+            function ($val) {
+                $record = new Entity\Api\StationPlaylistQueue();
+                $record->spm_id = $val['spm_id'];
+                $record->media_id = $val['id'];
+                $record->song_id = $val['song_id'];
+                $record->artist = $val['artist'];
+                $record->title = $val['title'];
+            },
+            $queuedMedia
+        );
     }
 }

--- a/src/Entity/Repository/StationRequestRepository.php
+++ b/src/Entity/Repository/StationRequestRepository.php
@@ -208,15 +208,13 @@ class StationRequestRepository extends Repository
             ->setParameter('threshold', $lastPlayThreshold)
             ->getArrayResult();
 
+        $eligibleTrack = new Entity\Api\StationPlaylistQueue();
+        $eligibleTrack->media_id = $media->getId();
+        $eligibleTrack->song_id = $media->getSongId();
+        $eligibleTrack->title = $media->getTitle() ?? '';
+        $eligibleTrack->artist = $media->getArtist() ?? '';
 
-        $eligibleTracks = [
-            $media->getId() => [
-                'title' => $media->getTitle(),
-                'artist' => $media->getArtist(),
-            ],
-        ];
-
-        $isDuplicate = (null === AutoDJ\Queue::getDistinctTrack($eligibleTracks, $recentTracks));
+        $isDuplicate = (null === AutoDJ\Queue::getDistinctTrack([$eligibleTrack], $recentTracks));
 
         if ($isDuplicate) {
             throw new Exception(

--- a/src/Entity/StationMedia.php
+++ b/src/Entity/StationMedia.php
@@ -460,22 +460,6 @@ class StationMedia implements SongInterface, ProcessableMediaInterface, PathAwar
         $this->art_updated_at = $art_updated_at;
     }
 
-    public function getItemForPlaylist(StationPlaylist $playlist): ?StationPlaylistMedia
-    {
-        $item = $this->playlists->filter(
-            function ($spm) use ($playlist) {
-                /** @var StationPlaylistMedia $spm */
-                return $spm->getPlaylist()->getId() === $playlist->getId();
-            }
-        );
-
-        $firstItem = $item->first();
-
-        return ($firstItem instanceof StationPlaylistMedia)
-            ? $firstItem
-            : null;
-    }
-
     public function getCustomFields(): Collection
     {
         return $this->custom_fields;

--- a/src/Entity/StationPlaylist.php
+++ b/src/Entity/StationPlaylist.php
@@ -251,14 +251,6 @@ class StationPlaylist
     protected $played_at = 0;
 
     /**
-     * @ORM\Column(name="queue", type="array", nullable=true)
-     * @AuditLog\AuditIgnore
-     *
-     * @var array|null The current queue of unplayed songs for this playlist.
-     */
-    protected $queue;
-
-    /**
      * @ORM\OneToMany(targetEntity="StationPlaylistMedia", mappedBy="playlist", fetch="EXTRA_LAZY")
      * @ORM\OrderBy({"weight" = "ASC"})
      * @var Collection
@@ -487,48 +479,12 @@ class StationPlaylist
      */
     public function getQueue(): ?array
     {
-        if (null === $this->queue) {
-            return null;
-        }
-
-        // Ensure queue is always formatted correctly.
-        $newQueue = [];
-        foreach ($this->queue as $media) {
-            $newQueue[$media['id']] = $media;
-        }
-        return $newQueue;
+        // TODO: Remove
     }
 
     public function setQueue(?array $queue): void
     {
-        $this->queue = $queue;
-    }
-
-    public function removeFromQueue(StationMedia $media): void
-    {
-        $queue = $this->getQueue();
-
-        if (null !== $queue) {
-            unset($queue[$media->getId()]);
-            $this->queue = $queue;
-        }
-    }
-
-    public function addToQueue(StationMedia $media): void
-    {
-        $queue = $this->getQueue();
-        if (null === $queue) {
-            return;
-        }
-
-        $queue[$media->getId()] = [
-            'id' => $media->getId(),
-            'song_id' => $media->getSongId(),
-            'artist' => $media->getArtist(),
-            'title' => $media->getTitle(),
-        ];
-
-        $this->setQueue($queue);
+        // TODO: Remove
     }
 
     /**

--- a/src/Entity/StationPlaylist.php
+++ b/src/Entity/StationPlaylist.php
@@ -329,11 +329,6 @@ class StationPlaylist
 
     public function setSource(string $source): void
     {
-        // Reset the playback queue if source is changed.
-        if ($source !== $this->source) {
-            $this->queue = null;
-        }
-
         $this->source = $source;
     }
 
@@ -344,11 +339,6 @@ class StationPlaylist
 
     public function setOrder(string $order): void
     {
-        // Reset the playback queue if order is changed.
-        if ($order !== $this->order) {
-            $this->queue = null;
-        }
-
         $this->order = $order;
     }
 
@@ -472,19 +462,6 @@ class StationPlaylist
     public function setPlayedAt(int $played_at): void
     {
         $this->played_at = $played_at;
-    }
-
-    /**
-     * @return mixed[]|null
-     */
-    public function getQueue(): ?array
-    {
-        // TODO: Remove
-    }
-
-    public function setQueue(?array $queue): void
-    {
-        // TODO: Remove
     }
 
     /**

--- a/src/Entity/StationPlaylistMedia.php
+++ b/src/Entity/StationPlaylistMedia.php
@@ -58,6 +58,13 @@ class StationPlaylistMedia implements JsonSerializable
     protected $weight;
 
     /**
+     * @ORM\Column(name="is_queued", type="boolean")
+     *
+     * @var bool
+     */
+    protected $is_queued = true;
+
+    /**
      * @ORM\Column(name="last_played", type="integer")
      * @var int
      */
@@ -104,6 +111,7 @@ class StationPlaylistMedia implements JsonSerializable
     public function played(int $timestamp = null): void
     {
         $this->last_played = $timestamp ?? time();
+        $this->is_queued = false;
     }
 
     /**

--- a/src/Radio/AutoDJ/Queue.php
+++ b/src/Radio/AutoDJ/Queue.php
@@ -291,28 +291,74 @@ class Queue implements EventSubscriberInterface
         CarbonInterface $now,
         bool $allowDuplicates = false
     ): ?Entity\StationQueue {
-        $mediaToPlay = $this->getQueuedSong($playlist, $recentSongHistory, $allowDuplicates);
-
-        if ($mediaToPlay instanceof Entity\StationMedia) {
-            $playlist->setPlayedAt($now->getTimestamp());
-            $this->em->persist($playlist);
-
-            $spm = $mediaToPlay->getItemForPlaylist($playlist);
-            if ($spm instanceof Entity\StationPlaylistMedia) {
-                $spm->played($now->getTimestamp());
-                $this->em->persist($spm);
-            }
-
-            $stationQueueEntry = Entity\StationQueue::fromMedia($playlist->getStation(), $mediaToPlay);
-            $stationQueueEntry->setPlaylist($playlist);
-
-            $stationQueueEntry->setTimestampCued($now->getTimestamp());
-
-            $this->em->persist($stationQueueEntry);
-            $this->em->flush();
-
-            return $stationQueueEntry;
+        if (Entity\StationPlaylist::SOURCE_REMOTE_URL === $playlist->getSource()) {
+            return $this->getSongFromRemotePlaylist($playlist, $now);
         }
+
+        switch ($playlist->getOrder()) {
+            case Entity\StationPlaylist::ORDER_RANDOM:
+                $validTrack = $this->getRandomMediaIdFromPlaylist(
+                    $playlist,
+                    $recentSongHistory,
+                    $allowDuplicates
+                );
+                break;
+
+            case Entity\StationPlaylist::ORDER_SEQUENTIAL:
+                $validTrack = $this->getSequentialMediaIdFromPlaylist($playlist);
+                break;
+
+            case Entity\StationPlaylist::ORDER_SHUFFLE:
+            default:
+                $validTrack = $this->getShuffledMediaIdFromPlaylist(
+                    $playlist,
+                    $recentSongHistory,
+                    $allowDuplicates
+                );
+                break;
+        }
+
+        if (null === $validTrack) {
+            $this->logger->warning(
+                sprintf('Playlist "%s" did not return a playable track.', $playlist->getName()),
+                [
+                    'playlist_id' => $playlist->getId(),
+                    'playlist_order' => $playlist->getOrder(),
+                    'allow_duplicates' => $allowDuplicates,
+                ]
+            );
+            return null;
+        }
+
+        $mediaToPlay = $this->em->find(Entity\StationMedia::class, $validTrack->media_id);
+        if (!$mediaToPlay instanceof Entity\StationMedia) {
+            return null;
+        }
+
+        $spm = $this->em->find(Entity\StationPlaylistMedia::class, $validTrack->spm_id);
+        if ($spm instanceof Entity\StationPlaylistMedia) {
+            $spm->played($now->getTimestamp());
+            $this->em->persist($spm);
+        }
+
+        $playlist->setPlayedAt($now->getTimestamp());
+        $this->em->persist($playlist);
+
+        $stationQueueEntry = Entity\StationQueue::fromMedia($playlist->getStation(), $mediaToPlay);
+        $stationQueueEntry->setPlaylist($playlist);
+        $stationQueueEntry->setTimestampCued($now->getTimestamp());
+
+        $this->em->persist($stationQueueEntry);
+        $this->em->flush();
+
+        return $stationQueueEntry;
+    }
+
+    protected function getSongFromRemotePlaylist(
+        Entity\StationPlaylist $playlist,
+        CarbonInterface $now
+    ): ?Entity\StationQueue {
+        $mediaToPlay = $this->getMediaFromRemoteUrl($playlist);
 
         if (is_array($mediaToPlay)) {
             [$mediaUri, $mediaDuration] = $mediaToPlay;
@@ -337,64 +383,6 @@ class Queue implements EventSubscriberInterface
         }
 
         return null;
-    }
-
-    /**
-     * @param Entity\StationPlaylist $playlist
-     * @param array $recentSongHistory
-     * @param bool $allowDuplicates Whether to return a media ID even if duplicates can't be prevented.
-     *
-     * @return Entity\StationMedia|mixed[]|null
-     */
-    protected function getQueuedSong(
-        Entity\StationPlaylist $playlist,
-        array $recentSongHistory,
-        bool $allowDuplicates = false
-    ) {
-        if (Entity\StationPlaylist::SOURCE_REMOTE_URL === $playlist->getSource()) {
-            return $this->getMediaFromRemoteUrl($playlist);
-        }
-
-        $mediaId = null;
-
-        switch ($playlist->getOrder()) {
-            case Entity\StationPlaylist::ORDER_RANDOM:
-                $mediaId = $this->getRandomMediaIdFromPlaylist(
-                    $playlist,
-                    $recentSongHistory,
-                    $allowDuplicates
-                );
-                break;
-
-            case Entity\StationPlaylist::ORDER_SEQUENTIAL:
-                $mediaId = $this->getSequentialMediaIdFromPlaylist($playlist);
-                break;
-
-            case Entity\StationPlaylist::ORDER_SHUFFLE:
-            default:
-                $mediaId = $this->getShuffledMediaIdFromPlaylist(
-                    $playlist,
-                    $recentSongHistory,
-                    $allowDuplicates
-                );
-                break;
-        }
-
-        $this->em->flush();
-
-        if (!$mediaId) {
-            $this->logger->warning(
-                sprintf('Playlist "%s" did not return a playable track.', $playlist->getName()),
-                [
-                    'playlist_id' => $playlist->getId(),
-                    'playlist_order' => $playlist->getOrder(),
-                    'allow_duplicates' => $allowDuplicates,
-                ]
-            );
-            return null;
-        }
-
-        return $this->em->find(Entity\StationMedia::class, $mediaId);
     }
 
     /**
@@ -442,45 +430,35 @@ class Queue implements EventSubscriberInterface
         Entity\StationPlaylist $playlist,
         array $recentSongHistory,
         bool $allowDuplicates
-    ): ?int {
-        $mediaQueue = $this->spmRepo->getPlayableMedia($playlist);
+    ): ?Entity\Api\StationPlaylistQueue {
+        $mediaQueue = $this->spmRepo->getQueue($playlist);
 
         if ($playlist->getAvoidDuplicates()) {
             return $this->preventDuplicates($mediaQueue, $recentSongHistory, $allowDuplicates);
         }
 
-        $mediaId = array_key_first($mediaQueue);
-
-        return $mediaId;
+        return array_shift($mediaQueue);
     }
 
-    protected function getSequentialMediaIdFromPlaylist(Entity\StationPlaylist $playlist): ?int
-    {
-        $mediaQueue = $playlist->getQueue();
-
+    protected function getSequentialMediaIdFromPlaylist(
+        Entity\StationPlaylist $playlist
+    ): ?Entity\Api\StationPlaylistQueue {
+        $mediaQueue = $this->spmRepo->getQueue($playlist);
         if (empty($mediaQueue)) {
-            $mediaQueue = $this->spmRepo->getPlayableMedia($playlist);
+            $mediaQueue = $this->spmRepo->resetQueue($playlist);
         }
 
-        $nextMediaArray = array_shift($mediaQueue);
-        $mediaId = $nextMediaArray['id'];
-
-        $playlist->setQueue($mediaQueue);
-        $this->em->persist($playlist);
-
-        return $mediaId;
+        return array_shift($mediaQueue);
     }
 
     protected function getShuffledMediaIdFromPlaylist(
         Entity\StationPlaylist $playlist,
         array $recentSongHistory,
         bool $allowDuplicates
-    ): ?int {
-        $mediaId = null;
-        $mediaQueue = $playlist->getQueue();
-
+    ): ?Entity\Api\StationPlaylistQueue {
+        $mediaQueue = $this->spmRepo->getQueue($playlist);
         if (empty($mediaQueue)) {
-            $mediaQueue = $this->spmRepo->getPlayableMedia($playlist);
+            $mediaQueue = $this->spmRepo->resetQueue($playlist);
         }
 
         if ($playlist->getAvoidDuplicates()) {
@@ -489,27 +467,17 @@ class Queue implements EventSubscriberInterface
                     'Duplicate prevention yielded no playable song; resetting song queue.'
                 );
 
-                $mediaQueue = $this->spmRepo->getPlayableMedia($playlist);
+                $mediaQueue = $this->spmRepo->resetQueue($playlist);
             }
 
-            $mediaId = $this->preventDuplicates($mediaQueue, $recentSongHistory, $allowDuplicates);
-        } else {
-            $mediaId = array_key_first($mediaQueue);
+            return $this->preventDuplicates($mediaQueue, $recentSongHistory, $allowDuplicates);
         }
 
-        if (null !== $mediaId) {
-            unset($mediaQueue[$mediaId]);
-        }
-
-        // Save the modified cache, sans the now-missing entry.
-        $playlist->setQueue($mediaQueue);
-        $this->em->persist($playlist);
-
-        return $mediaId;
+        return array_shift($mediaQueue);
     }
 
     /**
-     * @param array $eligibleTracks
+     * @param Entity\Api\StationPlaylistQueue[] $eligibleTracks
      * @param array $playedTracks
      * @param bool $allowDuplicates Whether to return a media ID even if duplicates can't be prevented.
      */
@@ -517,7 +485,7 @@ class Queue implements EventSubscriberInterface
         array $eligibleTracks = [],
         array $playedTracks = [],
         bool $allowDuplicates = false
-    ): ?int {
+    ): ?Entity\Api\StationPlaylistQueue {
         if (empty($eligibleTracks)) {
             $this->logger->debug('Eligible song queue is empty!');
             return null;
@@ -533,10 +501,11 @@ class Queue implements EventSubscriberInterface
             }
         }
 
+        /** @var Entity\Api\StationPlaylistQueue[] $notPlayedEligibleTracks */
         $notPlayedEligibleTracks = [];
 
         foreach ($eligibleTracks as $mediaId => $track) {
-            $songId = $track['song_id'];
+            $songId = $track->song_id;
             if (isset($latestSongIdsPlayed[$songId])) {
                 continue;
             }
@@ -544,38 +513,49 @@ class Queue implements EventSubscriberInterface
             $notPlayedEligibleTracks[$mediaId] = $track;
         }
 
-        $mediaId = self::getDistinctTrack($notPlayedEligibleTracks, $playedTracks);
+        $validTrack = self::getDistinctTrack($notPlayedEligibleTracks, $playedTracks);
 
-        if (null !== $mediaId) {
+        if (null !== $validTrack) {
             $this->logger->info(
                 'Found track that avoids duplicate title and artist.',
-                ['media_id' => $mediaId]
+                [
+                    'media_id' => $validTrack->media_id,
+                    'title' => $validTrack->title,
+                    'artist' => $validTrack->artist,
+                ]
             );
 
-            return $mediaId;
+            return $validTrack;
         }
 
+        // If we reach this point, there's no way to avoid a duplicate title and artist.
         if ($allowDuplicates) {
-            // If we reach this point, there's no way to avoid a duplicate title.
+            /** @var Entity\Api\StationPlaylistQueue[] $mediaIdsByTimePlayed */
             $mediaIdsByTimePlayed = [];
 
             // For each piece of eligible media, get its latest played timestamp.
             foreach ($eligibleTracks as $track) {
-                $songId = $track['song_id'];
-                $mediaIdsByTimePlayed[$track['id']] = $latestSongIdsPlayed[$songId] ?? 0;
+                $songId = $track->song_id;
+                $trackKey = $latestSongIdsPlayed[$songId] ?? 0;
+                $mediaIdsByTimePlayed[$trackKey] = $track;
             }
 
-            // Pull the lowest value, which corresponds to the least recently played song.
-            asort($mediaIdsByTimePlayed);
+            ksort($mediaIdsByTimePlayed);
 
-            $mediaId = array_key_first($mediaIdsByTimePlayed);
-            if (null !== $mediaId) {
+            $validTrack = array_shift($mediaIdsByTimePlayed);
+
+            // Pull the lowest value, which corresponds to the least recently played song.
+            if (null !== $validTrack) {
                 $this->logger->warning(
                     'No way to avoid same title OR same artist; using least recently played song.',
-                    ['media_id' => $mediaId]
+                    [
+                        'media_id' => $validTrack->media_id,
+                        'title' => $validTrack->title,
+                        'artist' => $validTrack->artist,
+                    ]
                 );
 
-                return $mediaId;
+                return $validTrack;
             }
         }
 
@@ -615,13 +595,15 @@ class Queue implements EventSubscriberInterface
      * Both should be in the form of an array, i.e.:
      *  [ 'id' => ['artist' => 'Foo', 'title' => 'Fighters'] ]
      *
-     * @param array $eligibleTracks
+     * @param Entity\Api\StationPlaylistQueue[] $eligibleTracks
      * @param array $playedTracks
      *
-     * @return int|string|null
+     * @return Entity\Api\StationPlaylistQueue|null
      */
-    public static function getDistinctTrack(array $eligibleTracks, array $playedTracks)
-    {
+    public static function getDistinctTrack(
+        array $eligibleTracks,
+        array $playedTracks
+    ): ?Entity\Api\StationPlaylistQueue {
         $artistSeparators = [
             ', ',
             ' feat ',
@@ -657,18 +639,19 @@ class Queue implements EventSubscriberInterface
             }
         }
 
+        /** @var Entity\Api\StationPlaylistQueue[] $eligibleTracksWithoutSameTitle */
         $eligibleTracksWithoutSameTitle = [];
 
-        foreach ($eligibleTracks as $mediaId => $track) {
+        foreach ($eligibleTracks as $track) {
             // Avoid all direct title matches.
-            $title = trim($track['title']);
+            $title = trim($track->title);
 
             if (isset($titles[$title])) {
                 continue;
             }
 
             // Attempt to avoid an artist match, if possible.
-            $artist = trim($track['artist']);
+            $artist = trim($track->artist);
 
             $artistMatchFound = false;
             if (!empty($artist)) {
@@ -687,23 +670,16 @@ class Queue implements EventSubscriberInterface
             }
 
             if (!$artistMatchFound) {
-                return $mediaId;
+                return $track;
             }
 
-            $eligibleTracksWithoutSameTitle[$mediaId] = $track;
+            $songId = $track->song_id;
+            $trackKey = $latestSongIdsPlayed[$songId] ?? 0;
+            $eligibleTracksWithoutSameTitle[$trackKey] = $track;
         }
 
-        $mediaIdsByTimePlayed = [];
-
-        foreach ($eligibleTracksWithoutSameTitle as $mediaId => $track) {
-            $songId = $track['song_id'];
-
-            $mediaIdsByTimePlayed[$mediaId] = $latestSongIdsPlayed[$songId] ?? 0;
-        }
-
-        asort($mediaIdsByTimePlayed);
-
-        return array_key_first($mediaIdsByTimePlayed);
+        ksort($eligibleTracksWithoutSameTitle);
+        return array_shift($eligibleTracksWithoutSameTitle);
     }
 
     protected function logRecentSongHistory(


### PR DESCRIPTION
This PR moves the queue for playlists from a giant JSON dump in the `StationPlaylist` table to a separate `is_queued` flag in the existing `StationPlaylistMedia` table.

This actually solves a number of problems in our queue management; several other types of problem were solved by returning an API response for the queue, which allows us to pass around a SPM ID that we can use to precisely mark a specific queued item as played (instead of trying to guess it again later).