### PR TITLE
Don't assume that no streamer is live when get next song is called

### DIFF
--- a/src/Radio/AutoDJ/Annotations.php
+++ b/src/Radio/AutoDJ/Annotations.php
@@ -121,9 +121,5 @@ class Annotations implements EventSubscriberInterface
             $queueRow->setTimestampCued(time());
             $this->em->persist($queueRow);
         }
-
-        // The "get next song" function is only called when a streamer is not live.
-        $this->streamerRepo->onDisconnect($event->getStation());
-        $this->em->flush();
     }
 }


### PR DESCRIPTION
**Fixes issue:**
Fixes #5486

**Proposed changes:**
This PR does indeed fix the issue that AzuraCast doesn't register the DJ as being live / considers them immediately disconnected due to the call to the get next song.

What this however does not address is why on every metadata change a call is made to `/api/internal/1/liquidsoap/auth`.
@SlvrEagle23 any idea what's up with that behaviour of LS there?
