### PR TITLE
Only append sid to PW for SHOUTcast v2 frontends

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -1057,15 +1057,17 @@ class ConfigWriter implements EventSubscriberInterface
         if (!empty($username)) {
             $output_params[] = 'user = "' . self::cleanUpString($username) . '"';
         }
-
-        $protocol = $mount->getAutodjProtocolEnum();
-
+        
         $password = self::cleanUpString($mount->getAutodjPassword());
-        if (StreamProtocols::Icy === $protocol) {
+        
+        $adapterType = $mount->getAutodjAdapterTypeEnum();
+        if (FrontendAdapters::Shoutcast === $adapterType) {
             $password .= ':#' . $id;
         }
+        
         $output_params[] = 'password = "' . $password . '"';
 
+        $protocol = $mount->getAutodjProtocolEnum();        
         if (!empty($mount->getAutodjMount())) {
             if (StreamProtocols::Icy === $protocol) {
                 $output_params[] = 'icy_id = ' . $id;

--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -1057,17 +1057,17 @@ class ConfigWriter implements EventSubscriberInterface
         if (!empty($username)) {
             $output_params[] = 'user = "' . self::cleanUpString($username) . '"';
         }
-        
+
         $password = self::cleanUpString($mount->getAutodjPassword());
-        
+
         $adapterType = $mount->getAutodjAdapterTypeEnum();
         if (FrontendAdapters::Shoutcast === $adapterType) {
             $password .= ':#' . $id;
         }
-        
+
         $output_params[] = 'password = "' . $password . '"';
 
-        $protocol = $mount->getAutodjProtocolEnum();        
+        $protocol = $mount->getAutodjProtocolEnum();
         if (!empty($mount->getAutodjMount())) {
             if (StreamProtocols::Icy === $protocol) {
                 $output_params[] = 'icy_id = ' . $id;


### PR DESCRIPTION
**Fixes issue:**
Fixes #5085 

**Proposed changes:**
The `:#N` part in the password is only used by SHOUTcast v2 although SC v1 also uses the Icy protocol.
This PR makes sure that this `sid` is only added to SC v2 mounts.

Since the [Entity\StationRemote::getAutodjPassword()](https://github.com/AzuraCast/AzuraCast/blob/main/src/Entity/StationRemote.php#L196) already returns the password with the remotes configured `sid` appended I have switched this part to only add it when it's a local SC mount.

I originally wanted to adapt the [Entity\StationMount::getAutodjPassword()](https://github.com/AzuraCast/AzuraCast/blob/main/src/Entity/StationMount.php#L386) to match the behaviour of the one from the `StationRemote` but noticed that for local SC 2 frontends the `sid` is generated by a manual index number.

This brought up question for me.
A bit further down there is this block of code:

```php
if (!empty($mount->getAutodjMount())) {
    if (StreamProtocols::Icy === $protocol) {
        $output_params[] = 'icy_id = ' . $id;
    } else {
        $output_params[] = 'mount = "' . self::cleanUpString($mount->getAutodjMount()) . '"';
    }
}
```

For remote SHOUTcast v2 mounts this will not add the `icy_id` output parameter to the output in Liquidsoap.
This means Liquidsoap will automatically use the default `icy_id=1`. In those cases this should probably also be set to the respective `sid` as configured in the remote mount. I'm not sure what unintended side effects having this always be `1` for remote SC 2 mounts could have.

@SlvrEagle23 What do you think about this?
