### PR TITLE
Update ssl paths in icecast on ssl renewal

### DIFF
--- a/src/Console/Command/Internal/OnSslRenewal.php
+++ b/src/Console/Command/Internal/OnSslRenewal.php
@@ -7,7 +7,6 @@ namespace App\Console\Command\Internal;
 use App\Console\Command\CommandAbstract;
 use App\Entity;
 use App\Radio\Adapters;
-use App\Radio\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,7 +21,6 @@ class OnSslRenewal extends CommandAbstract
     public function __construct(
         protected EntityManagerInterface $em,
         protected Adapters $adapters,
-        protected Configuration $configuration,
     ) {
         parent::__construct();
     }
@@ -39,12 +37,7 @@ class OnSslRenewal extends CommandAbstract
             /** @var Entity\Station $station */
             $frontend = $this->adapters->getFrontendAdapter($station);
             if ($frontend->supportsReload()) {
-                $this->configuration->writeConfiguration(
-                    $station,
-                    forceRestart: false,
-                    attemptReload: false
-                );
-
+                $frontend->write($station);
                 $frontend->reload($station);
             }
         }


### PR DESCRIPTION
**Fixes issue:**
X

**Proposed changes:**
This PR addresses the recent SSL problem with Icecast after updating from `0.14.1` to `0.15.2` that a user reported to us on Discord where we found out that the Icecast config was still referring to the old `default.key` and `default.crt` instead of the new `ssl.key` and `ssl.crt`.

When running the update the radio station will be restarted automatically already (which is something we have done for a long time now) but since the new SSL certificate will be generated up to a few minutes after the containers have been started the reload of the stations will still write the old paths to the Icecast configuration.

When the LE script then generates the script and triggers a reload of Icecast it will not update those paths causing people to have SSL issues when trying to access Icecast directly via HTTPS. This behaviour is pretty unintuitive and causes us additional support requests where we basically just need to tell people "restart your station".

We should just trigger a write of an updated Icecast config on SSL renewal before reloading Icecast so that it gets the new path automatically, completely preventing this issue.

(PS. please sqash this PR when merging, my first commit was doing a full rewrite of configs and reload/restart instead of just the frontend which would be pretty unnecessary 😅 )