### PR TITLE
Prevent PRs from being impacted by the lock action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -22,6 +22,3 @@ jobs:
           exclude-any-issue-labels: 'in progress'
           issue-comment: 'This issue has not been updated in over a year, so it is being closed for further discussion. If you are experiencing a similar issue, please create a new issue. Thank you!'
           issue-lock-reason: 'resolved'
-          pr-inactive-days: '365'
-          pr-comment: 'This pull request has not been updated in over a year, so it is being closed for further discussion. If you are experiencing a similar issue, please create a new pull request. Thank you!'
-          pr-lock-reason: 'resolved'


### PR DESCRIPTION

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
N/A
**Proposed changes:**
Closed / merged PRs are currently being flagged by our Lock action, I've gone ahead and removed it since it's fairly unnecessary and people don't typically look / reply to old PRs.
