### PR TITLE
Add gulp watch script

### DIFF
--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -84,7 +84,7 @@ defaultTasks.forEach(function (libName) {
   });
 });
 
-gulp.task('bundle_deps', gulp.parallel(
+gulp.task('bundle-deps', gulp.parallel(
   defaultTasks.map(function (name) {
     return 'scripts:' + name;
   })
@@ -130,11 +130,17 @@ gulp.task('build-css', function () {
     .pipe(gulp.dest('../web/static/dist'));
 });
 
-gulp.task('default', gulp.series('clean', gulp.parallel('concat-js', 'build-vue', 'build-js', 'build-css', 'bundle_deps'), function () {
+gulp.task('watch', function () {
+  gulp.watch(['./vue/**', './js/**/*.js'], buildAll);
+});
+
+const buildAll = gulp.series('clean', gulp.parallel('concat-js', 'build-vue', 'build-js', 'build-css', 'bundle-deps'), function () {
   return gulp.src(['../web/static/dist/**/*.{js,css}'], { base: '../web/static/' })
     .pipe(rev())
     .pipe(revdel())
     .pipe(gulp.dest('../web/static/'))
     .pipe(rev.manifest('assets.json'))
     .pipe(gulp.dest('../web/static/'));
-}));
+});
+
+exports.default = buildAll

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "npm ci && bash",
     "dev-build": "npm ci && npm run build",
-    "build": "gulp"
+    "build": "gulp",
+    "watch": "gulp watch"
   },
   "dependencies": {
     "@babel/core": "^7.15.5",


### PR DESCRIPTION
Add gulp watch script to watch for vue and js file changes

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->
I want to have the frontend automatically be built when I change vue and js files so frontend development is sped up.

**Proposed changes:**
1. Added a new `gulp watch` script
2. It could be part of the default gulp run, but didn't want to change existing dev process too much
3. Only looks at `vue` and `js` files and it rebuilds **everything**. This can be further optimised but this is a start.
4. Renamed `bundle_deps` to `bundle-deps` to align with existing naming convention
5. After changes have been built, you still need to refresh the page on your browser to see them. I haven't looked at how this part can also be automated (maybe an apache config?)