### PR TITLE
Fix type error in arrayToCsv utility method

### DIFF
--- a/src/Utilities/Csv.php
+++ b/src/Utilities/Csv.php
@@ -26,7 +26,7 @@ class Csv
                     $header_row[] = '"' . str_replace('"', '""', $table_col) . '"';
                 }
 
-                $body_row[] = '"' . str_replace('"', '""', $table_val) . '"';
+                $body_row[] = '"' . str_replace('"', '""', (string) $table_val) . '"';
             }
 
             if ($header_row) {


### PR DESCRIPTION
**Fixes issue:**
Closes #4461

**Proposed changes:**
This PR fixes a type error when exporting the song playback timeline as CSV.
The CSV helper utility wrongly assumes all `$table_val` to be of type string so this PR adds an explicit string cast to the problematic line.
