### PR TITLE
Fix type error in OnDemand API endpoint

### DIFF
--- a/src/Controller/Api/Stations/OnDemand/ListAction.php
+++ b/src/Controller/Api/Stations/OnDemand/ListAction.php
@@ -53,7 +53,7 @@ class ListAction
 
         $params = $request->getQueryParams();
 
-        $searchPhrase = trim($params['searchPhrase']);
+        $searchPhrase = trim($params['searchPhrase'] ?? '');
         if (!empty($searchPhrase)) {
             $searchFields = [
                 'media_title',


### PR DESCRIPTION
**Fixes issue:**
Fixes #4422

**Proposed changes:**
This PR fixes a type error in the OnDemand API endpoint when the `searchPhrase` is `null`.
