### PR TITLE
Added a querystring to audiourl in Firefox

### DIFF
--- a/frontend/vue/components/Common/AudioPlayer.vue
+++ b/frontend/vue/components/Common/AudioPlayer.vue
@@ -118,6 +118,12 @@ export default {
 
                 this.audio.src = this.current.url;
 
+                // Firefox caches the downloaded stream, this causes playback issues.
+                // Giving the browser a new url on each start bypasses the old cache/buffer
+                if (navigator.userAgent.includes("Firefox")) {
+                  this.audio.src += "?refresh=" + Date.now();
+                }
+
                 this.audio.load();
                 this.audio.play();
             });


### PR DESCRIPTION
This could fix playbackproblems with the Firefox browser

Please test if this works for all people having playback issues in Firefox
I have tested this on my machine and it seems to work.
Fedora Linux + Firefox (and mp3 codec's installed)

**Fixes issue:**
#4901 

**Proposed changes:**
add querystring to playback url when using the firefox browser
"somestream.com/radio.mp3?refresh=[unixtimestamp]"