### PR TITLE
 Fixes #6304 - Broken Icecast Safari cache busting redirect

### DIFF
--- a/src/Nginx/ConfigWriter.php
+++ b/src/Nginx/ConfigWriter.php
@@ -46,13 +46,13 @@ final class ConfigWriter implements EventSubscriberInterface
 
             location ~ ^({$listenBaseUrl}|/radio/{$port})/(.*)\$ {
                 include proxy_params;
-                
+
                 proxy_intercept_errors    on;
                 proxy_next_upstream       error timeout invalid_header;
                 proxy_redirect            off;
                 proxy_connect_timeout     60;
-                
-                proxy_set_header Host localhost:{$port};
+
+                proxy_set_header Host \$host/{$listenBaseUrl};
                 proxy_pass http://127.0.0.1:{$port}/\$2?\$args;
             }
             NGINX
@@ -104,14 +104,14 @@ final class ConfigWriter implements EventSubscriberInterface
                     application/vnd.apple.mpegurl m3u8;
                     video/mp2t ts;
                 }
-                
+
                 location ~ \.m3u8$ {
                     access_log {$hlsLogPath} hls_json;
                 }
-                
+
                 add_header 'Access-Control-Allow-Origin' '*';
                 add_header 'Cache-Control' 'no-cache';
-                
+
                 alias {$hlsFolder};
                 try_files \$uri =404;
             }


### PR DESCRIPTION
**Fixes issue:**
Fixes #6304

**Proposed changes:**
Due to Icecast-KH including a special cache busting mechanism for Safari we get a `302` redirect to `$host/<mount>?&_ic2=xxxxxxxx` back when opening a stream URL.

In our nginx proxy block we set the `Host` proxy header to `localhost:8000` so Icecast was redirecting to `localhost:8000/<mount>`.

I haven't found a simple way to make it redirect to `/listen/<station>` OR `/radio/<port>` depending on which is accessed so I opted for the more sensible default of setting the header to `$host/listen/<station>`.

This means when a Safari user is accessing a stream for example via `/radio/8000` they get redirected to `/listen/<station>` and the stream starts playing correctly.
