### PR TITLE
Fix Issue 4761 - Fix LS input.http buffer parameter for LS 2.0

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -280,7 +280,7 @@ class ConfigWriter implements EventSubscriberInterface
                             $buffer = $playlist->getRemoteBuffer();
                             $buffer = ($buffer < 1) ? Entity\StationPlaylist::DEFAULT_REMOTE_BUFFER : $buffer;
 
-                            $playlistConfigLines[] = $playlistVarName . ' = mksafe(input.http(max=' . $buffer . '., "' . self::cleanUpString($remote_url) . '"))';
+                            $playlistConfigLines[] = $playlistVarName . ' = mksafe(input.http(max_buffer=' . $buffer . '., "' . self::cleanUpString($remote_url) . '"))';
                         }
                         break;
                 }


### PR DESCRIPTION
**Fixes issue:**
Closes #4761

**Proposed changes:**
Updates the `input.http` parameter `max` to use `max_buffer`.