### PR TITLE
Add OGG FLAC mountpoint support to AutoDJ

### DIFF
--- a/frontend/vue/Stations/Mounts/Form/AutoDj.vue
+++ b/frontend/vue/Stations/Mounts/Form/AutoDj.vue
@@ -24,7 +24,7 @@
                         :options="formatOptions"
                     ></b-form-radio-group>
                 </b-form-group>
-                <b-form-group class="col-md-6" label-for="edit_form_autodj_bitrate">
+                <b-form-group class="col-md-6" label-for="edit_form_autodj_bitrate" v-if="formatSupportsBitrateOptions">
                     <template #label>
                         <translate key="lang_edit_form_autodj_bitrate">AutoDJ Bitrate (kbps)</translate>
                     </template>
@@ -60,7 +60,8 @@ export default {
                         'mp3': 'MP3',
                         'ogg': 'OGG Vorbis',
                         'opus': 'OGG Opus',
-                        'aac': 'AAC+ (MPEG4 HE-AAC v2)'
+                        'aac': 'AAC+ (MPEG4 HE-AAC v2)',
+                        'flac': 'FLAC (OGG FLAC)',
                     };
 
                 case FRONTEND_SHOUTCAST:
@@ -68,7 +69,8 @@ export default {
                         'mp3': 'MP3',
                         'ogg': 'OGG Vorbis',
                         'opus': 'OGG Opus',
-                        'aac': 'AAC+ (MPEG4 HE-AAC v2)'
+                        'aac': 'AAC+ (MPEG4 HE-AAC v2)',
+                        'flac': 'FLAC (OGG FLAC)',
                     };
 
                 default:
@@ -86,6 +88,19 @@ export default {
                 256: '256',
                 320: '320'
             };
+        },
+        formatSupportsBitrateOptions () {
+            switch (this.form.autodj_format.$model) {
+                case 'flac':
+                    return false;
+
+                case 'mp3':
+                case 'ogg':
+                case 'opus':
+                case 'aac':
+                default:
+                    return true;
+            }
         }
     }
 };

--- a/src/Entity/Interfaces/StationMountInterface.php
+++ b/src/Entity/Interfaces/StationMountInterface.php
@@ -8,6 +8,7 @@ interface StationMountInterface
     public const FORMAT_OGG = 'ogg';
     public const FORMAT_AAC = 'aac';
     public const FORMAT_OPUS = 'opus';
+    public const FORMAT_FLAC = 'flac';
 
     public const PROTOCOL_ICY = 'icy';
     public const PROTOCOL_HTTP = 'http';

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -1074,6 +1074,9 @@ class ConfigWriter implements EventSubscriberInterface
             case Entity\Interfaces\StationMountInterface::FORMAT_OPUS:
                 return '%opus(samplerate=48000, bitrate=' . $bitrate . ', vbr="constrained", application="audio", channels=2, signal="music", complexity=10, max_bandwidth="full_band")';
 
+            case Entity\Interfaces\StationMountInterface::FORMAT_FLAC:
+                return '%ogg(%flac(samplerate=48000, channels=2, compression=4, bits_per_sample=24))';
+
             case Entity\Interfaces\StationMountInterface::FORMAT_MP3:
             default:
                 return '%mp3(samplerate=44100, stereo=true, bitrate=' . $bitrate . ', id3v2=true)';

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -1050,7 +1050,10 @@ class ConfigWriter implements EventSubscriberInterface
             $output_params[] = 'protocol="' . $protocol . '"';
         }
 
-        if (Entity\Interfaces\StationMountInterface::FORMAT_OPUS === $mount->getAutodjFormat()) {
+        if (
+            Entity\Interfaces\StationMountInterface::FORMAT_OPUS === $mount->getAutodjFormat()
+            || Entity\Interfaces\StationMountInterface::FORMAT_FLAC === $mount->getAutodjFormat()
+        ) {
             $output_params[] = 'icy_metadata="true"';
         }
 


### PR DESCRIPTION
**Proposed changes:**
This PR adds the ability to let the Liquidsoap AutoDJ stream to a mountpoint in the FLAC format within an OGG container as described in the LS documentation on how to send FLAC to IceCast.

I have hard coded the `samplerate` to `48000` and the `bits_per_sample` to `24` in order to output in max quality which is most likely what users would be interested in when using FLAC.

The `compression` is set to `4` in order to keep the compressed size as small as possible while keeping the encoding time as low as possible. The default in LS would be `5` but when looking at comparisons the compression ratio of `4` and `5` are nearly identical while `5` needs much more encoding time. See https://z-issue.com/wp/flac-compression-level-comparison/

Related feature request: https://features.azuracast.com/suggestions/142262/flac-streaming-option
