### PR TITLE
Fixes #6333 - wrong parameter name for media edit

### DIFF
--- a/src/Controller/Api/Stations/FilesController.php
+++ b/src/Controller/Api/Stations/FilesController.php
@@ -235,7 +235,7 @@ final class FilesController extends AbstractStationApiCrudController
     public function editAction(
         ServerRequest $request,
         Response $response,
-        string $stationId,
+        string $station_id,
         string $id
     ): ResponseInterface {
         $station = $this->getStation($request);


### PR DESCRIPTION
**Fixes issue:**
Fixes #6333 

**Proposed changes:**
Fixes an error due to a parameter name that doesn't match the naming of the parameter in the route signature.


<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6335"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

