### PR TITLE
Convert metadata tag names to lowercase to match getID3 behaviour

### DIFF
--- a/src/Media/Metadata/Reader.php
+++ b/src/Media/Metadata/Reader.php
@@ -99,7 +99,7 @@ class Reader
                         $tagValue = implode(', ', $flatValue);
                     }
 
-                    $metaTags[(string)$tagName] = $this->cleanUpString((string)$tagValue);
+                    $metaTags[strtolower((string)$tagName)] = $this->cleanUpString((string)$tagValue);
                 }
             }
         }


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR fixes an issue with processing the metadata of files that was reported to us through Discord.
When a file is uploaded where the metadata tags for example for the title and artist are not `title` and `artist` but `TITLE` and `ARTIST` the current metadata processing will ignore them.

Previously getID3 was automatically converting tag names to all lowercase.
This PR adjusts the metadata reader to match this behaviour.
