### PR TITLE
Fix checking incompatible Stereo Tool binary infinite loading page

### DIFF
--- a/src/Controller/Api/Admin/StereoTool/PostAction.php
+++ b/src/Controller/Api/Admin/StereoTool/PostAction.php
@@ -11,6 +11,7 @@ use App\Radio\StereoTool;
 use App\Service\Flow;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 final class PostAction
@@ -36,7 +37,13 @@ final class PostAction
         $process = new Process([$binaryPath, '--help']);
         $process->setWorkingDirectory(dirname($binaryPath));
         $process->setTimeout(5.0);
-        $process->run();
+
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException) {
+            unlink($binaryPath);
+            throw new RuntimeException('Incompatible binary for StereoTool was uploaded.');
+        }
 
         if (!$process->isSuccessful()) {
             unlink($binaryPath);

--- a/src/Radio/StereoTool.php
+++ b/src/Radio/StereoTool.php
@@ -6,6 +6,7 @@ namespace App\Radio;
 
 use App\Entity;
 use App\Environment;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 
 final class StereoTool
@@ -42,7 +43,12 @@ final class StereoTool
         $process = new Process([$binaryPath, '--help']);
         $process->setWorkingDirectory(dirname($binaryPath));
         $process->setTimeout(5.0);
-        $process->run();
+        
+        try {
+            $process->run();
+        } catch (ProcessTimedOutException) {
+            return null;
+        }
 
         if (!$process->isSuccessful()) {
             return null;

--- a/src/Radio/StereoTool.php
+++ b/src/Radio/StereoTool.php
@@ -43,7 +43,7 @@ final class StereoTool
         $process = new Process([$binaryPath, '--help']);
         $process->setWorkingDirectory(dirname($binaryPath));
         $process->setTimeout(5.0);
-        
+
         try {
             $process->run();
         } catch (ProcessTimedOutException) {


### PR DESCRIPTION
**Fixes issue:**
Fixes #5495

**Proposed changes:**
This PR adds a `try / catch` to the execution of the Stereo Tool binary to correctly check if someone uploaded an incompatible (GUI) version.

FYI: The later `!$process->isSuccessful()` is still necessary though to check if someone uploaded for example an x86 binary on ARM.