### PR TITLE
Fix Icecast relay mount config generation issue

### DIFF
--- a/src/Radio/Frontend/Icecast.php
+++ b/src/Radio/Frontend/Icecast.php
@@ -206,7 +206,7 @@ class Icecast extends AbstractFrontend
             }
 
             $mountRelayUrl = $mount_row->getRelayUrl();
-            if (null !== $mountRelayUrl) {
+            if (!empty($mountRelayUrl)) {
                 $mountRelayUri = new Uri($mountRelayUrl);
 
                 $config['relay'][] = [


### PR DESCRIPTION
**Fixes issue:**
Fixes #4413

**Proposed changes:**
This PR fixes an issue that is caused due to a small change in the comparison logic when building the Icecast configuration.

When the `relay_url` of a `StationMount` is an empty string instead of `null` the following block was generated:
```xml
<relay>
    <server></server>
    <port></port>
    <mount></mount>
    <local-mount>/radio.mp3</local-mount>
</relay>
```

