### PR TITLE
Add configurable max listerner duration to mountpoints

### DIFF
--- a/frontend/vue/Stations/Mounts/EditModal.vue
+++ b/frontend/vue/Stations/Mounts/EditModal.vue
@@ -61,6 +61,7 @@ export default {
         }
         if (FRONTEND_ICECAST === this.stationFrontendType) {
             validations.form.fallback_mount = {};
+            validations.form.max_listener_duration = { required };
             validations.form.frontend_config = {};
         }
 
@@ -88,6 +89,7 @@ export default {
                 custom_listen_url: null,
                 authhash: null,
                 fallback_mount: '/error.mp3',
+                max_listener_duration: 0,
                 frontend_config: null
             };
         },
@@ -105,6 +107,7 @@ export default {
                 'custom_listen_url': d.custom_listen_url,
                 'authhash': d.authhash,
                 'fallback_mount': d.fallback_mount,
+                'max_listener_duration': d.max_listener_duration,
                 'frontend_config': d.frontend_config
             };
         }

--- a/frontend/vue/Stations/Mounts/Form/BasicInfo.vue
+++ b/frontend/vue/Stations/Mounts/Form/BasicInfo.vue
@@ -69,6 +69,19 @@
                         <translate key="lang_edit_form_is_public">Publish to "Yellow Pages" Directories</translate>
                     </b-form-checkbox>
                 </b-form-group>
+                <b-form-group class="col-md-6" label-for="edit_form_max_listener_duration">
+                    <template #label>
+                        <translate key="lang_edit_form_max_listener_duration">Max Listener Duration</translate>
+                    </template>
+                    <template #description>
+                        <translate key="lang_edit_form_max_listener_duration_desc">Set the length of time (Seconds) a listener will stay connected to the stream. If set to 0 listeners can stay connected infinitely.</translate>
+                    </template>
+                    <b-form-input type="number" min="0" max="2147483647" id="edit_form_max_listener_duration" v-model="form.max_listener_duration.$model"
+                                  :state="form.max_listener_duration.$dirty ? !form.max_listener_duration.$error : null"></b-form-input>
+                    <b-form-invalid-feedback>
+                        <translate key="lang_error_required">This field is required.</translate>
+                    </b-form-invalid-feedback>
+                </b-form-group>
             </b-row>
 
             <b-row v-if="isShoutcast">

--- a/src/Entity/Migration/Version20210620131126.php
+++ b/src/Entity/Migration/Version20210620131126.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210620131126 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE station_mounts ADD max_listener_duration INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE station_mounts DROP max_listener_duration');
+    }
+}

--- a/src/Entity/StationMount.php
+++ b/src/Entity/StationMount.php
@@ -5,6 +5,7 @@
 namespace App\Entity;
 
 use App\Annotations\AuditLog;
+use App\Entity\Traits\TruncateInts;
 use App\Radio\Adapters;
 use App\Radio\Frontend\AbstractFrontend;
 use Doctrine\ORM\Mapping as ORM;
@@ -23,6 +24,7 @@ class StationMount implements Stringable, Interfaces\StationMountInterface, Inte
 {
     use Traits\HasAutoIncrementId;
     use Traits\TruncateStrings;
+    use Traits\TruncateInts;
 
     #[ORM\Column(nullable: false)]
     protected int $station_id;
@@ -63,6 +65,10 @@ class StationMount implements Stringable, Interfaces\StationMountInterface, Inte
     /** @OA\Property(example="") */
     #[ORM\Column(length: 255, nullable: true)]
     protected ?string $authhash = null;
+
+    /** @OA\Property(example=43200) */
+    #[ORM\Column(type: 'integer', nullable: false)]
+    protected int $max_listener_duration = 0;
 
     /** @OA\Property(example=true) */
     #[ORM\Column]
@@ -206,6 +212,21 @@ class StationMount implements Stringable, Interfaces\StationMountInterface, Inte
     public function setAuthhash(?string $authhash = null): void
     {
         $this->authhash = $this->truncateNullableString($authhash);
+    }
+
+    public function getMaxListenerDuration(): int
+    {
+        return $this->max_listener_duration;
+    }
+
+    public function setMaxListenerDuration(int $max_listener_duration): void
+    {
+        $this->max_listener_duration = $this->truncateIntToLimit(
+            signed_limit: 2147483647,
+            unsigned_limit: 4294967295,
+            unsigned: false,
+            int: $max_listener_duration
+        );
     }
 
     public function getEnableAutodj(): bool

--- a/src/Radio/Frontend/Icecast.php
+++ b/src/Radio/Frontend/Icecast.php
@@ -191,6 +191,10 @@ class Icecast extends AbstractFrontend
                 $mount['fallback-override'] = 1;
             }
 
+            if ($mount_row->getMaxListenerDuration()) {
+                $mount['max-listener-duration'] = $mount_row->getMaxListenerDuration();
+            }
+
             $mountFrontendConfig = trim($mount_row->getFrontendConfig() ?? '');
             if (!empty($mountFrontendConfig)) {
                 $mount_conf = $this->processCustomConfig($mountFrontendConfig);

--- a/src/Radio/Frontend/SHOUTcast.php
+++ b/src/Radio/Frontend/SHOUTcast.php
@@ -152,6 +152,10 @@ class SHOUTcast extends AbstractFrontend
             if ($mount_row->getAuthhash()) {
                 $config['streamauthhash_' . $i] = $mount_row->getAuthhash();
             }
+
+            if ($mount_row->getMaxListenerDuration()) {
+                $config['streammaxuser_' . $i] = $mount_row->getMaxListenerDuration();
+            }
         }
 
         $configFileOutput = '';


### PR DESCRIPTION
**Proposed changes:**
This PR adds a config value for mountpoints to control the amount of time a listener is allowed to stay connected to the frontend. When the configured time is exceeded by a listener the frontend automatically disconnects them.

Currently users have to add the following to their custom mountpoint config:
```xml
<max-listener-duration>36000</max-listener-duration>
```

This implements the following feature request:

https://features.azuracast.com/suggestions/81239/disconnect-listeners
