### PR TITLE
Fix placeholder usage in help card template

### DIFF
--- a/templates/partials/log_help_card.phtml
+++ b/templates/partials/log_help_card.phtml
@@ -3,15 +3,15 @@
         <h2 class="card-title"><?=__('Need Help?')?></h2>
     </div>
     <div class="card-body">
-        <p><?=__(
-                'You can find answers for many common questions in our <a href="%s" target="_blank">support documents</a>.',
+        <p><?=sprintf(
+                __('You can find answers for many common questions in our <a href="%s" target="_blank">support documents</a>.'),
                 'https://docs.azuracast.com/en/user-guide/troubleshooting'
             )?></p>
 
         <p><?=__('If you\'re experiencing a bug or error, you can submit a GitHub issue using the link below.')?></p>
 
-        <p><?=__(
-                'Your current installation type is <b>%s</b>. Be sure to include this when creating a new issue.',
+        <p><?=sprintf(
+                __('Your current installation type is <b>%s</b>. Be sure to include this when creating a new issue.'),
                 ($environment->isDocker() ? 'Docker' : 'Ansible')
             )?></p>
     </div>


### PR DESCRIPTION
**Fixes issue:**
Fixes #5439

**Proposed changes:**
Add missing `sprintf` in templates for string replacements.
