### PR TITLE
Add buffer to input.http remote streams

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -283,7 +283,7 @@ class ConfigWriter implements EventSubscriberInterface
                             $buffer = $playlist->getRemoteBuffer();
                             $buffer = ($buffer < 1) ? Entity\StationPlaylist::DEFAULT_REMOTE_BUFFER : $buffer;
 
-                            $playlistConfigLines[] = $playlistVarName . ' = mksafe(input.http(max_buffer=' . $buffer . '., "' . self::cleanUpString($remote_url) . '"))';
+                            $playlistConfigLines[] = $playlistVarName . ' = mksafe(buffer(buffer='. $buffer . '., input.http(max_buffer=' . $buffer . '., "' . self::cleanUpString($remote_url) . '")))';
                         }
                         break;
                 }

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -283,7 +283,7 @@ class ConfigWriter implements EventSubscriberInterface
                             $buffer = $playlist->getRemoteBuffer();
                             $buffer = ($buffer < 1) ? Entity\StationPlaylist::DEFAULT_REMOTE_BUFFER : $buffer;
 
-                            $playlistConfigLines[] = $playlistVarName . ' = mksafe(buffer(buffer='. $buffer . '., input.http(max_buffer=' . $buffer . '., "' . self::cleanUpString($remote_url) . '")))';
+                            $playlistConfigLines[] = $playlistVarName . ' = mksafe(buffer(buffer=' . $buffer . '., input.http(max_buffer=' . $buffer . '., "' . self::cleanUpString($remote_url) . '")))';
                         }
                         break;
                 }


### PR DESCRIPTION
**Fixes issue:**
#4770

**Proposed changes:**
This PR adds a `buffer()` to the `input.http` that is generated for Remote Stream playlists to bridge between the 2 clocks of the `radio` and the input source.
