### PR TITLE
Hide public page link on dashboard if disabled

### DIFF
--- a/frontend/vue/components/Dashboard.vue
+++ b/frontend/vue/components/Dashboard.vue
@@ -125,9 +125,11 @@
                         </td>
                         <td class="pl-2">
                             <big>{{ item.station.name }}</big><br>
-                            <a :href="item.links.public" target="_blank">
-                                <translate key="dashboard_link_public_page">Public Page</translate>
-                            </a>
+                            <template v-if="item.station.is_public">
+                                <a :href="item.links.public" target="_blank">
+                                    <translate key="dashboard_link_public_page">Public Page</translate>
+                                </a>
+                            </template>
                         </td>
                         <td class="text-center">
                             <icon class="sm align-middle" icon="headset"></icon>


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR hides the public page link on the dashboard page if the public page is disabled for a station.
