### PR TITLE
Fix enum usage in listener auth for geoblocking

### DIFF
--- a/src/Controller/Api/InternalController.php
+++ b/src/Controller/Api/InternalController.php
@@ -209,7 +209,7 @@ class InternalController
         if ('success' === $listenerLocation['status']) {
             $listenerCountry = $listenerLocation['country'];
 
-            $countries = Countries::getNames(SupportedLocales::default()->name);
+            $countries = Countries::getNames(SupportedLocales::default()->value);
 
             $listenerCountryCode = '';
             foreach ($countries as $countryCode => $countryName) {


### PR DESCRIPTION
**Fixes issue:**
#4972

**Proposed changes:**
This PR fixes a small usage error with the `SupportedLocales` Enum in the listener authentication for geoblocking.
The code was accidentally using the name of the Enum instead of the value leading the auth to always reject listeners regardless of which country they are from.
