### PR TITLE
link to listeners page

### DIFF
--- a/frontend/vue/components/Stations/Profile/NowPlayingPanel.vue
+++ b/frontend/vue/components/Stations/Profile/NowPlayingPanel.vue
@@ -13,14 +13,16 @@
                     class="card-subtitle text-right flex-fill my-0"
                     style="line-height: 1;"
                 >
+                <a href="reports/listeners" style="color: #fff;">
                     <icon
                         class="sm align-middle"
                         icon="headset"
                     />
                     <span class="pl-1">
                         {{ langListeners }}
+                        </a>
                     </span>
-
+                </a>
                     <br>
                     <small>
                         <span class="pr-1">{{ np.listeners.unique }}</span>

--- a/frontend/vue/components/Stations/Profile/NowPlayingPanel.vue
+++ b/frontend/vue/components/Stations/Profile/NowPlayingPanel.vue
@@ -19,7 +19,7 @@
                         icon="headset"
                     />
                     <span class="pl-1">
-                        {{ langListeners }}                  
+                        {{ langListeners }}
                     </span>
                 </a>
                     <br>

--- a/frontend/vue/components/Stations/Profile/NowPlayingPanel.vue
+++ b/frontend/vue/components/Stations/Profile/NowPlayingPanel.vue
@@ -19,8 +19,7 @@
                         icon="headset"
                     />
                     <span class="pl-1">
-                        {{ langListeners }}
-                        </a>
+                        {{ langListeners }}                  
                     </span>
                 </a>
                     <br>


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->I'm suggesting wrapping a link to the listeners reports around the Headset icon + total listeners part of the Now Playing panel in the main station profile, it's pretty handy to be able to navigate to that page from this. I added color #fff to avoid making the text blue (which is not very legible since the card header is blue by default). Not sure if this should be specified in another place for the CSS...