### PR TITLE
Fix ondemand embed widget width and padding

### DIFF
--- a/frontend/vue/Public/OnDemand.vue
+++ b/frontend/vue/Public/OnDemand.vue
@@ -49,6 +49,13 @@
 </template>
 
 <style lang="scss">
+.ondemand.embed {
+    .container {
+        max-width: 100%;
+        padding: 0 !important;
+    }
+}
+
 #station_on_demand_table {
     .datatable-main {
         overflow-y: auto;


### PR DESCRIPTION
**Proposed changes:**
This PR fixes an issue with the width and padding of the ondemand embed widget that I saw in the embed widget builder as well as the embed itself. I think I also saw this reported in Discord but I didn't see a GH issue for this problem.
