### PR TITLE
Fix Issue #4770 - Only use cue_cut in LS config for song playlists

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -264,6 +264,9 @@ class ConfigWriter implements EventSubscriberInterface
 
                 $playlistConfigLines[] = $playlistVarName . ' = ' . $playlistFuncName . '('
                     . implode(',', $playlistParams) . ')';
+
+                $playlistConfigLines[] = $playlistVarName . ' = cue_cut(id="cue_'
+                    . self::cleanUpString($playlistVarName) . '", ' . $playlistVarName . ')';
             } else {
                 switch ($playlist->getRemoteType()) {
                     case Entity\StationPlaylist::REMOTE_TYPE_PLAYLIST:
@@ -285,9 +288,6 @@ class ConfigWriter implements EventSubscriberInterface
                         break;
                 }
             }
-
-            $playlistConfigLines[] = $playlistVarName . ' = cue_cut(id="cue_'
-                . self::cleanUpString($playlistVarName) . '", ' . $playlistVarName . ')';
 
             if ($playlist->getIsJingle()) {
                 $playlistConfigLines[] = $playlistVarName . ' = drop_metadata(' . $playlistVarName . ')';


### PR DESCRIPTION
**Fixes issue:**
#4770 

**Proposed changes:**
Only generate cue_cut in LS script for song source playlists since remote playlists might not be cuttable.
