### PR TITLE
Feature: Playbutton in playlist re-order modal

### DIFF
--- a/frontend/vue/components/Stations/Playlists/ReorderModal.vue
+++ b/frontend/vue/components/Stations/Playlists/ReorderModal.vue
@@ -1,18 +1,30 @@
 <template>
     <b-modal size="lg" id="reorder_modal" ref="modal" :title="langTitle" :busy="loading" hide-footer>
         <b-overlay variant="card" :show="loading">
+            <div style="min-height: 40px;" class="flex-fill text-left bg-primary rounded">
+              <inline-player ref="player"></inline-player>
+            </div>
             <b-table-simple striped class="sortable mb-0">
                 <b-thead>
                     <tr>
-                        <th style="width: 30%;" key="lang_col_title" v-translate>Title</th>
-                        <th style="width: 25%;" key="lang_col_artist" v-translate>Artist</th>
-                        <th style="width: 25%;" key="lang_col_album" v-translate>Album</th>
+                        <th style="width: 34%;" key="lang_col_title" v-translate>Title</th>
+                        <th style="width: 23%;" key="lang_col_artist" v-translate>Artist</th>
+                        <th style="width: 23%;" key="lang_col_album" v-translate>Album</th>
                         <th style="width: 20%;" key="lang_col_actions" v-translate>Actions</th>
                     </tr>
                 </b-thead>
                 <draggable v-model="media" tag="tbody" @change="save">
                     <tr class="align-middle" v-for="(row,index) in media" :key="media.id">
-                        <td><big>{{ row.media.title }}</big></td>
+                        <td>
+                            <div style="display: flex; align-items: center; justify-content: flex-start;">
+                                <div style="font-size: 1.1rem; margin-right: 1rem;">
+                                    <play-button :url="row.playback_url" icon-class="outlined"></play-button>
+                                </div>
+                                <div class="flex-fill">
+                                    <big>{{ row.media.title }}</big>
+                                </div>
+                            </div>
+                        </td>
                         <td>{{ row.media.artist }}</td>
                         <td>{{ row.media.album }}</td>
                         <td>
@@ -43,12 +55,16 @@ table.sortable {
 <script>
 import Draggable from 'vuedraggable';
 import Icon from '~/components/Common/Icon';
+import PlayButton from "~/components/Common/PlayButton";
+import InlinePlayer from '../../InlinePlayer';
 
 export default {
     name: 'ReorderModal',
     components: {
         Icon,
-        Draggable
+        Draggable,
+        PlayButton,
+        InlinePlayer
     },
     data() {
         return {
@@ -75,7 +91,27 @@ export default {
             this.loading = true;
 
             this.axios.get(this.reorderUrl).then((resp) => {
-                this.media = resp.data;
+                // this is a bit of a hack to get the api_url & station_id; suggetions welcome.
+                let playbackBaseUrl = "";
+                if (this.reorderUrl.includes("://")) {
+                    playbackBaseUrl = this.reorderUrl.match(/.*\/station\/(\d+)\//i)?.[0] || "";
+                } else {
+                    playbackBaseUrl = 
+                      window.location.protocol 
+                      + "//" 
+                      + window.location.host 
+                      + this.reorderUrl.match(/.*\/station\/(\d+)\//i)?.[0] || ""; // selects all after domain return "/api/station/{id}/" or ""
+                }
+                playbackBaseUrl += "files/play/";
+
+                // add playback url to each media object
+                this.media = resp.data.map( obj => {
+                  const playbackUrl = playbackBaseUrl + obj.media_id;
+                  return {
+                    ...obj, 
+                    playback_url: playbackUrl
+                  }
+                });
                 this.loading = false;
             });
         },

--- a/frontend/vue/components/Stations/Playlists/ReorderModal.vue
+++ b/frontend/vue/components/Stations/Playlists/ReorderModal.vue
@@ -7,29 +7,27 @@
             <b-table-simple striped class="sortable mb-0">
                 <b-thead>
                     <tr>
-                        <th style="width: 34%;" key="lang_col_title" v-translate>Title</th>
-                        <th style="width: 23%;" key="lang_col_artist" v-translate>Artist</th>
-                        <th style="width: 23%;" key="lang_col_album" v-translate>Album</th>
+                        <th style="width: 5%">&nbsp;</th>
+                        <th style="width: 25%;" key="lang_col_title" v-translate>Title</th>
+                        <th style="width: 25%;" key="lang_col_artist" v-translate>Artist</th>
+                        <th style="width: 25%;" key="lang_col_album" v-translate>Album</th>
                         <th style="width: 20%;" key="lang_col_actions" v-translate>Actions</th>
                     </tr>
                 </b-thead>
                 <draggable v-model="media" tag="tbody" @change="save">
                     <tr class="align-middle" v-for="(row,index) in media" :key="media.id">
-                        <td>
-                            <div style="display: flex; align-items: center; justify-content: flex-start;">
-                                <div style="font-size: 1.1rem; margin-right: 1rem;">
-                                    <play-button :url="row.media.links.play" icon-class="outlined"></play-button>
-                                </div>
-                                <div class="flex-fill">
-                                    <big>{{ row.media.title }}</big>
-                                </div>
-                            </div>
+                        <td class="pr-2">
+                            <play-button :url="row.media.links.play" icon-class="lg outlined"></play-button>
+                        </td>
+                        <td class="pl-2">
+                            <big>{{ row.media.title }}</big>
                         </td>
                         <td>{{ row.media.artist }}</td>
                         <td>{{ row.media.album }}</td>
                         <td>
                             <b-button-group size="sm">
-                                <b-button size="sm" variant="primary" @click.prevent="moveDown(index)" :title="langDownBtn"
+                                <b-button size="sm" variant="primary" @click.prevent="moveDown(index)"
+                                          :title="langDownBtn"
                                           v-if="index+1 < media.length">
                                     <icon icon="arrow_downward"></icon>
                                 </b-button>
@@ -56,7 +54,7 @@ table.sortable {
 import Draggable from 'vuedraggable';
 import Icon from '~/components/Common/Icon';
 import PlayButton from "~/components/Common/PlayButton";
-import InlinePlayer from '../../InlinePlayer';
+import InlinePlayer from '~/components/InlinePlayer';
 
 export default {
     name: 'ReorderModal',

--- a/frontend/vue/components/Stations/Playlists/ReorderModal.vue
+++ b/frontend/vue/components/Stations/Playlists/ReorderModal.vue
@@ -1,8 +1,8 @@
 <template>
     <b-modal size="lg" id="reorder_modal" ref="modal" :title="langTitle" :busy="loading" hide-footer>
         <b-overlay variant="card" :show="loading">
-            <div style="min-height: 40px;" class="flex-fill text-left bg-primary rounded">
-              <inline-player ref="player"></inline-player>
+            <div style="min-height: 40px;" class="flex-fill text-left bg-primary rounded mb-2">
+                <inline-player ref="player"></inline-player>
             </div>
             <b-table-simple striped class="sortable mb-0">
                 <b-thead>
@@ -18,7 +18,7 @@
                         <td>
                             <div style="display: flex; align-items: center; justify-content: flex-start;">
                                 <div style="font-size: 1.1rem; margin-right: 1rem;">
-                                    <play-button :url="row.playback_url" icon-class="outlined"></play-button>
+                                    <play-button :url="row.media.links.play" icon-class="outlined"></play-button>
                                 </div>
                                 <div class="flex-fill">
                                     <big>{{ row.media.title }}</big>
@@ -91,27 +91,7 @@ export default {
             this.loading = true;
 
             this.axios.get(this.reorderUrl).then((resp) => {
-                // this is a bit of a hack to get the api_url & station_id; suggetions welcome.
-                let playbackBaseUrl = "";
-                if (this.reorderUrl.includes("://")) {
-                    playbackBaseUrl = this.reorderUrl.match(/.*\/station\/(\d+)\//i)?.[0] || "";
-                } else {
-                    playbackBaseUrl = 
-                      window.location.protocol 
-                      + "//" 
-                      + window.location.host 
-                      + this.reorderUrl.match(/.*\/station\/(\d+)\//i)?.[0] || ""; // selects all after domain return "/api/station/{id}/" or ""
-                }
-                playbackBaseUrl += "files/play/";
-
-                // add playback url to each media object
-                this.media = resp.data.map( obj => {
-                  const playbackUrl = playbackBaseUrl + obj.media_id;
-                  return {
-                    ...obj, 
-                    playback_url: playbackUrl
-                  }
-                });
+                this.media = resp.data;
                 this.loading = false;
             });
         },

--- a/frontend/vue/pages/Stations/Playlists.js
+++ b/frontend/vue/pages/Stations/Playlists.js
@@ -3,6 +3,7 @@ import initBase from '~/base.js';
 import '~/vendor/bootstrapVue.js';
 import '~/vendor/luxon.js';
 import '~/vendor/sweetalert.js';
+import '~/store';
 
 import Playlists from '~/components/Stations/Playlists.vue';
 

--- a/src/Controller/Api/Stations/Files/PlayAction.php
+++ b/src/Controller/Api/Stations/Files/PlayAction.php
@@ -12,10 +12,17 @@ use Psr\Http\Message\ResponseInterface;
 
 class PlayAction
 {
+    /**
+     * @param ServerRequest $request
+     * @param Response $response
+     * @param int|string $id
+     * @param Entity\Repository\StationMediaRepository $mediaRepo
+     * @return ResponseInterface
+     */
     public function __invoke(
         ServerRequest $request,
         Response $response,
-        int $id,
+        $id,
         Entity\Repository\StationMediaRepository $mediaRepo
     ): ResponseInterface {
         set_time_limit(600);

--- a/src/Controller/Api/Stations/Playlists/GetOrderAction.php
+++ b/src/Controller/Api/Stations/Playlists/GetOrderAction.php
@@ -17,7 +17,8 @@ class GetOrderAction extends AbstractPlaylistsAction
         Response $response,
         int $id
     ): ResponseInterface {
-        $record = $this->requireRecord($request->getStation(), $id);
+        $station = $request->getStation();
+        $record = $this->requireRecord($station, $id);
 
         if (
             $record->getSource() !== Entity\StationPlaylist::SOURCE_SONGS
@@ -37,6 +38,23 @@ class GetOrderAction extends AbstractPlaylistsAction
         )->setParameter('playlist_id', $id)
             ->getArrayResult();
 
-        return $response->withJson($media_items);
+        $router = $request->getRouter();
+
+        return $response->withJson(
+            array_map(
+                function (array $row) use ($router, $station): array {
+                    $row['media']['links'] = [
+                        'play' => (string)$router->named(
+                            'api:stations:files:play',
+                            ['station_id' => $station->getIdRequired(), 'id' => $row['media']['unique_id']],
+                            [],
+                            true
+                        ),
+                    ];
+                    return $row;
+                },
+                $media_items
+            )
+        );
     }
 }


### PR DESCRIPTION
**Feature:**

Frontend: A playbutton for songs in the re-order playlist modal

**Proposed changes:**

- Add playbutton before song title in table in re-order modal
- Add inlineplayer to top of modal, so the playback can be controlled and is not hidden behind the modal in the header

Feel free to comment with any improvements or suggestions; 
i'm guessing there is a better way of getting the station_id + hostname inside this component (see comment in code)

Thank you for your time.

**Preview modal:**
![afbeelding](https://user-images.githubusercontent.com/14849712/146623517-f4459b79-1a28-4bb8-bf39-8c044455b084.png)
