### PR TITLE
Fix "unary operator expected" error in disable redis script

### DIFF
--- a/util/docker/redis/startup_scripts/00_disable_redis.sh
+++ b/util/docker/redis/startup_scripts/00_disable_redis.sh
@@ -10,7 +10,7 @@ bool() {
 # If Redis is expressly disabled or the host is anything but localhost, disable Redis on this container.
 ENABLE_REDIS=${ENABLE_REDIS:-true}
 
-if [ "$REDIS_HOST" != "localhost" ] || bool "$ENABLE_REDIS"; then
+if [ "$REDIS_HOST" != "localhost" ] || ! bool "$ENABLE_REDIS"; then
     echo "Redis is disabled or host is not localhost; disabling Redis..."
     rm -rf /etc/service/redis
     rm -rf /etc/service.minimal/redis

--- a/util/docker/redis/startup_scripts/00_disable_redis.sh
+++ b/util/docker/redis/startup_scripts/00_disable_redis.sh
@@ -8,9 +8,9 @@ bool() {
 }
 
 # If Redis is expressly disabled or the host is anything but localhost, disable Redis on this container.
-ENABLE_REDIS=${ENABLE_REDIS:-false}
+ENABLE_REDIS=${ENABLE_REDIS:-true}
 
-if [ "$REDIS_HOST" != "localhost" ] || [ bool "$ENABLE_REDIS" ]; then
+if [ "$REDIS_HOST" != "localhost" ] || bool "$ENABLE_REDIS"; then
     echo "Redis is disabled or host is not localhost; disabling Redis..."
     rm -rf /etc/service/redis
     rm -rf /etc/service.minimal/redis


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
When starting the container there is currently an error message printed due to the second condition in the `if` of the `00_disable_redis.sh`:

```
/etc/my_init.d/00_disable_redis.sh: line 13: [: bool: unary operator expected
```

When using a function in a bash `if` you shouldn't use the `[` square brackets since this is basically the `test` command which doesn't invoke functions you put between it.

I have also changed the default for the `ENABLE_REDIS` env var here since everywhere else it is set to `true` as default when none is given.