### PR TITLE
Fix bug in Swagger API

### DIFF
--- a/src/OpenApi.php
+++ b/src/OpenApi.php
@@ -67,7 +67,8 @@ use OpenApi\Attributes as OA;
         )
     ),
     OA\Parameter(
-        name: "StationIdRequired",
+        parameter: "StationIdRequired",
+        name: "station_id",
         in: "path",
         required: true,
         schema: new OA\Schema(

--- a/web/static/api/openapi.yml
+++ b/web/static/api/openapi.yml
@@ -5090,7 +5090,7 @@ components:
             $ref: '#/components/schemas/Api_Error'
   parameters:
     StationIdRequired:
-      name: StationIdRequired
+      name: station_id
       in: path
       required: true
       schema:


### PR DESCRIPTION
Hello guys,

Today, was a developing WHMCS Module for a friend and when I was testing the API, comes out the issue of the parameter `station_id`, not being updated by Swagger, so I did a quick search and found the bug of it. Tested it out in my friend's system and it solved the issue.

Hope this helps your users and thank you for keeping this updated,
Without any further more,

André Antunes

**Fixes issue:**
#5631 at least.

**Proposed changes:**
- Change the name to search in the path, of the URL.