### PR TITLE
Swap around Album and Artist on song history. 

### DIFF
--- a/frontend/vue/components/Public/FullPlayer/SongHistory.vue
+++ b/frontend/vue/components/Public/FullPlayer/SongHistory.vue
@@ -102,7 +102,7 @@ export default {
             return DateTime.fromSeconds(timestamp).toRelative();
         },
         albumAndArtist (song) {
-            return [song.album, song.artist].filter(str => !!str).join(', ');
+            return [song.artist, song.album].filter(str => !!str).join(', ');
         }
     }
 };


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
A user mentioned this in our discord that we was handling history files in this format: 
```
Old ---  New
Title --- Title
Album, Artist --- Artist, Album
```
I've gone ahead and swapped it to Artist and Album, since it's more userfriendly and clears up confusion. 