### PR TITLE
Allow robots index for podcast pages & feed

### DIFF
--- a/src/Controller/Frontend/PublicPages/PodcastEpisodeController.php
+++ b/src/Controller/Frontend/PublicPages/PodcastEpisodeController.php
@@ -28,6 +28,8 @@ class PodcastEpisodeController
         string $podcast_id,
         string $episode_id
     ): ResponseInterface {
+        $response = $response->withHeader('X-Robots-Tag', 'index, nofollow');
+
         $router = $request->getRouter();
         $station = $request->getStation();
 

--- a/src/Controller/Frontend/PublicPages/PodcastEpisodesController.php
+++ b/src/Controller/Frontend/PublicPages/PodcastEpisodesController.php
@@ -27,6 +27,8 @@ class PodcastEpisodesController
         Response $response,
         string $podcast_id
     ): ResponseInterface {
+        $response = $response->withHeader('X-Robots-Tag', 'index, nofollow');
+
         $router = $request->getRouter();
         $station = $request->getStation();
 

--- a/src/Controller/Frontend/PublicPages/PodcastFeedController.php
+++ b/src/Controller/Frontend/PublicPages/PodcastFeedController.php
@@ -77,7 +77,9 @@ class PodcastFeedController
 
         $response->getBody()->write($generatedRss);
 
-        return $response->withHeader('Content-Type', 'application/rss+xml');
+        return $response
+            ->withHeader('Content-Type', 'application/rss+xml')
+            ->withHeader('X-Robots-Tag', 'index, nofollow');
     }
 
     protected function checkHasPublishedEpisodes(Podcast $podcast): bool

--- a/src/Controller/Frontend/PublicPages/PodcastsController.php
+++ b/src/Controller/Frontend/PublicPages/PodcastsController.php
@@ -19,6 +19,8 @@ class PodcastsController
 
     public function __invoke(ServerRequest $request, Response $response): ResponseInterface
     {
+        $response = $response->withHeader('X-Robots-Tag', 'index, nofollow');
+
         $station = $request->getStation();
 
         if (!$station->getEnablePublicPage()) {


### PR DESCRIPTION
**Fixes issue:**
Fixes #5170

**Proposed changes:**
This PR adds the required `X-Robots-Tag: index` to the podcast pages and the feed to allow search engines like Google to index those.