### PR TITLE
fix: imported playlist's filenames are now sanitized

### DIFF
--- a/src/Controller/Api/Stations/Playlists/ImportAction.php
+++ b/src/Controller/Api/Stations/Playlists/ImportAction.php
@@ -70,14 +70,31 @@ class ImportAction extends AbstractPlaylistsAction
                 // De-Windows paths (if applicable)
                 $path_raw = str_replace('\\', '/', $path_raw);
 
-                // Work backwards from the basename to try to find matches.
+                // split path into parts
                 $path_parts = explode('/', $path_raw);
-                for ($i = 1, $iMax = count($path_parts); $i <= $iMax; $i++) {
+                $path_parts_length = count($path_parts);
+                
+                // no parts; skipping path
+                if( $path_parts_length < 1 ) {
+                    continue;
+                }
+                
+                // uploaded filenames are sanitized (tolowercase and space to _)
+                // maybe use UploadedFile->filterOriginalFilename(filename) instead of code below
+                $path_parts[$path_parts_length - 1] = strtolower( 
+                    str_replace(' ', '_', $path_parts[$path_parts_length - 1]) 
+                );
+
+                // Work backwards from the basename to try to find matches.
+                for ($i = 1; $i <= $path_parts_length; $i++) {
                     $path_attempt = implode('/', array_slice($path_parts, 0 - $i));
                     $path_hash = md5($path_attempt);
 
                     if (isset($media_lookup[$path_hash])) {
                         $matches[] = $media_lookup[$path_hash];
+
+                        // breaking loop, no need to add a single playlistentry twice.
+                        break 1;
                     }
                 }
             }


### PR DESCRIPTION
Uploaded files have their filename sanitized (only checked the webbrowser upload, not sure about sftp uploads). 
When importing a playlist from the same source the filenames do not match if they contain uppercase or spaces in their filepaths / filenames.

**Proposed changes:**
Simple addition to sanitize the filename part of the imported playlist.

`// uploaded filenames are sanitized (tolowercase and space to _)
// maybe of code below
$path_parts[$path_parts_length - 1] = strtolower( 
    str_replace(' ', '_', $path_parts[$path_parts_length - 1]) 
);`

I also found a function that does the sanitizing; Class UploadedFile->filterOriginalFilename(filename) instead 
but not knowing the azuracast api as a whole, i don't know if it will have side effects.

This should only sanitize the filename part of the path, because a folder can contain spaces and uppercase letters (within Azuracast).

Please add any improvements or fixes you may spot.