### PR TITLE
Add AutoDJ setting for looping playlist only once when scheduled

### DIFF
--- a/frontend/vue/Stations/Playlists/EditModal.vue
+++ b/frontend/vue/Stations/Playlists/EditModal.vue
@@ -75,7 +75,8 @@ export default {
                     'end_time': { required },
                     'start_date': {},
                     'end_date': {},
-                    'days': {}
+                    'days': {},
+                    'loop_once': {}
                 }
             }
         }

--- a/frontend/vue/Stations/Playlists/Form/Schedule.vue
+++ b/frontend/vue/Stations/Playlists/Form/Schedule.vue
@@ -93,6 +93,15 @@
                             </b-form-invalid-feedback>
                         </b-form-group>
 
+                        <b-form-group class="col-md-4" :label-for="'edit_form_loop_once_'+index">
+                            <template v-slot:description>
+                                <translate key="lang_form_loop_once_desc">Only loop through playlist once.</translate>
+                            </template>
+                            <b-form-checkbox :id="'edit_form_loop_once_'+index" v-model="row.loop_once.$model">
+                                <translate key="lang_form_loop_once">Loop Once</translate>
+                            </b-form-checkbox>
+                        </b-form-group>
+
                         <b-form-group class="col-md-4" :label-for="'edit_form_days_'+index">
                             <template v-slot:label>
                                 <translate key="lang_form_days">Scheduled Play Days of Week</translate>
@@ -158,7 +167,8 @@ export default {
                 end_time: null,
                 start_date: null,
                 end_date: null,
-                days: []
+                days: [],
+                loop_once: false
             });
         },
         remove (index) {

--- a/src/Entity/Migration/Version20210703185549.php
+++ b/src/Entity/Migration/Version20210703185549.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210703185549 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE station_playlists ADD queue_reset_at INT NOT NULL');
+        $this->addSql('ALTER TABLE station_schedules ADD loop_once TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE station_playlists DROP queue_reset_at');
+        $this->addSql('ALTER TABLE station_schedules DROP loop_once');
+    }
+}

--- a/src/Entity/Repository/StationPlaylistMediaRepository.php
+++ b/src/Entity/Repository/StationPlaylistMediaRepository.php
@@ -6,7 +6,10 @@ use App\Doctrine\ReloadableEntityManagerInterface;
 use App\Doctrine\Repository;
 use App\Entity;
 use App\Environment;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\QueryBuilder;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -165,7 +168,7 @@ class StationPlaylistMediaRepository extends Repository
     /**
      * @return Entity\Api\StationPlaylistQueue[]
      */
-    public function resetQueue(Entity\StationPlaylist $playlist): array
+    public function resetQueue(Entity\StationPlaylist $playlist, CarbonInterface $now = null): array
     {
         if ($playlist::SOURCE_SONGS !== $playlist->getSource()) {
             throw new InvalidArgumentException('Playlist must contain songs.');
@@ -214,6 +217,12 @@ class StationPlaylistMediaRepository extends Repository
             );
         }
 
+        $now = $now ?? CarbonImmutable::now($playlist->getStation()->getTimezoneObject());
+
+        $playlist->setQueueResetAt($now->getTimestamp());
+        $this->em->persist($playlist);
+        $this->em->flush();
+
         return $this->getQueue($playlist);
     }
 
@@ -255,5 +264,63 @@ class StationPlaylistMediaRepository extends Repository
             },
             $queuedMedia
         );
+    }
+
+    public function isQueueCompletelyFilled(Entity\StationPlaylist $playlist): bool
+    {
+        if ($playlist::SOURCE_SONGS !== $playlist->getSource()) {
+            return true;
+        }
+
+        if ($playlist::ORDER_RANDOM === $playlist->getOrder()) {
+            return true;
+        }
+
+        $notQueuedMediaCount = $this->getCountPlaylistMediaBaseQuery($playlist)
+            ->andWhere('spm.is_queued = 0')
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        if ($notQueuedMediaCount === 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function isQueueEmpty(Entity\StationPlaylist $playlist): bool
+    {
+        if ($playlist::SOURCE_SONGS !== $playlist->getSource()) {
+            return false;
+        }
+
+        if ($playlist::ORDER_RANDOM === $playlist->getOrder()) {
+            return false;
+        }
+
+        $totalMediaCount = $this->getCountPlaylistMediaBaseQuery($playlist)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        $notQueuedMediaCount = $this->getCountPlaylistMediaBaseQuery($playlist)
+            ->andWhere('spm.is_queued = 0')
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        if ($notQueuedMediaCount === $totalMediaCount) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected function getCountPlaylistMediaBaseQuery(Entity\StationPlaylist $playlist): QueryBuilder
+    {
+        return $this->em->createQueryBuilder()
+            ->select('count(spm.id)')
+            ->from(Entity\StationMedia::class, 'sm')
+            ->join('sm.playlists', 'spm')
+            ->where('spm.playlist = :playlist')
+            ->setParameter('playlist', $playlist);
     }
 }

--- a/src/Entity/Repository/StationQueueRepository.php
+++ b/src/Entity/Repository/StationQueueRepository.php
@@ -129,6 +129,25 @@ class StationQueueRepository extends Repository
             ->getOneOrNullResult();
     }
 
+    public function hasCuedPlaylistMedia(Entity\StationPlaylist $playlist): bool
+    {
+        $station = $playlist->getStation();
+
+        $cuedPlaylistContentCountQuery = $this->getUpcomingBaseQuery($station)
+            ->select('count(sq.id)')
+            ->andWhere('sq.playlist = :playlist')
+            ->setParameter('playlist', $playlist)
+            ->getQuery();
+
+        $cuedPlaylistContentCount = $cuedPlaylistContentCountQuery->getSingleScalarResult();
+
+        if ($cuedPlaylistContentCount > 0) {
+            return true;
+        }
+
+        return false;
+    }
+
     protected function getRecentBaseQuery(Entity\Station $station): QueryBuilder
     {
         return $this->getBaseQuery($station)

--- a/src/Entity/Repository/StationScheduleRepository.php
+++ b/src/Entity/Repository/StationScheduleRepository.php
@@ -54,6 +54,7 @@ class StationScheduleRepository extends Repository
             $record->setStartDate($item['start_date']);
             $record->setEndDate($item['end_date']);
             $record->setDays($item['days']);
+            $record->setLoopOnce($item['loop_once']);
 
             $this->em->persist($record);
         }

--- a/src/Entity/StationPlaylist.php
+++ b/src/Entity/StationPlaylist.php
@@ -158,6 +158,10 @@ class StationPlaylist implements Stringable, Interfaces\StationCloneAwareInterfa
     #[Attributes\AuditIgnore]
     protected int $played_at = 0;
 
+    #[ORM\Column]
+    #[Attributes\AuditIgnore]
+    protected int $queue_reset_at = 0;
+
     #[ORM\OneToMany(mappedBy: 'playlist', targetEntity: StationPlaylistMedia::class, fetch: 'EXTRA_LAZY')]
     #[ORM\OrderBy(['weight' => 'ASC'])]
     protected Collection $media_items;
@@ -360,6 +364,16 @@ class StationPlaylist implements Stringable, Interfaces\StationCloneAwareInterfa
     public function setPlayedAt(int $played_at): void
     {
         $this->played_at = $played_at;
+    }
+
+    public function getQueueResetAt(): int
+    {
+        return $this->queue_reset_at;
+    }
+
+    public function setQueueResetAt(int $queue_reset_at): void
+    {
+        $this->queue_reset_at = $queue_reset_at;
     }
 
     /**

--- a/src/Entity/StationSchedule.php
+++ b/src/Entity/StationSchedule.php
@@ -52,6 +52,10 @@ class StationSchedule
     #[ORM\Column(length: 50, nullable: true)]
     protected ?string $days = null;
 
+    /** @OA\Property(example=false) */
+    #[ORM\Column]
+    protected bool $loop_once = false;
+
     public function __construct(StationPlaylist|StationStreamer $relation)
     {
         if ($relation instanceof StationPlaylist) {
@@ -151,6 +155,16 @@ class StationSchedule
     public function setDays($days): void
     {
         $this->days = implode(',', (array)$days);
+    }
+
+    public function getLoopOnce(): bool
+    {
+        return $this->loop_once;
+    }
+
+    public function setLoopOnce(bool $loop_once): void
+    {
+        $this->loop_once = $loop_once;
     }
 
     public function __toString(): string


### PR DESCRIPTION
**Fixes issue:**
See https://github.com/AzuraCast/AzuraCast/discussions/4186

**Proposed changes:**
This PR adds an option to each schedule entry of a playlist that makes it possible to control if the playlist should only loop through its contents once at the scheduled time. When the next scheduled time for a playlist is due it will also check if the playback queue of the playlist if completely full and if not reset it accordingly to make sure that the playlist is played from the beginning.