### PR TITLE
Add replaceLine to WriteLiquidsoapConfiguration

### DIFF
--- a/src/Event/Radio/WriteLiquidsoapConfiguration.php
+++ b/src/Event/Radio/WriteLiquidsoapConfiguration.php
@@ -57,6 +57,17 @@ final class WriteLiquidsoapConfiguration extends Event
     {
         $this->configLines = array_merge($lines, [''], $this->configLines);
     }
+    
+     /**
+     * Replace the line at the specified index with the specified string.
+     *
+     * @param int $index
+     * @param string $line
+     */
+    public function replaceLine(int $index, string $line): void
+    {
+        $this->configLines[$index] = $line;
+    }
 
     /**
      * Compile the configuration lines together and return the result.

--- a/src/Event/Radio/WriteLiquidsoapConfiguration.php
+++ b/src/Event/Radio/WriteLiquidsoapConfiguration.php
@@ -58,7 +58,7 @@ final class WriteLiquidsoapConfiguration extends Event
         $this->configLines = array_merge($lines, [''], $this->configLines);
     }
     
-     /**
+    /**
      * Replace the line at the specified index with the specified string.
      *
      * @param int $index


### PR DESCRIPTION
**Proposed changes:**
- Adding a method (replaceLine) to the WriteLiquidsoapConfiguration event to allow plugins to override Liquidsoap Config autogenerated config lines. Just prepend/append code isn't enough and could be done trough the dashboard anyway.
