### PR TITLE
Improve Listener User-Agent parsing performance

### DIFF
--- a/src/Service/DeviceDetector.php
+++ b/src/Service/DeviceDetector.php
@@ -18,7 +18,8 @@ class DeviceDetector
         $this->dd = new \DeviceDetector\DeviceDetector();
     }
 
-    public function parse(string $userAgent): \DeviceDetector\DeviceDetector {
+    public function parse(string $userAgent): \DeviceDetector\DeviceDetector
+    {
         $userAgentHash = md5($userAgent);
         if (isset($this->parsedUserAgents[$userAgentHash])) {
             return $this->parsedUserAgents[$userAgentHash];


### PR DESCRIPTION
**Fixes issue:**
Fixes #4978 

**Proposed changes:**
After analyzing the PHP SPX profiler logs for the Listeners Reports page I found some big inefficiencies with our usage of the `matomo/device-detector` library that is used to parse the Listeners User-Agents.

Here some stats from my own radio station with around 1k unique listeners in 30 days:

## Without the PR

### Zend Engine Memory Usage
![image](https://user-images.githubusercontent.com/13745863/153984506-64b1ae0e-0ecc-40b4-85c8-68d868f63f99.png)

### Wall Time (Real World Time)
![image](https://user-images.githubusercontent.com/13745863/153984649-3eed31a5-3eea-4cbf-b28d-dea46e2930ad.png)

## With this PR applied

### Zend Engine Memory Usage
<img width="353" alt="image" src="https://user-images.githubusercontent.com/13745863/153984835-290d5598-9d84-43d9-84f4-0fa4b45ff248.png">

### Wall Time (Real World Time)
<img width="353" alt="image" src="https://user-images.githubusercontent.com/13745863/153984797-22bcabbd-34a6-4ff1-8b03-81a60073354b.png">
