### PR TITLE
Set media relation of history to null on delete

### DIFF
--- a/src/Entity/Migration/Version20211227232320.php
+++ b/src/Entity/Migration/Version20211227232320.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211227232320 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE song_history DROP FOREIGN KEY FK_2AD16164EA9FDD75');
+        $this->addSql('ALTER TABLE song_history ADD CONSTRAINT FK_2AD16164EA9FDD75 FOREIGN KEY (media_id) REFERENCES station_media (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE song_history DROP FOREIGN KEY FK_2AD16164EA9FDD75');
+        $this->addSql('ALTER TABLE song_history ADD CONSTRAINT FK_2AD16164EA9FDD75 FOREIGN KEY (media_id) REFERENCES station_media (id) ON DELETE CASCADE');
+    }
+}

--- a/src/Entity/SongHistory.php
+++ b/src/Entity/SongHistory.php
@@ -51,7 +51,7 @@ class SongHistory implements SongInterface, IdentifiableEntityInterface
     protected ?int $media_id = null;
 
     #[ORM\ManyToOne]
-    #[ORM\JoinColumn(name: 'media_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'media_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     protected ?StationMedia $media = null;
 
     #[ORM\Column(nullable: true)]


### PR DESCRIPTION
**Fixes issue:**
X

**Proposed changes:**
I noticed that the `StationMedia` relation of the `SongHistory` entity is defined with `onDelete: 'CASCADE'` which causes them to be removed by the DB when the related `StationMedia` is deleted from the station.

This can potentially cause big gaps in the history of stations if their media library changes more frequently which could cause them problems with licensing agencies.

The media relation of the `SongHistory` entity is already defined as `nullable: true` and regularly contains elements that have no relation to media so I have switched the `onDelete: 'CASCADE'` to `onDelete: SET NULL`.
This will prevent history from being deleted when the media is removed.

@SlvrEagle23 I'm not sure how the performance of the migration looks like for huge installations with long history retention. This could potentially take a while for those installations. Just wanted to mention it so that you are aware that this could happen.