### PR TITLE
Fix media file upload for very short files that are not using chunked upload

### DIFF
--- a/src/Service/Flow.php
+++ b/src/Service/Flow.php
@@ -60,7 +60,7 @@ class Flow
         // Handle a regular file upload that isn't using flow.
         if (1 === $targetChunks) {
             if ('GET' === $request->getMethod()) {
-                return $response->withStatus(200, 'OK');
+                return $response->withStatus(204, 'No Content');
             }
 
             return self::handleStandardUpload($request, $tempDir);


### PR DESCRIPTION
**Fixes issue:**
Closes #4357

**Proposed changes:**
Very short media files that are uploaded via the media web page are uploaded as single chunks. Due to the introduction of the `testChunks` setting [here](https://github.com/AzuraCast/AzuraCast/commit/63094172d17c2f69f88a35dacc2b366f1f004e9c#diff-88ccbc2b45121248758cb72be19c56fc46dcd68a518118a484cfb1a492e6ac96R34) and since the [Flow upload script](https://github.com/AzuraCast/AzuraCast/blob/main/src/Service/Flow.php#L61-L67) handles single chunk uploads as a regular non-chunked uploads the testChunk `GET` request send by flow.js has been returning a `200 Ok` thus preventing the upload.

This PR fixes this issue for single chunk flow files by returning a `204 No Content` instead of a `200 Ok` for `GET` requests which will be treated by flow.js as a signal to upload the single chunk.
