### PR TITLE
Automatically fetch the latest Icecast KH Version

### DIFF
--- a/util/docker/stations/setup/icecast.sh
+++ b/util/docker/stations/setup/icecast.sh
@@ -9,13 +9,20 @@ apt-get install -q -y --no-install-recommends \
 mkdir -p /bd_build/stations/icecast_build
 cd /bd_build/stations/icecast_build
 
-curl -fsSL https://github.com/karlheyes/icecast-kh/archive/refs/tags/icecast-2.4.0-kh20.tar.gz \
-  -o icecast.tar.gz
+# Get the latest release tag name for Icecast
+tag_name=$(curl -s https://api.github.com/repos/karlheyes/icecast-kh/releases/latest | grep "tag_name" | cut -d '"' -f 4)
+
+# Construct the release URL for Icecast
+release_url="https://github.com/karlheyes/icecast-kh/archive/refs/tags/$tag_name.tar.gz"
+
+# Download and extract the Icecast source code
+curl -fsSL -o icecast.tar.gz "$release_url"
 tar -xvzf icecast.tar.gz --strip-components=1
 
 # git clone https://github.com/karlheyes/icecast-kh.git .
 # git checkout 3b04a78133b7c4b8f879b55e83c139532976de87
 
+# Build and install Icecast
 ./configure
 make
 make install


### PR DESCRIPTION
Just saw the latest KH19 & KH20 commits. It seems you would stay up to date with Icecast KH. So i think this will help you to save some time. If you want , this would be a way you can make sure your script is downloading automatically the latest version.

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
