### PR TITLE
Add formatted connected time in listeners report

### DIFF
--- a/templates/stations/reports/listeners.js.phtml
+++ b/templates/stations/reports/listeners.js.phtml
@@ -128,6 +128,26 @@ $(function () {
                 var tlh_hours = tlh_seconds / 3600;
                 return Math.round((tlh_hours + 0.00001) * 100) / 100;
             }
+        },
+        methods: {
+            formatTime (time) {
+                let sec_num = parseInt(time, 10);
+
+                let hours = Math.floor(sec_num / 3600);
+                let minutes = Math.floor((sec_num - (hours * 3600)) / 60);
+                let seconds = sec_num - (hours * 3600) - (minutes * 60);
+
+                if (hours < 10) {
+                    hours = '0' + hours;
+                }
+                if (minutes < 10) {
+                    minutes = '0' + minutes;
+                }
+                if (seconds < 10) {
+                    seconds = '0' + seconds;
+                }
+                return (hours !== '00' ? hours + ':' : '') + minutes + ':' + seconds;
+            }
         }
     });
 

--- a/templates/stations/reports/listeners.phtml
+++ b/templates/stations/reports/listeners.phtml
@@ -59,6 +59,7 @@ $assets
                     <thead>
                     <tr>
                         <th><?=__('IP')?></th>
+                        <th><?=__('Time')?></th>
                         <th><?=__('Time (sec)')?></th>
                         <th><?=__('User Agent')?></th>
                         <th><?=__('Stream')?></th>
@@ -68,6 +69,7 @@ $assets
                     <tbody>
                     <tr v-for="listener in listeners">
                         <td>{{ listener.ip }}</td>
+                        <td>{{ formatTime(listener.connected_time) }}</td>
                         <td>{{ listener.connected_time }}</td>
                         <td>
                                 <span v-if="listener.is_mobile">


### PR DESCRIPTION
**Implements Feature Request:**
https://features.azuracast.com/suggestions/72921/report-statistics-show-time-in-minutes-and-hours-not-only-in-seconds

**Proposed changes:**
This PR adds a column for a formatted `listener.connected_time` in order to improve the UX when looking at the listeners report.
