### PR TITLE
Added dvh for public pages

### DIFF
--- a/frontend/scss/azuracast/pages/_public.scss
+++ b/frontend/scss/azuracast/pages/_public.scss
@@ -3,6 +3,7 @@
 body.page-minimal {
   .public-page {
     height: 100vh;
+    height: 100dvh;
 
     display: -ms-flexbox;
     display: -webkit-flex;


### PR DESCRIPTION
**Proposed changes:**
Adding dynamic viewport height for public pages as web browsers have started [supporting](https://caniuse.com/?search=dvh) it. This will make the footer on public pages visible by default on mobile devices.

![azura](https://github.com/AzuraCast/AzuraCast/assets/61133303/f0fd566b-0932-42da-8527-5b47370c9269)

In case the browser is not supported `height: 100vh;` will be used as a fallback. 


<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6387"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

