### PR TITLE
Add itunes:author field to podcasts RSS feed

### DIFF
--- a/src/Controller/Frontend/PublicPages/PodcastFeedController.php
+++ b/src/Controller/Frontend/PublicPages/PodcastFeedController.php
@@ -158,6 +158,7 @@ class PodcastFeedController
         $itunesChannel->setImage($rssImage->getUrl());
         $itunesChannel->setCategories($this->buildItunesCategoriesForPodcast($podcast));
         $itunesChannel->setOwner($this->buildItunesOwner($podcast));
+        $itunesChannel->setAuthor($podcast->getAuthor());
 
         $channel->addExtension($itunesChannel);
         $channel->addExtension(new Sy());


### PR DESCRIPTION
**Related issue:**
https://github.com/AzuraCast/AzuraCast/issues/4447#issuecomment-986308239

**Proposed changes:**
This PR adds the `itunes:author` field to the podcast RSS feed.

A user mentioned on the above issue that for Spotify Podcasts the previous fix has not resolved the problem.
The error message from Spotify is a bit misleading though, it showed that the author and email address were missing but it's actually only the `itunes:author` field that's missing. When I added this field the [Spotify Validator](https://podcasters.spotify.com/submit) said all looking good.
