### PR TITLE
Allow users to debug Slim Application Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ release channel, you can take advantage of these new features and fixes.
   allocation does not use these ports, many stations need to use ports in that range for legacy purposes, which should
   once again be possible.
 
+- Docker users can now debug Slim Application Errors by editing the `SHOW_DETAILED_ERRORS` in the `azuracast.env` file,
+  reports should be submitted to our [issues](https://github.com/azuracast/azuracast/issues) section for review by our team. 
+
 ## Bug Fixes
 
 - A bug preventing SFTP from properly supporting SSH public keys has been fixed.

--- a/azuracast.sample.env
+++ b/azuracast.sample.env
@@ -32,7 +32,7 @@ AUTO_ASSIGN_PORT_MIN=8000
 AUTO_ASSIGN_PORT_MAX=8499
 
 # This allows you to debug Slim Application Errors you may encounter
-# By default, this is disabled to prevent users from seeing priviledged information
+# By default, this is disabled to prevent users from seeing privileged information
 # Please report any Slim Application Error logs to the development team on GitHub
 # Valid options: true, false
 SHOW_DETAILED_ERRORS=false 

--- a/azuracast.sample.env
+++ b/azuracast.sample.env
@@ -31,6 +31,13 @@ AUTO_ASSIGN_PORT_MIN=8000
 # See AUTO_ASSIGN_PORT_MIN.
 AUTO_ASSIGN_PORT_MAX=8499
 
+# This allows you to debug Slim Application Errors you may encounter
+# By default, this is disabled to prevent users from seeing priviledged information
+# Please report any Slim Application Error logs to the development team on GitHub
+# Valid options: true, false
+SHOW_DETAILED_ERRORS=false 
+
+
 #
 # Database Configuration
 # --


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
This change will allow users to have the option to enable debugging on Slim Application Errors they encounter, by default it's disabled to avoid any unexpecting users coming across it. Should they find a issue, they'll be able to accurately report it to us for proper debugging purposes. 

Unsure if I missed anything, let me know. 