### PR TITLE
Fix frontend build process for dev and missing admin/station menus

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -763,9 +763,9 @@ restore-legacy() {
 # Usage: ./docker.sh static [static_container_command]
 #
 static() {
-  docker-compose -f frontend/docker-compose.yml down -v
-  docker-compose -f frontend/docker-compose.yml build
-  docker-compose --env-file=.env -f frontend/docker-compose.yml run --rm frontend "$@"
+  docker-compose -f docker-compose.frontend.yml down -v
+  docker-compose -f docker-compose.frontend.yml build
+  docker-compose --env-file=.env -f docker-compose.frontend.yml run --rm frontend "$@"
   exit
 }
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,6 +28,7 @@ USER node:node
 VOLUME /data/frontend/node_modules
 
 ENV NODE_ENV=production
+ENV HOME=/home/node
 
 # Define default command.
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/Event/AbstractBuildMenu.php
+++ b/src/Event/AbstractBuildMenu.php
@@ -71,7 +71,7 @@ abstract class AbstractBuildMenu extends Event
      */
     protected function filterMenuItem(array $item): bool
     {
-        if (empty($item['items'])) {
+        if (isset($item['items']) && empty($item['items'])) {
             return false;
         }
 


### PR DESCRIPTION
**Fixes issue:**
#5380

**Proposed changes:**
This PR fixes an issue with the latest version where the frontend build process doesn't run on dev without showing any errors as well as correcting the path for the docker-compose.yml in the `./docker.sh static` command.

Additionally I have fixed the issue that is preventing the admin and station menu from showing up.