### PR TITLE
Fix frontend dev container permissions on macOS

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,9 @@
 FROM library/node:lts-alpine
 
 RUN apk update \
-    && apk add bash python make curl g++
+    && apk add bash python make curl g++ shadow
+
+RUN groupdel dialout
 
 RUN mkdir -p /data/frontend/node_modules /data/resources/locale /data/web/static \
     && chown -R node:node /data
@@ -12,10 +14,7 @@ RUN USER=node && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid && \
     mkdir -p /etc/fixuid && \
-    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
-
-COPY build_entrypoint.sh /
-RUN chmod a+x /build_entrypoint.sh
+    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /\n  - /data/frontend/node_modules\n" > /etc/fixuid/config.yml
 
 # Define working directory.
 WORKDIR /data/frontend


### PR DESCRIPTION
**Fixes issue:**
-

**Proposed changes:**
This PR fixes some issues with the frontend container:

- Removes non-existent build_entrypoint.sh steps
- Removes `dialout` group (GID `20` in the container) since on macOS the `staff` group of a user is GID `20` which leads to fixuid not working for the groups part
- Explicitly adds the `/data/frontend/node_modules` path to the `fixuid` paths to allow changing permissions for volumes
