### PR TITLE
Add mapping for .mod files due to application/octet-stream detection

### DIFF
--- a/src/Media/MimeTypeExtensionMap.php
+++ b/src/Media/MimeTypeExtensionMap.php
@@ -9,6 +9,7 @@ use League\MimeTypeDetection\GeneratedExtensionToMimeTypeMap;
 final class MimeTypeExtensionMap extends GeneratedExtensionToMimeTypeMap
 {
     public const ADDED_MIME_TYPES = [
+        'mod' => 'audio/x-mod',
         'stm' => 'audio/x-mod',
     ];
 


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR adds a new mapping to the `MimeTypeExtensionMap` to enable processing of `.mod` files that are detected as `application/octet-stream`.
