### PR TITLE
Prevent SC from removing sc_serv.ban & fix format

### DIFF
--- a/src/Radio/Frontend/AbstractFrontend.php
+++ b/src/Radio/Frontend/AbstractFrontend.php
@@ -201,10 +201,23 @@ abstract class AbstractFrontend extends AbstractAdapter
     protected function writeIpBansFile(
         Entity\Station $station,
         string $fileName = 'ip_bans.txt',
+        string $ipsSeparator = "\n"
     ): string {
-        $ips = [];
-        $bannedIps = $station->getFrontendConfig()->getBannedIps();
+        $ips = $this->getBannedIps($station);
 
+        $configDir = $station->getRadioConfigDir();
+        $bansFile = $configDir . '/' . $fileName;
+
+        file_put_contents($bansFile, implode($ipsSeparator, $ips));
+
+        return $bansFile;
+    }
+
+    protected function getBannedIps(Entity\Station $station): array
+    {
+        $ips = [];
+
+        $bannedIps = $station->getFrontendConfig()->getBannedIps();
         if (!empty($bannedIps)) {
             foreach (array_filter(array_map('trim', explode("\n", $bannedIps))) as $ip) {
                 try {
@@ -222,11 +235,6 @@ abstract class AbstractFrontend extends AbstractAdapter
             }
         }
 
-        $configDir = $station->getRadioConfigDir();
-        $bansFile = $configDir . '/' . $fileName;
-
-        file_put_contents($bansFile, implode("\n", $ips));
-
-        return $bansFile;
+        return $ips;
     }
 }

--- a/src/Radio/Frontend/Shoutcast.php
+++ b/src/Radio/Frontend/Shoutcast.php
@@ -145,8 +145,6 @@ class Shoutcast extends AbstractFrontend
             }
         }
 
-        $config = array_filter($config);
-
         $i = 0;
         foreach ($station->getMounts() as $mount_row) {
             /** @var Entity\StationMount $mount_row */

--- a/src/Radio/Frontend/Shoutcast.php
+++ b/src/Radio/Frontend/Shoutcast.php
@@ -122,12 +122,14 @@ class Shoutcast extends AbstractFrontend
             'adminpassword' => $frontendConfig->getAdminPassword(),
             'logfile' => $configPath . '/sc_serv.log',
             'w3clog' => $configPath . '/sc_w3c.log',
-            'banfile' => $this->writeIpBansFile($station, 'sc_serv.ban'),
+            'banfile' => $this->writeIpBansFile($station),
             'agentfile' => $this->writeUserAgentBansFile($station, 'sc_serv.agent'),
             'ripfile' => $configPath . '/sc_serv.rip',
             'maxuser' => $frontendConfig->getMaxListeners() ?? 250,
             'portbase' => $frontendConfig->getPort(),
             'requirestreamconfigs' => 1,
+            'savebanlistonexit' => '0',
+            'saveagentlistonexit' => '0',
             'licenceid' => $frontendConfig->getScLicenseId(),
             'userid' => $frontendConfig->getScUserId(),
             'sslCertificateFile' => $certPaths->getCertPath(),
@@ -191,5 +193,25 @@ class Shoutcast extends AbstractFrontend
         $public_url = $this->getPublicUrl($station, $base_url);
         return $public_url
             ->withPath($public_url->getPath() . '/admin.cgi');
+    }
+
+    protected function writeIpBansFile(
+        Entity\Station $station,
+        string $fileName = 'sc_serv.ban',
+        string $ipsSeparator = ";255;\n"
+    ): string {
+        $ips = $this->getBannedIps($station);
+
+        $configDir = $station->getRadioConfigDir();
+        $bansFile = $configDir . '/' . $fileName;
+
+        $bannedIpsString = implode($ipsSeparator, $ips);
+        if (!empty($bannedIpsString)) {
+            $bannedIpsString .= $ipsSeparator;
+        }
+
+        file_put_contents($bansFile, $bannedIpsString);
+
+        return $bansFile;
     }
 }


### PR DESCRIPTION
**Fixes issue:**
Fixes #5120

**Proposed changes:**
This PR changes the format of the `sc_serv.ban` IP banlist file for SHOUTcast since they use a pretty... custom... format for the banlist that looks like this:
```
192.168.178.1;255;
192.168.178.2;255;
192.168.178.3;255;
192.168.178.4;255;
```

Additonally I have added the following 2 config lines to prevent SC from automatically deleting the `sc_serv.ban` and `sc_serv.agent` files on restarts:
```
savebanlistonexit=0,
saveagentlistonexit=0,
```

Due to the `array_filter` config entries that are set to `0` are always removed preventing this from working correctly so I just removed it.