### PR TITLE
Fix renewal check (compare SAN)

### DIFF
--- a/src/Service/Acme.php
+++ b/src/Service/Acme.php
@@ -125,7 +125,7 @@ final class Acme
         if (
             !$force
             && file_exists($acmeDir . '/acme.crt')
-            && $domains === $acme->getSAN('file://' . $acmeDir . '/acme.crt')
+            && empty(array_diff($domains, $acme->getSAN('file://' . $acmeDir . '/acme.crt')))
             && $acme->getRemainingDays('file://' . $acmeDir . '/acme.crt') > self::THRESHOLD_DAYS
         ) {
             throw new RuntimeException('Certificate does not need renewal.');


### PR DESCRIPTION
Since the order of domains (SAN) - in both arrays - is not determined the `===` comparison will fail if the order of names differ.
Now `array_diff` is used to check if there are domains which are not covered by the certificate yet, no matter the order.