### PR TITLE
Fix 404 when manually running sync tasks

### DIFF
--- a/templates/admin/debug/index.phtml
+++ b/templates/admin/debug/index.phtml
@@ -95,7 +95,7 @@ $assets
                     <div class="buttons">
                         <a class="btn btn-sm btn-primary" role="button" href="<?= $router->named(
                             'admin:debug:sync',
-                            ['task' => $task]
+                            ['task' => rawurlencode($task)]
                         ) ?>">
                             <?= __('Run Task') ?>
                         </a>


### PR DESCRIPTION
**Fixes issue:**
Fixes #5840

**Proposed changes:**
When running any of the Synchronization Tasks from the System Debugger page manually via the Run Task button it results in a "404 Not Found" page instead of executing the task.

When compared to an earlier version the `App/Sync/Task/CheckFolderPlaylistsTask` for the parameter `{task}` of the `/admin/debug/sync/{task}` route was URL encoded like this: `App%5CSync%5CTask%5CCheckMediaTask`.

I'm not sure where we got the URL encoded class-string from before (I have looked at the history of the related files but couldn't make out when/why/where this changed) so I have added an explicit `rawurlencode` call on the class-string in the template.
