### PR TITLE
fix type error which breaks liquidsoap, bool instead of string

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -1331,7 +1331,7 @@ final class ConfigWriter implements EventSubscriberInterface
         }
 
         if ($format->sendIcyMetadata()) {
-            $outputParams[] = 'send_icy_metadata="true"';
+            $outputParams[] = 'send_icy_metadata=true';
         }
 
         $outputParams[] = 'radio';


### PR DESCRIPTION
this type error breaks liquidsoap when you try to create a FLAC station

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
#6358

**Proposed changes:**
convert string "true" to boolean 

<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6359"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

