### PR TITLE
Fix ReplayGain metadata calculation and usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ release channel, you can take advantage of these new features and fixes.
 
 - Fixed a bug where album art on the song requests page wouldn't respect "Prefer Browser URL" setting.
 
+- Fixed a bug where Liquidsoap wasn't calculating the ReplayGain values of tracks due to a missing binary
+
+- Added a missing Liquidsoap operator call to apply calculated ReplayGain values on the stream
+
 ---
 
 # AzuraCast 0.15.0 (Jan 12, 2022)

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -956,6 +956,7 @@ class ConfigWriter implements EventSubscriberInterface
                 <<<EOF
                 # Replaygain Metadata
                 enable_replaygain_metadata()
+                radio = replaygain(radio)
                 EOF
             );
         }

--- a/update.sh
+++ b/update.sh
@@ -34,7 +34,7 @@ else
 fi
 
 APP_ENV="${APP_ENV:-production}"
-UPDATE_REVISION="${UPDATE_REVISION:-72}"
+UPDATE_REVISION="${UPDATE_REVISION:-73}"
 
 echo "Updating AzuraCast (Environment: $APP_ENV, Update revision: $UPDATE_REVISION)"
 

--- a/util/ansible/roles/azuracast-radio/tasks/liquidsoap.yml
+++ b/util/ansible/roles/azuracast-radio/tasks/liquidsoap.yml
@@ -48,6 +48,7 @@
       - libx11-dev
       - libxpm-dev
       - bubblewrap
+      - ffmpeg
 
 - name: Install Optional Audio Plugins
   apt:

--- a/util/ansible/update.yml
+++ b/util/ansible/update.yml
@@ -20,7 +20,7 @@
     - role: "azuracast-config"
 
     - role: "azuracast-radio"
-      when: update_revision|int < 70
+      when: update_revision|int < 73
 
     - role: "supervisord"
       when: update_revision|int < 13


### PR DESCRIPTION
**Fixes issue:**
Fixes #2074

**Proposed changes:**
This PR fixes the long standing issue that Liquidsoap is not calculating and applying ReplaGain values correctly in AzuraCast.

For this I have moved the `ffmpeg` from the build dependencies in the `radio` docker image to the base dependencies that will be present in the image after building it. This lets Liquidsoap correctly calculate the ReplayGain values.

In order to apply them to the stream I have added the `replaygain()` operator to the `ConfigWriter` when replaygain metadata is enabled in the station profile.

Related PR: https://github.com/AzuraCast/docker-azuracast-radio/pull/16