### PR TITLE
Remove Chained Array Cache from IpGeolocation

### DIFF
--- a/src/Service/IpGeolocation.php
+++ b/src/Service/IpGeolocation.php
@@ -9,8 +9,6 @@ use App\Service\IpGeolocator;
 use Exception;
 use MaxMind\Db\Reader;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Contracts\Cache\CacheInterface;

--- a/src/Service/IpGeolocation.php
+++ b/src/Service/IpGeolocation.php
@@ -29,13 +29,7 @@ class IpGeolocation
 
     public function __construct(CacheItemPoolInterface $psr6Cache)
     {
-        $this->cache = new ProxyAdapter(
-            new ChainAdapter([
-                new ArrayAdapter(),
-                $psr6Cache,
-            ]),
-            'ip_geo.'
-        );
+        $this->cache = new ProxyAdapter($psr6Cache, 'ip_geo.');
     }
 
     protected function initialize(): void


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR removes the chained Array Adapter cache from the IpGeolocation service.

While testing the performance optimizations from @SlvrEagle23 I noticed that the `IpGeolocation` service was taking 2.3s and the `Symfony\Component\Cache\LockRegistry::compute` around 3.3s on a non-cached page load for the Listeners Report.

I ran some more PHP SPX profilings (results at the bottom) and due to the new Chained Array Cache in the `IpGeoloation` service there is a lot of time unnecessarily spent on computing Cache Locks. In the case of the `DeviceDetector` the chained Array Cache does make sense since a lot of User-Agents are potentially duplicates but in the case of IP-Addresses this is not the case since most residential internet connections have dynamic IP addresses so most of the time listeners will not have the same IP as they had in earlier sessions. This means we can't re-use already resolved GeoIp data from the Array cache in this case as much as we can in the `DeviceDetector` causing a lot of overhead due to having to check both caches for entries as well as putting data into both caches.

# Non-Cached, with Chained Array Cache
### Wall Time
![image](https://user-images.githubusercontent.com/13745863/154070280-1c98a04f-af3a-4168-94d0-6d8f607b8176.png)
### Zend Engine Memory Usage
![image](https://user-images.githubusercontent.com/13745863/154071071-ceb59a13-5c34-4293-a277-ad7e42124374.png)

# Cached, with Chained Array Cache
### Wall Time
![image](https://user-images.githubusercontent.com/13745863/154070349-724d1294-bdfd-46a5-b639-85f48b40ba5a.png)
### Zend Engine Memory Usage
![image](https://user-images.githubusercontent.com/13745863/154071117-ee351647-1dda-4f40-9f05-4bf3c6184cce.png)

# Non-Cached, without Chained Array Cache
### Wall Time
![image](https://user-images.githubusercontent.com/13745863/154070460-b4cc9f5f-4cf2-4ccf-a08c-88e58bc5c23f.png)
### Zend Engine Memory Usage
![image](https://user-images.githubusercontent.com/13745863/154071167-e3390a57-a583-4b50-a6a0-f8201789aa00.png)

# Cached, with Chained Array Cache
### Wall Time
![image](https://user-images.githubusercontent.com/13745863/154070477-3d53cf03-eb01-4998-afda-90b85ace73b8.png)
### Zend Engine Memory Usage
![image](https://user-images.githubusercontent.com/13745863/154071214-db6eafc1-3356-4fec-bd66-d0817f7ced65.png)