### PR TITLE
Improvement: PlaylistParser.php - split filelines by \n or \r

### DIFF
--- a/src/Radio/PlaylistParser.php
+++ b/src/Radio/PlaylistParser.php
@@ -30,11 +30,14 @@ class PlaylistParser
 
         // Process as a simple list of files or M3U-style playlist.
         $lines = preg_split(
-          "/[\r\n]+/",        // regex supports Windows, Linux/Unix & Old Macs EOL's
-          $playlistRaw, 
-          -1,               
-          PREG_SPLIT_NO_EMPTY
+            "/[\r\n]+/",        // regex supports Windows, Linux/Unix & Old Macs EOL's
+            $playlistRaw, 
+            -1,               
+            PREG_SPLIT_NO_EMPTY
         ); 
+        if (false === $lines) {
+            return [];
+        }
         return array_filter(
             array_map($filter_line, $lines),
             static function ($line) {

--- a/src/Radio/PlaylistParser.php
+++ b/src/Radio/PlaylistParser.php
@@ -29,11 +29,16 @@ class PlaylistParser
         };
 
         // Process as a simple list of files or M3U-style playlist.
-        $lines = explode("\n", $playlistRaw);
+        $lines = preg_split(
+          "/[\r\n]+/",        // regex supports Windows, Linux/Unix & Old Macs EOL's
+          $playlistRaw, 
+          -1,               
+          PREG_SPLIT_NO_EMPTY
+        ); 
         return array_filter(
             array_map($filter_line, $lines),
             static function ($line) {
-                return !empty($line) && $line[0] !== '#';
+                return $line[0] !== '#';
             }
         );
     }


### PR DESCRIPTION

**Fixes issue:**

Playlists created on Macs store their files with \r as a newline, 
importing these playlist files does not work properly, cause currently the file contents is split only by \n


**Proposed changes:**

- Change rawfilestring.split( \n ) to .preg_split( \r\n ); Split the content of the playlistfile by \n or \r to support multiple OS'es end of lines characters.
- The regex splitfunction should also not return any empty strings, so I removed the !empty() check in the filterfunction below.


Feel free to make any improvements.

Thank you for replying and keep up the good work.
