### PR TITLE
Replace deprecated LS operators & fix a warning

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -190,31 +190,31 @@ final class ConfigWriter implements EventSubscriberInterface
             <<<LIQ
             init.daemon.set(false)
             init.daemon.pidfile.path.set("{$pidfile}")
-            
+
             log.stdout.set(true)
             log.file.set(false)
-            
+
             settings.server.log.level.set(4)
-            
+
             settings.server.socket.set(true)
             settings.server.socket.permissions.set(0o660)
             settings.server.socket.path.set("{$socketFile}")
-            
+
             settings.harbor.bind_addrs.set(["0.0.0.0"])
             settings.encoder.metadata.export.set(["artist","title","album","song"])
-            
-            setenv("TZ", "{$stationTz}")
-            
+
+            environment.set("TZ", "{$stationTz}")
+
             autodj_is_loading = ref(true)
             ignore(autodj_is_loading)
-            
+
             autodj_ping_attempts = ref(0)
             ignore(autodj_ping_attempts)
-            
+
             # Track live-enabled status.
             live_enabled = ref(false)
             ignore(live_enabled)
-            
+
             # Track live transition for crossfades.
             to_live = ref(false)
             ignore(to_live)
@@ -231,10 +231,10 @@ final class ConfigWriter implements EventSubscriberInterface
             <<<LIQ
             azuracast_api_url = "{$stationApiUrl}"
             azuracast_api_key = "{$stationApiAuth}"
-            
+
             def azuracast_api_call(~timeout=2.0, url, payload) =
                 full_url = "#{azuracast_api_url}/#{url}"
-                
+
                 log("API #{url} - Sending POST request to '#{full_url}' with body: #{payload}")
                 try
                     response = http.post(full_url,
@@ -246,7 +246,7 @@ final class ConfigWriter implements EventSubscriberInterface
                         timeout=timeout,
                         data=payload
                     )
-                    
+
                     log("API #{url} - Response (#{response.status_code}): #{response}")
                     "#{response}"
                 catch err do
@@ -268,8 +268,8 @@ final class ConfigWriter implements EventSubscriberInterface
                 def azuracast_media_protocol(~rlog=_,~maxtime=_,arg) =
                     ["#{station_media_dir}/#{arg}"]
                 end
-                
-                add_protocol(
+
+                protocol.add(
                     "media",
                     azuracast_media_protocol,
                     doc="Pull files from AzuraCast media directory.",
@@ -282,14 +282,14 @@ final class ConfigWriter implements EventSubscriberInterface
                 <<<LIQ
                 def azuracast_media_protocol(~rlog=_,~maxtime,arg) =
                     timeout = 1000.0 * (maxtime - time())
-                    
+
                     j = json()
                     j.add("uri", arg)
-                    
+
                     [azuracast_api_call(timeout=timeout, "cp", json.stringify(j))]
                 end
-                
-                add_protocol(
+
+                protocol.add(
                     "media",
                     azuracast_media_protocol,
                     temporary=true,
@@ -600,11 +600,11 @@ final class ConfigWriter implements EventSubscriberInterface
                        end
                     end
                 end
-                
+
                 # Delayed ping for AutoDJ Next Song
                 def wait_for_next_song(autodj)
                     autodj_ping_attempts.set(autodj_ping_attempts() + 1)
-                    
+
                     if source.is_ready(autodj) then
                         log("AutoDJ is ready!")
                         autodj_is_loading.set(false)
@@ -617,10 +617,10 @@ final class ConfigWriter implements EventSubscriberInterface
                         0.5
                     end
                 end
-                
+
                 dynamic = request.dynamic(id="next_song", timeout=20.0, retry_delay=10., autodj_next_song)
                 dynamic = cue_cut(id="cue_next_song", dynamic)
-                
+
                 dynamic_startup = fallback(
                     id = "dynamic_startup",
                     track_sensitive = false,
@@ -633,7 +633,7 @@ final class ConfigWriter implements EventSubscriberInterface
                     ]
                 )
                 radio = fallback(id="autodj_fallback", track_sensitive = true, [dynamic_startup, radio])
-                
+
                 ref_dynamic = ref(dynamic);
                 thread.run.recurrent(delay=0.25, { wait_for_next_song(ref_dynamic()) })
                 LIQ
@@ -658,7 +658,7 @@ final class ConfigWriter implements EventSubscriberInterface
             requests = request.queue(id="{$requestsQueueName}")
             requests = cue_cut(id="cue_{$requestsQueueName}", requests)
             radio = fallback(id="requests_fallback", track_sensitive = true, [requests, radio])
-            
+
             interrupting_queue = request.queue(id="{$interruptingQueueName}")
             interrupting_queue = cue_cut(id="cue_{$interruptingQueueName}", interrupting_queue)
             radio = fallback(id="interrupting_fallback", track_sensitive = false, [interrupting_queue, radio])
@@ -688,10 +688,10 @@ final class ConfigWriter implements EventSubscriberInterface
                     source.skip(s)
                     "Done!"
                 end
-                
+
                 server.register(namespace="radio", usage="skip", description="Skip the current song.", "skip",skip)
             end
-            
+
             add_skip_command(radio)
             LIQ
         );
@@ -839,7 +839,7 @@ final class ConfigWriter implements EventSubscriberInterface
                         {$crossfadeFunc}
                     end
                 end
-                
+
                 radio = cross(minimum=0., duration={$crossDuration}, live_aware_crossfade, radio)
                 LS
             );
@@ -870,7 +870,7 @@ final class ConfigWriter implements EventSubscriberInterface
             # DJ Authentication
             last_authenticated_dj = ref("")
             live_dj = ref("")
-            
+
             def dj_auth(login) =
                 auth_info =
                     if (login.user == "source" or login.user == "") and (string.match(pattern="(:|,)+", login.password)) then
@@ -880,13 +880,13 @@ final class ConfigWriter implements EventSubscriberInterface
                     else
                         {user = login.user, password = login.password}
                     end
-                
+
                 response = azuracast_api_call(
                     timeout=5.0,
                     "auth",
                     json.stringify(auth_info)
                 )
-                
+
                 if (response == "true") then
                     last_authenticated_dj.set(auth_info.user)
                     true
@@ -894,28 +894,28 @@ final class ConfigWriter implements EventSubscriberInterface
                     false
                 end
             end
-            
+
             def live_connected(header) =
                 dj = last_authenticated_dj()
                 log("DJ Source connected! Last authenticated DJ: #{dj} - #{header}")
-            
+
                 live_enabled.set(true)
                 live_dj.set(dj)
-                
+
                 _ = azuracast_api_call(
                     timeout=5.0,
                     "djon",
                     json.stringify({user = dj})
                 )
             end
-            
+
             def live_disconnected() =
                 _ = azuracast_api_call(
                     timeout=5.0,
                     "djoff",
                     json.stringify({user = live_dj()})
                 )
-                
+
                 live_enabled.set(false)
                 live_dj.set("")
             end
@@ -947,10 +947,10 @@ final class ConfigWriter implements EventSubscriberInterface
             # A Pre-DJ source of radio that can be broadcast if needed',
             radio_without_live = radio
             ignore(radio_without_live)
-            
+
             # Live Broadcasting
             live = input.harbor({$harborParams})
-            
+
             def insert_missing(m) =
                 if m == [] then
                     [("title", "Live Broadcast"), ("is_live", "true")]
@@ -959,10 +959,10 @@ final class ConfigWriter implements EventSubscriberInterface
                 end
             end
             live = metadata.map(insert_missing, live)
-            
+
             radio = fallback(id="live_fallback", replay_metadata=true, [live, radio])
-            
-            # Skip non-live track when live DJ goes live. 
+
+            # Skip non-live track when live DJ goes live.
             def check_live() =
                 if live.is_ready() then
                     if not to_live() then
@@ -973,7 +973,7 @@ final class ConfigWriter implements EventSubscriberInterface
                     to_live.set(false)
                 end
             end
-            
+
             # Continuously check on live.
             radio = source.on_frame(radio, check_live)
             LIQ
@@ -993,23 +993,23 @@ final class ConfigWriter implements EventSubscriberInterface
                 # Record Live Broadcasts
                 recording_base_path = "{$recordBasePath}"
                 recording_extension = "{$recordExtension}"
-                
+
                 output.file(
-                    {$formatString}, 
+                    {$formatString},
                     fun () -> begin
                         if (live_enabled()) then
                             "#{recording_base_path}/#{live_dj()}/{$recordPathPrefix}_%Y%m%d-%H%M%S.#{recording_extension}.tmp"
                         else
                             ""
                         end
-                    end, 
-                    live, 
-                    fallible=true, 
+                    end,
+                    live,
+                    fallible=true,
                     on_close=fun (tempPath) -> begin
                         path = string.replace(pattern=".tmp$", (fun(_) -> ""), tempPath)
-                    
+
                         log("Recording stopped: Switching from #{tempPath} to #{path}")
-                        
+
                         process.run("mv #{tempPath} #{path}")
                         ()
                     end
@@ -1028,7 +1028,7 @@ final class ConfigWriter implements EventSubscriberInterface
             <<<LIQ
             # Allow for Telnet-driven insertion of custom metadata.
             radio = server.insert_metadata(id="custom_metadata", radio)
-            
+
             # Apply amplification metadata (if supplied)
             radio = amplify(override="liq_amplify", 1., radio)
             LIQ
@@ -1054,13 +1054,14 @@ final class ConfigWriter implements EventSubscriberInterface
 
         $event->appendBlock(
             <<<LIQ
-            error_file = single(id="error_jingle", "{$errorFile}") 
-            
+            error_file = single(id="error_jingle", "{$errorFile}")
+
             def tag_error_file(m) =
+                ignore(m)
                 [("is_error_file", "true")]
             end
             error_file = metadata.map(tag_error_file, error_file)
-            
+
             radio = fallback(id="safe_fallback", track_sensitive = false, [radio, error_file])
             LIQ
         );
@@ -1070,16 +1071,16 @@ final class ConfigWriter implements EventSubscriberInterface
             # Send metadata changes back to AzuraCast
             last_title = ref("")
             last_artist = ref("")
-            
+
             def metadata_updated(m) =
                 def f() =
                     if (m["is_error_file"] != "true") then
                         if (m["title"] != last_title() or m["artist"] != last_artist()) then
                             last_title.set(m["title"])
                             last_artist.set(m["artist"])
-                            
+
                             j = json()
-                            
+
                             if (m["song_id"] != "") then
                                 j.add("song_id", m["song_id"])
                                 j.add("media_id", m["media_id"])
@@ -1088,7 +1089,7 @@ final class ConfigWriter implements EventSubscriberInterface
                                 j.add("artist", m["artist"])
                                 j.add("title", m["title"])
                             end
-                            
+
                             _ = azuracast_api_call(
                                 "feedback",
                                 json.stringify(j)
@@ -1096,15 +1097,15 @@ final class ConfigWriter implements EventSubscriberInterface
                         end
                     end
                 end
-                
+
                 thread.run(f)
             end
-            
+
             radio.on_metadata(metadata_updated)
-            
+
             # Handle "Jingle Mode" tracks by replaying the previous metadata.
             last_metadata = ref([])
-            def handle_jingle_mode(m) = 
+            def handle_jingle_mode(m) =
                 if (m["jingle_mode"] == "true") then
                     last_metadata()
                 else
@@ -1112,7 +1113,7 @@ final class ConfigWriter implements EventSubscriberInterface
                     m
                 end
             end
-            
+
             radio = metadata.map(update=false, strip=true, handle_jingle_mode, radio)
             LIQ
         );
@@ -1218,7 +1219,7 @@ final class ConfigWriter implements EventSubscriberInterface
                 duration = {$hlsSegmentLength}
                 "#{stream_name}_#{duration}_#{timestamp}_#{position}.#{extname}"
             end
-            
+
             output.file.hls(playlist="live.m3u8",
                 segment_duration={$hlsSegmentLength}.0,
                 segments={$hlsSegmentsInPlaylist},


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
I've fixed 2 deprecations and a warning about an unused variable I've seen while debugging the startup issue in LS 2.2.0.

Deprecations / Replacements:
```
setenv => environment.set
add_protocol => protocol.add
```

My IDE also automatically removed unnecessary spaces from the LS config blocks.