### PR TITLE
Fix LS type error due to source without methods

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -749,7 +749,7 @@ class ConfigWriter implements EventSubscriberInterface
                         sequence([fade.out(old.source),fade.in(new.source)])
                     else
                         # Otherwise, use the smart transition
-                        {$crossfadeMethod}(old.source, new.source, fade_in={$crossfadeDuration}, fade_out={$crossfadeDuration})
+                        {$crossfadeMethod}(old, new, fade_in={$crossfadeDuration}, fade_out={$crossfadeDuration})
                     end
                 end
                 


### PR DESCRIPTION
**Fixes issue:**
Fixes #5483

**Proposed changes:**
This PR fixes a type issue with the new live aware crossfades.

Going by the documentation the type of `old.source` and `new.source` is as follows:
```
source(audio=pcm('a), video='b, midi='c)
```

So a source without methods.
The `cross.smart` method however expects parameters that look as follows:
```
.{
   db_level : float,
   metadata : [string * string],
   source : source(audio=pcm('a), video=internal('b), midi=internal('c))
 }
```

This is the format of the `old` and `new` variable itself.
