### PR TITLE
Fix type error when setting schedule entries

### DIFF
--- a/src/Entity/Repository/StationScheduleRepository.php
+++ b/src/Entity/Repository/StationScheduleRepository.php
@@ -58,7 +58,7 @@ class StationScheduleRepository extends Repository
             $record->setEndTime($item['end_time']);
             $record->setStartDate($item['start_date']);
             $record->setEndDate($item['end_date']);
-            $record->setDays($item['days']);
+            $record->setDays($item['days'] ?? []);
             $record->setLoopOnce($item['loop_once']);
 
             $this->em->persist($record);


### PR DESCRIPTION
**Proposed changes:**
Fixes the following type error when creating or updating schedule entries / playlists with schedule entries:

```
TypeError at /var/azuracast/www/src/Entity/StationSchedule.php L168: App\Entity\StationSchedule::setDays(): Argument #1 ($days) must be of type array, null given, called in /var/azuracast/www/src/Entity/Repository/StationScheduleRepository.php on line 61
```
