### PR TITLE
Remove duplicate format parameter for output.file

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -996,7 +996,6 @@ final class ConfigWriter implements EventSubscriberInterface
 
                 output.file(
                     {$formatString},
-                    {$formatString},
                     fun () -> begin
                         if (live_enabled()) then
                             "#{recording_base_path}/#{live_dj()}/{$recordPathPrefix}_%Y%m%d-%H%M%S.#{recording_extension}.tmp"


### PR DESCRIPTION
**Fixes issue:**
Fixes https://github.com/AzuraCast/AzuraCast/issues/6319

**Proposed changes:**
This PR fixes an issue in the code for recording streamers where we have a duplicated parameter.
