### PR TITLE
Fix issue #4780 - Increase update revision for Ansible

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -34,7 +34,7 @@ else
 fi
 
 APP_ENV="${APP_ENV:-production}"
-UPDATE_REVISION="${UPDATE_REVISION:-65}"
+UPDATE_REVISION="${UPDATE_REVISION:-66}"
 
 echo "Updating AzuraCast (Environment: $APP_ENV, Update revision: $UPDATE_REVISION)"
 

--- a/util/ansible/update.yml
+++ b/util/ansible/update.yml
@@ -16,7 +16,7 @@
   roles :
     - init
     - azuracast-config
-    - { role : azuracast-radio, when : update_revision|int < 64 }
+    - { role : azuracast-radio, when : update_revision|int < 66 }
     - { role : supervisord, when : update_revision|int < 13 }
     - { role : mariadb, when : update_revision|int < 63 }
     - { role : nginx, when : update_revision|int < 60 }


### PR DESCRIPTION
**Fixes issue:**
Closes #4780

**Proposed changes:**
The update for Liquidsoap 2.0 for Ansible installations was missing an increase of the update revision number thus not triggering the update for Liquidsoap correctly.
