### PR TITLE
Replace gettimeofday with time to fix deprecation

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -1084,7 +1084,7 @@ class ConfigWriter implements EventSubscriberInterface
         $event->appendBlock(
             <<<LS
             def hls_segment_name(~position,~extname,stream_name) =
-                timestamp = int_of_float(gettimeofday())
+                timestamp = int_of_float(time())
                 duration = 4
                 "#{stream_name}_#{duration}_#{timestamp}_#{position}.#{extname}"
             end


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR replaces the old `gettimeofday` function of LS that is used in the new HLS code to generate the timestamp of the HLS segments with the `time` function to fix the flood of deprecation warnings:

```
[lang.deprecated:2] WARNING: "gettimeofday" is deprecated and will be removed in future version. Please use "time" instead.
```