### PR TITLE
Fix missing city in listener geo data

### DIFF
--- a/src/Service/IpGeolocator/IpResult.php
+++ b/src/Service/IpGeolocator/IpResult.php
@@ -31,7 +31,7 @@ final class IpResult
         }
 
         $record->region = $ipInfo['subdivisions'][0]['names']['en'] ?? null;
-        $record->city = $ipInfo['city'][0]['names']['en'] ?? null;
+        $record->city = $ipInfo['city']['names']['en'] ?? null;
         $record->country = $ipInfo['country']['iso_code'] ?? null;
         $record->description = implode(
             ', ',


### PR DESCRIPTION
**Fixes issue:**
Fixes #5628

**Proposed changes:**
This PR fixes a small bug in the `IpResult` class where the array path is incorrect when trying to get the city from the geolocation result.
