### PR TITLE
Implement changes for Liquidsoap 2.0.0

### DIFF
--- a/src/Entity/Repository/StationQueueRepository.php
+++ b/src/Entity/Repository/StationQueueRepository.php
@@ -133,6 +133,18 @@ class StationQueueRepository extends Repository
             ->getOneOrNullResult();
     }
 
+    /**
+     * @return Entity\StationQueue[]
+     */
+    public function getLastCuedSongs(Entity\Station $station, int $maxResults = 2): array
+    {
+        return $this->getRecentBaseQuery($station)
+            ->andWhere('sq.sent_to_autodj = 1')
+            ->getQuery()
+            ->setMaxResults($maxResults)
+            ->getResult();
+    }
+
     public function findRecentlyCuedSong(
         Entity\Station $station,
         Entity\Interfaces\SongInterface $song

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -955,7 +955,7 @@ class ConfigWriter implements EventSubscriberInterface
             thread.run.recurrent(fast=false, delay=0., f)
         end
 
-        source.on_metadata(radio, metadata_updated)
+        radio.on_metadata(metadata_updated)
         EOF
         );
     }

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -435,13 +435,13 @@ class ConfigWriter implements EventSubscriberInterface
                 log("AzuraCast Raw Response: #{uri}")
 
                 if uri == "" or string.match(pattern="Error", uri) then
-                    []
+                    null()
                 else
                     r = request.create(uri)
                     if request.resolve(r) then
-                        [r]
+                        r
                     else
-                        []
+                        null()
                    end
                 end
             end
@@ -466,7 +466,7 @@ class ConfigWriter implements EventSubscriberInterface
                 !delay
             end
 
-            dynamic = request.dynamic.list(id="next_song", timeout=20., retry_delay=2., autodj_next_song)
+            dynamic = request.dynamic(id="next_song", timeout=20., retry_delay=2., autodj_next_song)
             dynamic = cue_cut(id="cue_next_song", dynamic)
 
             dynamic_startup = fallback(

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -482,9 +482,9 @@ class ConfigWriter implements EventSubscriberInterface
                 track_sensitive = false,
                 [
                     dynamic,
-                    at(
-                        fun()-> !autodj_is_loading,
-                        blank(id = "autodj_startup_blank", duration = 120.)
+                    source.available(
+                        blank(id = "autodj_startup_blank", duration = 120.),
+                        predicate.activates({!autodj_is_loading})
                     )
                 ]
             )
@@ -949,7 +949,7 @@ class ConfigWriter implements EventSubscriberInterface
                     ret = {$feedbackCommand}
                     log("AzuraCast Feedback Response: #{ret}")
                 end
-                (-1.)
+                (-1.0)
             end
 
             thread.run.recurrent(fast=false, delay=0., f)

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -145,13 +145,13 @@ class ConfigWriter implements EventSubscriberInterface
         init.daemon.pidfile.path.set("${pidfile}")
         log.stdout.set(true)
         log.file.set(false)
-        setting.server.telnet.set(true)
-        setting.server.telnet.bind_addr.set("${telnetBindAddr}")
-        setting.server.telnet.port.set(${telnetPort})
-        setting.harbor.bind_addrs.set(["0.0.0.0"])
+        settings.server.telnet.set(true)
+        settings.server.telnet.bind_addr.set("${telnetBindAddr}")
+        settings.server.telnet.port.set(${telnetPort})
+        settings.harbor.bind_addrs.set(["0.0.0.0"])
 
-        setting.tag.encodings.set(["UTF-8","ISO-8859-1"])
-        setting.encoder.encoder.export.set(["artist","title","album","song"])
+        settings.tag.encodings.set(["UTF-8","ISO-8859-1"])
+        settings.encoder.encoder.export.set(["artist","title","album","song"])
 
         setenv("TZ", "${stationTz}")
 

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -151,7 +151,7 @@ class ConfigWriter implements EventSubscriberInterface
         settings.harbor.bind_addrs.set(["0.0.0.0"])
 
         settings.tag.encodings.set(["UTF-8","ISO-8859-1"])
-        settings.encoder.encoder.export.set(["artist","title","album","song"])
+        settings.encoder.metadata.export.set(["artist","title","album","song"])
 
         setenv("TZ", "${stationTz}")
 

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -949,7 +949,7 @@ class ConfigWriter implements EventSubscriberInterface
                     ret = {$feedbackCommand}
                     log("AzuraCast Feedback Response: #{ret}")
                 end
-                (-1.0)
+                (-1.)
             end
 
             thread.run.recurrent(fast=false, delay=0., f)

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -226,7 +226,6 @@ class ConfigWriter implements EventSubscriberInterface
 
             $usesRandom = true;
             $usesReloadMode = true;
-            $usesConservative = false;
 
             if ($playlist->backendLoopPlaylistOnce()) {
                 $playlistFuncName = 'playlist.once';
@@ -236,7 +235,6 @@ class ConfigWriter implements EventSubscriberInterface
             } else {
                 $playlistFuncName = 'playlist';
                 $usesRandom = false;
-                $usesConservative = true;
             }
 
             $playlistConfigLines = [];
@@ -268,12 +266,6 @@ class ConfigWriter implements EventSubscriberInterface
 
                 if ($usesReloadMode) {
                     $playlistParams[] = 'reload_mode="watch"';
-                }
-
-                if ($usesConservative) {
-                    $playlistParams[] = 'conservative=true';
-                    $playlistParams[] = 'default_duration=10.';
-                    $playlistParams[] = 'length=20.';
                 }
 
                 $playlistParams[] = '"' . $playlistFilePath . '"';

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -864,7 +864,7 @@ class ConfigWriter implements EventSubscriberInterface
 
             def start_recording(path) =
                 output_live_recording = output.file({$formatString}, fallible=true, reopen_on_metadata=false, "#{path}", live)
-                stop_recording_f := fun () -> source.shutdown(output_live_recording)
+                stop_recording_f := fun () -> output_live_recording.shutdown()
             end
 
             def stop_recording() =

--- a/util/ansible/roles/azuracast-radio/tasks/main.yml
+++ b/util/ansible/roles/azuracast-radio/tasks/main.yml
@@ -53,6 +53,7 @@
     install_recommends : no
   vars :
     packages :
+      - ffmpeg
       - opam
       - ocaml
       - libavcodec-dev
@@ -72,6 +73,7 @@
       - libpostproc-dev
       - libsamplerate0-dev
       - libswresample-dev
+      - libswscale-dev
       - libssl-dev
       - libtag1-dev
       - libvorbis-dev
@@ -81,6 +83,7 @@
       - pkg-config
       - unzip
       - bubblewrap
+      - frei0r-plugins-dev
       - ladspa-sdk
       - multimedia-audio-plugins
       - swh-plugins
@@ -99,7 +102,7 @@
 
 - name : Initialize OPAM (Bionic)
   become_user : azuracast
-  shell : "opam init -a --disable-sandboxing --bare && opam switch create 4.08.0"
+  shell : "opam init -a --disable-sandboxing --bare && opam switch create 4.12.0"
   args :
     chdir : "{{ app_base }}"
     executable : "bash" # Fixes some possible hang issues.
@@ -108,7 +111,7 @@
 
 - name : Initialize OPAM (Focal)
   become_user : azuracast
-  shell : "opam init --disable-sandboxing -a --bare && opam switch create ocaml-system.4.08.1"
+  shell : "opam init --disable-sandboxing -a --bare && opam switch create 4.12.0"
   args :
     chdir : "{{ app_base }}"
     executable : "bash" # Fixes some possible hang issues.
@@ -120,7 +123,7 @@
   git :
     repo : https://github.com/savonet/liquidsoap.git
     dest : "{{ app_base }}/liquidsoap-src"
-    version : 75d530c86bf638e3c50c08b7802d92270288e31b
+    version : bd9a2e3531ec03bae4f2812b6d83bdacf2277f0c
     clone : yes
     update : yes
     force : yes
@@ -134,7 +137,7 @@
 
 - name : Build and Install Liquidsoap and Dependencies
   become_user : azuracast
-  shell : "opam install -y ladspa.0.1.5 ffmpeg.0.4.3 samplerate.0.1.4 taglib.0.3.3 mad.0.4.5 faad.0.4.0 fdkaac.0.3.1 lame.0.3.3 vorbis.0.7.1 cry.0.6.1 flac.0.1.5 opus.0.1.3 duppy.0.8.0 ssl liquidsoap"
+  shell : "opam install -y ladspa.0.2.0 ffmpeg.1.0.1 ffmpeg-avutil.1.0.1 ffmpeg-avcodec.1.0.1 ffmpeg-avdevice.1.0.1 ffmpeg-av.1.0.1 ffmpeg-avfilter.1.0.1 ffmpeg-swresample.1.0.1 ffmpeg-swscale.1.0.1 frei0r.0.1.2 samplerate.0.1.6 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 dtools.0.4.4 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"
   args :
     chdir : "{{ app_base }}"
   register : install_result
@@ -152,7 +155,7 @@
 
 - name : Link Liquidsoap binary (Xenial/Bionic)
   file :
-    src : "{{ app_base }}/.opam/4.08.0/bin/liquidsoap"
+    src : "{{ app_base }}/.opam/4.12.0/bin/liquidsoap"
     dest : /usr/local/bin/liquidsoap
     state : link
     force : yes
@@ -161,7 +164,7 @@
 
 - name : Link Liquidsoap binary (Focal)
   file :
-    src : "{{ app_base }}/.opam/ocaml-system.4.08.1/bin/liquidsoap"
+    src : "{{ app_base }}/.opam/4.12.0/bin/liquidsoap"
     dest : /usr/local/bin/liquidsoap
     state : link
     force : yes

--- a/util/ansible/roles/azuracast-radio/tasks/main.yml
+++ b/util/ansible/roles/azuracast-radio/tasks/main.yml
@@ -123,7 +123,7 @@
   git :
     repo : https://github.com/savonet/liquidsoap.git
     dest : "{{ app_base }}/liquidsoap-src"
-    version : bd9a2e3531ec03bae4f2812b6d83bdacf2277f0c
+    version : 43aa734dd37595e991ad7d8d9b8560e7d47c19fe
     clone : yes
     update : yes
     force : yes


### PR DESCRIPTION
**Fixes issue:**
- [x] https://github.com/AzuraCast/AzuraCast/issues/3821
- [x] https://github.com/AzuraCast/AzuraCast/issues/2751
- [ ] https://github.com/AzuraCast/AzuraCast/issues/4440
  - Needs to be looked into
- [ ] https://github.com/AzuraCast/AzuraCast/issues/4434
  - Needs to be looked into

**ToDo:**
- [ ] When skipping, Liquidsoap is fetching a new track from the AzuraCast AutoDJ and instead of playing the already previously prefetched track it is playing this newly fetched one and when it finished this track it is playing the prefetched one
  - This is very unintuitive and in my opinion unexpected behaviour, currently waiting on input from the LS team about this
  - Related LS issue https://github.com/savonet/liquidsoap/issues/1993#issuecomment-960417855
  

**Proposed changes:**
This PR implements the changes to the Liquidsoap config generation necessary to make AzuraCast compatible with the current Liquidsoap 2.0.0 beta on the latest commit as of today.

This PR is directly related to https://github.com/AzuraCast/docker-azuracast-radio/pull/12

I have created this as a draft PR in order to gather feedback and prepare for the transition when Liquidsoap 2.0.0 is released.


