### PR TITLE
Add arg to install LS via OPAM when building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN chmod a+x /bd_build/*.sh \
     && /bd_build/cleanup.sh
 
 # Build each set of dependencies in their own step for cacheability.
+ARG ARM_FULL_BUILD
 COPY ./util/docker/stations /bd_build/stations/
 RUN bash /bd_build/stations/setup.sh \
     && bash /bd_build/cleanup.sh \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,10 @@ services:
   web:
     build:
       context: .
+      # Control wether Liquidsoap should be built from source via OPAM or download the
+      # pre-built .deb file from the Liquidsoap GitHub Releases on ARM based machines
+      # args:
+      #   ARM_FULL_BUILD: true
     ports:
       - "127.0.0.1:3306:3306"
       - "127.0.0.1:6379:6379"

--- a/util/docker/stations/setup/liquidsoap.sh
+++ b/util/docker/stations/setup/liquidsoap.sh
@@ -15,8 +15,9 @@ $minimal_apt_get_install frei0r-plugins-dev ladspa-sdk multimedia-audio-plugins 
 
 # Per-architecture LS installs
 ARCHITECTURE=amd64
+ARM_FULL_BUILD="${ARM_FULL_BUILD:-false}"
 
-if [ "$(uname -m)" = "aarch64" ]; then
+if [[ "$(uname -m)" = "aarch64" && ${ARM_FULL_BUILD} == "false" ]]; then
     ARCHITECTURE=arm64
 
     wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap/releases/download/v2.0.3/liquidsoap_2.0.3-ubuntu-focal-2_${ARCHITECTURE}.deb"


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR introduces an optional build argument to our Dockerfile to make it possible for developers using an ARM based PC to build Liquidsoap from source via OPAM instead of pulling the pre-built .deb from the LS GH Repo.
