### PR TITLE
Fix time format in playlist page sidebar

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -538,7 +538,6 @@ return [
     'Vue_StationsPlaylists' => [
         'order' => 10,
         'require' => ['vue-component-common', 'bootstrap-vue', 'moment_base', 'moment_timezone'],
-        'replace' => ['moment'],
         // Auto-managed by Assets
     ],
 


### PR DESCRIPTION
**Fixes issue:**
Fixes #4394

**Proposed changes:**
The station time shown at the top of the sidebar is displayed in the 24h format on all station pages (when the locale is using the 24h format) except for the playlists page. There it is shown in 12h format with AM / PM.

This PR intends to fix this by removing the `replace` of `moment` in the assets config which has worked in my local testing after rebuilding the assets.

What is/was the intended purpose of the `replace` on the `Vue_StationsPlaylists`?
It might be that removing the `replace` has some unintended side effects that I'm unaware of.