### PR TITLE
Implement geo-blocking for Icecast

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -102,12 +102,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/AzuraCast/azuraforms.git",
-                "reference": "8a32a97e4d633eed0dca09ea1107d88256281aed"
+                "reference": "c6a8b279b189c3ebe70a18ed7650ec195cbe702a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AzuraCast/azuraforms/zipball/8a32a97e4d633eed0dca09ea1107d88256281aed",
-                "reference": "8a32a97e4d633eed0dca09ea1107d88256281aed",
+                "url": "https://api.github.com/repos/AzuraCast/azuraforms/zipball/c6a8b279b189c3ebe70a18ed7650ec195cbe702a",
+                "reference": "c6a8b279b189c3ebe70a18ed7650ec195cbe702a",
                 "shasum": ""
             },
             "require": {
@@ -167,7 +167,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-07-18T17:02:47+00:00"
+            "time": "2021-08-20T15:53:02+00:00"
         },
         {
             "name": "azuracast/flysystem-v2-extensions",

--- a/config/forms/station.php
+++ b/config/forms/station.php
@@ -8,6 +8,7 @@ use App\Radio\Adapters;
 
 /**
  * @var Adapters $adapters
+ * @var array<string,string> $countries
  */
 
 $frontends = $adapters->listFrontendAdapters(true);
@@ -298,6 +299,29 @@ return [
                     ],
                 ],
 
+                StationFrontendConfiguration::BANNED_COUNTRIES => [
+                    'multipleselect',
+                    [
+                        'label' => __('Banned Countries'),
+                        'label_class' => 'advanced',
+                        'belongsTo' => 'frontend_config',
+                        'description' => __('Select the countries that are not allowed to connect to the streams.'),
+                        'form_group_class' => 'col-sm-7',
+                        'options' => $countries,
+                    ],
+                ],
+
+                StationFrontendConfiguration::ALLOWED_IPS => [
+                    'textarea',
+                    [
+                        'label' => __('Allowed IP Addresses'),
+                        'label_class' => 'advanced',
+                        'belongsTo' => 'frontend_config',
+                        'class' => 'text-preformatted',
+                        'description' => __('List one IP address or group (in CIDR format) per line to explicitly allow them to connect even when their country is banned.'),
+                        'form_group_class' => 'col-sm-5',
+                    ],
+                ],
             ],
         ],
 

--- a/config/forms/station.php
+++ b/config/forms/station.php
@@ -300,7 +300,7 @@ return [
                 ],
 
                 StationFrontendConfiguration::BANNED_COUNTRIES => [
-                    'multipleselect',
+                    'multiselect',
                     [
                         'label' => __('Banned Countries'),
                         'label_class' => 'advanced',

--- a/config/routes/api.php
+++ b/config/routes/api.php
@@ -102,6 +102,13 @@ return function (App $app) {
                                 '/feedback',
                                 Controller\Api\InternalController::class . ':feedbackAction'
                             )->setName('api:internal:feedback');
+
+                            // Icecast internal auth functions
+                            $group->map(
+                                ['GET', 'POST'],
+                                '/listener-auth',
+                                Controller\Api\InternalController::class . ':listenerAuthAction'
+                            )->setName('api:internal:listener-auth');
                         }
                     )->add(Middleware\GetStation::class);
 

--- a/src/Entity/StationFrontendConfiguration.php
+++ b/src/Entity/StationFrontendConfiguration.php
@@ -125,4 +125,28 @@ class StationFrontendConfiguration extends ArrayCollection
     {
         $this->set(self::BANNED_IPS, $ips);
     }
+
+    public const BANNED_COUNTRIES = 'banned_countries';
+
+    public function getBannedCountries(): ?array
+    {
+        return $this->get(self::BANNED_COUNTRIES);
+    }
+
+    public function setBannedCountries(?array $countries): void
+    {
+        $this->set(self::BANNED_COUNTRIES, $countries);
+    }
+
+    public const ALLOWED_IPS = 'allowed_ips';
+
+    public function getAllowedIps(): ?string
+    {
+        return $this->get(self::ALLOWED_IPS);
+    }
+
+    public function setAllowedIps(?string $ips): void
+    {
+        $this->set(self::ALLOWED_IPS, $ips);
+    }
 }

--- a/src/Form/StationForm.php
+++ b/src/Form/StationForm.php
@@ -11,6 +11,7 @@ use App\Environment;
 use App\Http\ServerRequest;
 use App\Radio\Adapters;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Intl\Countries;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -37,6 +38,7 @@ class StationForm extends EntityForm
             'forms/station',
             [
                 'adapters' => $adapters,
+                'countries' => Countries::getNames(),
             ]
         );
         parent::__construct($em, $serializer, $validator, $form_config);

--- a/src/Radio/Frontend/Icecast.php
+++ b/src/Radio/Frontend/Icecast.php
@@ -223,6 +223,29 @@ class Icecast extends AbstractFrontend
                 ];
             }
 
+            $bannedCountries = $station->getFrontendConfig()->getBannedCountries() ?? [];
+            if (!empty($bannedCountries)) {
+                $mountAuthenticationUrl = $this->environment->isDocker()
+                    ? 'http://web/api/internal/' . $station->getIdRequired() . '/listener-auth'
+                    : 'http://localhost/api/internal/' . $station->getId() . '/listener-auth';
+
+                $mountAuthenticationUrl .= '?api_auth=' . $station->getAdapterApiKey();
+
+                $mount['authentication'][] = [
+                    '@type' => 'url',
+                    'option' => [
+                        [
+                            '@name' => 'listener_add',
+                            '@value' => $mountAuthenticationUrl,
+                        ],
+                        [
+                            '@name' => 'auth_header',
+                            '@value' => 'icecast-auth-user: 1',
+                        ],
+                    ],
+                ];
+            }
+
             $config['mount'][] = $mount;
         }
 


### PR DESCRIPTION
**Implements Feature Request:**
https://features.azuracast.com/suggestions/64077/geo-ip-blocking

**Proposed changes:**
This PR implements a country level geo-blocking feature for Icecast based stations by using Icecasts support for URL based authentication and the `listener_add` event.

Icecast documentation about URL authentication:
https://icecast.org/docs/icecast-latest/auth.html#url

As far as I was able to find out SHOUTcast does not have something like Icecasts URL based authentication so for now this feature is only for Icecast based stations.

There is also an additional `Allowed IP Addresses` field to explicitly allow certain IPs / IP-blocks to connect even when the country of that IP is blocked since this could be useful when there are issues due to the IP geolocation resolution or when you have a server that you want to connect but that is located in a banned country.

**ToDo:**
- [ ] Saving the station profile after clearing the banned country list doesn't save this field correctly