### PR TITLE
Give more details to users when using the letsencrypt create command. 

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -772,11 +772,12 @@ uninstall() {
 # Usage: ./docker.sh letsencrypt-create
 #
 letsencrypt-create() {
+  echo "This script will automatically attempt to update your .env file, but if you see no response, you can:"
+  echo "  - Manually edit .env and provide a LETSENCRYPT_HOST and LETSENCRYPT_EMAIL"
+  echo "  - Stop existing services by running docker-compose down"
+  echo "  - Start services again by running docker-compose up -d"
+
   setup-letsencrypt
-  echo "If nothing happens when executing this command, go to your .env file and modify the LETSENCRYPT_HOST= and #LETSENCRYPT_EMAIL=" 
-  echo "After filling in these fields, restart your installation via docker-compose down && docker-compose up -d" 
-  # Temorary workaround for issue 4954
-  
   docker-compose down
   docker-compose up -d
   exit

--- a/docker.sh
+++ b/docker.sh
@@ -773,7 +773,10 @@ uninstall() {
 #
 letsencrypt-create() {
   setup-letsencrypt
-
+  echo "If nothing happens when executing this command, go to your .env file and modify the LETSENCRYPT_HOST= and #LETSENCRYPT_EMAIL=" 
+  echo "After filling in these fields, restart your installation via docker-compose down && docker-compose up -d" 
+  # Temorary workaround for issue 4954
+  
   docker-compose down
   docker-compose up -d
   exit


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
fixes #4954 
**Proposed changes:**
Add a prompt for users who run this command  `./docker.sh letsencrypt-create`

Gives further details on what to do should the command not give any response. 