### PR TITLE
Cast tags from media to string for cleanUpString()

### DIFF
--- a/src/MediaProcessor/Command/ReadCommand.php
+++ b/src/MediaProcessor/Command/ReadCommand.php
@@ -79,7 +79,7 @@ class ReadCommand
                         $tagValue = implode(', ', $flatValue);
                     }
 
-                    $metaTags[$tagName] = $this->cleanUpString($tagValue);
+                    $metaTags[$tagName] = $this->cleanUpString((string)$tagValue);
                 }
             }
         }


### PR DESCRIPTION
**Fixes issue:**
Closes #4439

**Proposed changes:**
Ensure that tags are of type string when running `cleanUpString` when processing metadata.
