### PR TITLE
Fix wrong color in help modal dot

### DIFF
--- a/frontend/vue/components/Admin/Index/MemoryStatsHelpModal.vue
+++ b/frontend/vue/components/Admin/Index/MemoryStatsHelpModal.vue
@@ -10,7 +10,7 @@
             <h6>
                 <b-badge
                     pill
-                    variant="danger"
+                    variant="warning"
                 >
 &nbsp;&nbsp;
                 </b-badge>&nbsp;


### PR DESCRIPTION
**Fixes issue:**
X

**Proposed changes:**
The dot for the cached memory is yellow/orange but in the help modal it is red. This PR fixes the color in the help modal.

<img width="584" alt="image" src="https://github.com/AzuraCast/AzuraCast/assets/13745863/59053389-8e42-42e6-a54b-b1014124bea7">
<img width="830" alt="image" src="https://github.com/AzuraCast/AzuraCast/assets/13745863/b812370e-0d5c-45a1-8722-40e2eb2364ba">



<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6309"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

