### PR TITLE
Bump Liquidsoap hash to resolve station crashes

### DIFF
--- a/util/docker/stations/liquidsoap/build_as_azuracast.sh
+++ b/util/docker/stations/liquidsoap/build_as_azuracast.sh
@@ -5,7 +5,7 @@ set -x
 opam init --disable-sandboxing -a --bare && opam switch create 4.13.1
 
 # Pin specific commit of Liquidsoap
-opam pin add --no-action liquidsoap https://github.com/savonet/liquidsoap.git#5f17110279432182cf38eb2c21c8f65eb6eaf09d
+opam pin add --no-action liquidsoap https://github.com/savonet/liquidsoap.git#05783c1e44b1f8456f0bbce706e03ca409c5430a
 
 opam pin add --no-action mm https://github.com/savonet/ocaml-mm.git#bfff160ece1676a3a912e8bc79c80ce6482f4d36
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
A user reported to me in discord they was having a fair few crashes related to the pre-release branch we're using, I informed the Liquidsoap team who pushed out some fixes for it. 

Fixes the following crashes related to the pre-release:
-> `Queue generic queue #2 crashed with exception Bad file descriptor in write()`
-> `Queue generic queue #1 crashed with exception Bad file descriptor in write()`
**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
