### PR TITLE
Restore missing annotateNextSong fixes from cpeter1207

### DIFF
--- a/src/Radio/AutoDJ.php
+++ b/src/Radio/AutoDJ.php
@@ -94,14 +94,18 @@ class AutoDJ
             return $this->annotateNextSong($station, $asAutoDj, $iteration + 1);
         }
 
-        $duration = $queueRow->getDuration();
-        $now = $this->getNowFromCurrentSong($station);
-        $now = $this->getAdjustedNow($station, $now, $duration);
+        // Build adjusted "now" based on the currently playing song before annotating up the next one
+        $adjustedNow = $this->getAdjustedNow(
+            $station,
+            $this->getNowFromCurrentSong($station),
+            $queueRow->getDuration()
+        );
 
         $event = new AnnotateNextSong($queueRow, $asAutoDj);
         $this->dispatcher->dispatch($event);
 
-        $this->buildQueue($station, true, $now);
+        // Refill station queue while taking into context that LS queues songs 40s before they are played
+        $this->buildQueue($station, true, $adjustedNow);
 
         return $event->buildAnnotations();
     }

--- a/src/Radio/AutoDJ.php
+++ b/src/Radio/AutoDJ.php
@@ -94,14 +94,22 @@ class AutoDJ
             return $this->annotateNextSong($station, $asAutoDj, $iteration + 1);
         }
 
+        $duration = $queueRow->getDuration();
+        $now = $this->getNowFromCurrentSong($station);
+        $now = $this->getAdjustedNow($station, $now, $duration);
+
         $event = new AnnotateNextSong($queueRow, $asAutoDj);
         $this->dispatcher->dispatch($event);
+
+        $this->buildQueue($station, true, $now);
+
         return $event->buildAnnotations();
     }
 
     public function buildQueue(
         Entity\Station $station,
-        bool $force = false
+        bool $force = false,
+        CarbonInterface $nowOverride = null
     ): void {
         $lock = $this->lockFactory->createAndAcquireLock(
             resource: 'autodj_queue_' . $station->getId(),
@@ -125,7 +133,7 @@ class AutoDJ
             );
 
             // Adjust "now" time from current queue.
-            $now = $this->getNowFromCurrentSong($station);
+            $now = $nowOverride ?? $this->getNowFromCurrentSong($station);
 
             $maxQueueLength = $station->getBackendConfig()->getAutoDjQueueLength();
             if ($maxQueueLength < 1) {


### PR DESCRIPTION
**Fixes issue:**
#4239

**Proposed changes:**
This PR intends to restore the fixes that @cpeter1207 has contributed in August / September 2020 and that seem to have got partly lost in the refactoring of the AutoDJ [here](https://github.com/AzuraCast/AzuraCast/commit/55444a7baa449fb58f9cb36a91be448f8392fe1e#diff-d3f1af29a1881ab8736d8a8aa1ea201131f18699cad02fcae16e203fc6112f6fL67-L81).
