### PR TITLE
Fix 5-minute sync for folder playlists where a directory does not exist anymore

### DIFF
--- a/src/Sync/Task/CheckFolderPlaylistsTask.php
+++ b/src/Sync/Task/CheckFolderPlaylistsTask.php
@@ -7,6 +7,7 @@ use App\Entity;
 use App\Flysystem\StationFilesystems;
 use Azura\Files\ExtendedFilesystemInterface;
 use Doctrine\ORM\Query;
+use League\Flysystem\UnableToRetrieveMetadata;
 use Psr\Log\LoggerInterface;
 
 class CheckFolderPlaylistsTask extends AbstractTask
@@ -103,7 +104,9 @@ class CheckFolderPlaylistsTask extends AbstractTask
             $path = $folder->getPath();
 
             // Verify the folder still exists.
-            if (!$fsMedia->isDir($path)) {
+            try {
+                $fsMedia->isDir($path);
+            } catch (UnableToRetrieveMetadata $exception) {
                 $this->em->remove($folder);
                 continue;
             }


### PR DESCRIPTION
Since Flysystem V2 has no way to check if a directory still exists we have to catch the exception thrown from the isDir method which will only report correctly for existing paths and otherwise throws an exception.

This PR fixes issues #4036 #4028 #3992