### PR TITLE
Add env vars for InnoDB buffer & log size

### DIFF
--- a/azuracast.sample.env
+++ b/azuracast.sample.env
@@ -35,7 +35,7 @@ AUTO_ASSIGN_PORT_MAX=8499
 # By default, this is disabled to prevent users from seeing privileged information
 # Please report any Slim Application Error logs to the development team on GitHub
 # Valid options: true, false
-SHOW_DETAILED_ERRORS=false 
+SHOW_DETAILED_ERRORS=false
 
 
 #
@@ -84,6 +84,16 @@ MYSQL_RANDOM_ROOT_PASSWORD=yes
 # if you are seeing the `Too many connections` error in the logs.
 # Default: 100
 # MYSQL_MAX_CONNECTIONS=100
+
+# The InnoDB buffer pool size controls how much data & indexes are kept in memory.
+# Making sure that this value is as large as possible reduces the amount of disk IO.
+# Default: 128M
+# MYSQL_INNODB_BUFFER_POOL_SIZE=128M
+
+# The InnoDB log file is used to achieve data durability in case of crashes or unexpected shutoffs
+# and to allow the DB to better optimize IO for write operations.
+# Default: 16M
+# MYSQL_INNODB_LOG_FILE_SIZE=16M
 
 #
 # Redis Configuration

--- a/src/Installer/EnvFiles/AzuraCastEnvFile.php
+++ b/src/Installer/EnvFiles/AzuraCastEnvFile.php
@@ -152,6 +152,20 @@ final class AzuraCastEnvFile extends AbstractEnvFile
                     ),
                     'default' => 100,
                 ],
+                'MYSQL_INNODB_BUFFER_POOL_SIZE' => [
+                    'name' => __('MariaDB InnoDB Buffer Pool Size'),
+                    'description' => __(
+                        'The InnoDB buffer pool size controls how much data & indexes are kept in memory. Making sure that this value is as large as possible reduces the amount of disk IO.',
+                    ),
+                    'default' => '128M',
+                ],
+                'MYSQL_INNODB_LOG_FILE_SIZE' => [
+                    'name' => __('MariaDB InnoDB Log File Size'),
+                    'description' => __(
+                        'The InnoDB log file is used to achieve data durability in case of crashes or unexpected shutoffs and to allow the DB to better optimize IO for write operations.',
+                    ),
+                    'default' => '16M',
+                ],
                 Environment::ENABLE_REDIS => [
                     'name' => __('Enable Redis'),
                     'description' => __(

--- a/util/docker/mariadb/mariadb/db.cnf.tmpl
+++ b/util/docker/mariadb/mariadb/db.cnf.tmpl
@@ -7,5 +7,8 @@ long_query_time = 0.2
 
 max_connections = {{ default .Env.MYSQL_MAX_CONNECTIONS "100" }}
 
+innodb_buffer_pool_size = {{ default .Env.MYSQL_INNODB_BUFFER_POOL_SIZE "128M" }}
+innodb_log_file_size = {{ default .Env.MYSQL_INNODB_LOG_FILE_SIZE "16M" }}
+
 [client]
 default-character-set=utf8mb4


### PR DESCRIPTION
**Fixes issue:**
X

**Proposed changes:**
This PR adds 2 new env vars to the `azuracast.env`:
- MYSQL_INNODB_BUFFER_POOL_SIZE
- MYSQL_INNODB_LOG_FILE_SIZE

I noticed that on my prod installation that runs on a server with HDD, 2 CPU cores and 4G of RAM that there was quite a lot of IO wait time on the CPU usage. Generally between 20-40% IO wait although not much is running on the same disk and with only 4 stations.

Those stations do however have quite a lot of history data. Overall the DB is 500-600MB in size.

After looking into it I saw that the IO was generated by MariaDB constantly needing to do disk reads for the `getVisibleHistory` query that is used for the now playing data.

This indicated to me that the buffer pool size is too low for the amount of data in my DB so to double check this I ran [MySQLTuner](https://github.com/major/MySQLTuner-perl) on my DB which recommended increasing the buffer pool size to `(>= 718.8M)` and the log file size to `(=32M)`.

After adding those settings manually inside the container and restarting the DB the IO wait time was completely gone.

So in order to make it possible to keep those settings through updates and reboots I have added those env vars to allow adjusting these settings.

I can imagine that this is also interesting for installations with lots of stations and lots of free memory.

<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6308"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

