### PR TITLE
Update Liquidsoap to match version from Docker installations

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -34,7 +34,7 @@ else
 fi
 
 APP_ENV="${APP_ENV:-production}"
-UPDATE_REVISION="${UPDATE_REVISION:-63}"
+UPDATE_REVISION="${UPDATE_REVISION:-64}"
 
 echo "Updating AzuraCast (Environment: $APP_ENV, Update revision: $UPDATE_REVISION)"
 

--- a/util/ansible/roles/azuracast-radio/tasks/main.yml
+++ b/util/ansible/roles/azuracast-radio/tasks/main.yml
@@ -55,6 +55,11 @@
     packages :
       - opam
       - ocaml
+      - libavcodec-dev
+      - libavfilter-dev
+      - libavformat-dev
+      - libavresample-dev
+      - libavutil-dev
       - libfaad-dev
       - libfdk-aac-dev
       - libflac-dev
@@ -63,10 +68,14 @@
       - libogg-dev
       - libopus-dev
       - libpcre3-dev
+      - libpostproc-dev
+      - libsamplerate0-dev
+      - libswresample-dev
       - libssl-dev
       - libtag1-dev
       - libvorbis-dev
-      - libsamplerate0-dev
+      - autoconf
+      - automake
       - m4
       - pkg-config
       - unzip
@@ -124,7 +133,7 @@
 
 - name : Build and Install Liquidsoap and Dependencies
   become_user : azuracast
-  shell : "opam install -y ladspa.0.1.5 samplerate.0.1.4 taglib.0.3.3 mad.0.4.5 faad.0.4.0 fdkaac.0.3.1 lame.0.3.3 vorbis.0.7.1 cry.0.6.1 flac.0.1.5 opus.0.1.3 duppy.0.8.0 ssl liquidsoap"
+  shell : "opam install -y ladspa.0.1.5 ffmpeg.0.4.3 samplerate.0.1.4 taglib.0.3.3 mad.0.4.5 faad.0.4.0 fdkaac.0.3.1 lame.0.3.3 vorbis.0.7.1 cry.0.6.1 flac.0.1.5 opus.0.1.3 duppy.0.8.0 ssl liquidsoap"
   args :
     chdir : "{{ app_base }}"
   register : install_result

--- a/util/ansible/roles/azuracast-radio/tasks/main.yml
+++ b/util/ansible/roles/azuracast-radio/tasks/main.yml
@@ -105,9 +105,26 @@
   when :
     - ansible_distribution_release == 'focal'
 
+- name : Download specific Liquidsoap commit
+  become_user : azuracast
+  git :
+    repo : https://github.com/savonet/liquidsoap.git
+    dest : "{{ app_base }}/liquidsoap-src"
+    version : 75d530c86bf638e3c50c08b7802d92270288e31b
+    clone : yes
+    update : yes
+    force : yes
+
+- name : Pin specific Liquidsoap commit
+  become_user : azuracast
+  shell : opam pin add --no-action liquidsoap .
+  args :
+    chdir : "{{ app_base }}/liquidsoap-src"
+    executable : "bash" # Fixes some possible hang issues.
+
 - name : Build and Install Liquidsoap and Dependencies
   become_user : azuracast
-  shell : "opam install -y ladspa.0.1.5 samplerate.0.1.4 taglib.0.3.3 mad.0.4.5 faad.0.4.0 fdkaac.0.3.1 lame.0.3.3 vorbis.0.7.1 cry.0.6.1 flac.0.1.5 opus.0.1.3 duppy.0.8.0 ssl liquidsoap.1.4.2"
+  shell : "opam install -y ladspa.0.1.5 samplerate.0.1.4 taglib.0.3.3 mad.0.4.5 faad.0.4.0 fdkaac.0.3.1 lame.0.3.3 vorbis.0.7.1 cry.0.6.1 flac.0.1.5 opus.0.1.3 duppy.0.8.0 ssl liquidsoap"
   args :
     chdir : "{{ app_base }}"
   register : install_result

--- a/util/ansible/update.yml
+++ b/util/ansible/update.yml
@@ -16,7 +16,7 @@
   roles :
     - init
     - azuracast-config
-    - { role : azuracast-radio, when : update_revision|int < 59 }
+    - { role : azuracast-radio, when : update_revision|int < 64 }
     - { role : supervisord, when : update_revision|int < 13 }
     - { role : mariadb, when : update_revision|int < 63 }
     - { role : nginx, when : update_revision|int < 60 }


### PR DESCRIPTION
**Fixes issue:**
Fixes #4338 

**Proposed changes:**
This PR adds the pinned commit version of Liquidsoap to Ansible installations as well as the added ffmpeg dependency analogous to what is being done in the radio docker container image.
