### PR TITLE
Add missing flac binary for writing metaflac and remove accidental format override of tagformats from GetId3

### DIFF
--- a/src/Media/MetadataService/GetId3MetadataService.php
+++ b/src/Media/MetadataService/GetId3MetadataService.php
@@ -151,7 +151,6 @@ class GetId3MetadataService
                 return false;
         }
 
-        $tagwriter->tagformats = ['id3v1', 'id3v2.3'];
         $tagwriter->overwrite_tags = true;
         $tagwriter->tag_encoding = 'UTF8';
         $tagwriter->remove_other_tags = true;

--- a/util/docker/web/setup/flac.sh
+++ b/util/docker/web/setup/flac.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+source /bd_build/buildconfig
+set -x
+
+$minimal_apt_get_install flac


### PR DESCRIPTION
Fix for the problem reported here https://github.com/AzuraCast/AzuraCast/issues/3798#issuecomment-822028738