### PR TITLE
hide bitrate for FLAC mount points

### DIFF
--- a/frontend/vue/components/Stations/Mounts.vue
+++ b/frontend/vue/components/Stations/Mounts.vue
@@ -32,7 +32,8 @@
                     <template v-if="row.item.enable_autodj">
                         <translate key="lang_autodj_enabled">Enabled</translate>
                         -
-                        {{ row.item.autodj_bitrate }}kbps {{ row.item.autodj_format|upper }}
+                        <template v-if="row.item.autodj_format != 'flac'">{{ row.item.autodj_bitrate }}kbps </template>
+                        {{ row.item.autodj_format|upper }}
                     </template>
                     <template v-else>
                         <translate key="lang_autodj_disabled">Disabled</translate>

--- a/frontend/vue/components/Stations/Remotes.vue
+++ b/frontend/vue/components/Stations/Remotes.vue
@@ -28,7 +28,8 @@
                     <template v-if="row.item.enable_autodj">
                         <translate key="lang_autodj_enabled">Enabled</translate>
                         -
-                        {{ row.item.autodj_bitrate }}kbps {{ row.item.autodj_format|upper }}
+                        <template v-if="row.item.autodj_format != 'flac'">{{ row.item.autodj_bitrate }}kbps </template>
+                        {{ row.item.autodj_format|upper }}
                     </template>
                     <template v-else>
                         <translate key="lang_autodj_disabled">Disabled</translate>


### PR DESCRIPTION
**Fixes issue:**
Mount points using FLAC show incorrect bitrate, as the encoder does not have a bitrate setting.

**Proposed changes:**
Only show bitrate when codec is not FLAC.