### PR TITLE
Truncate podcast and episode description to correct length - fixes issue #4218

### DIFF
--- a/src/Entity/Podcast.php
+++ b/src/Entity/Podcast.php
@@ -146,7 +146,7 @@ class Podcast
 
     public function setDescription(string $description): self
     {
-        $this->description = $this->truncateString($description);
+        $this->description = $this->truncateString($description, 4000);
 
         return $this;
     }

--- a/src/Entity/PodcastEpisode.php
+++ b/src/Entity/PodcastEpisode.php
@@ -158,7 +158,7 @@ class PodcastEpisode
 
     public function setDescription(string $description): self
     {
-        $this->description = $this->truncateString($description);
+        $this->description = $this->truncateString($description, 4000);
 
         return $this;
     }


### PR DESCRIPTION
**Fixes issue:**
#4218

**Proposed changes:**
Truncate the description for podcasts and podcast episodes to the 4000 character limit.
