### PR TITLE
Add libjemalloc2 to liquidsoap dependencies

### DIFF
--- a/util/docker/stations/setup/liquidsoap.sh
+++ b/util/docker/stations/setup/liquidsoap.sh
@@ -8,7 +8,7 @@ apt-get install -y --no-install-recommends \
     libsdl2-image-2.0-0 libsdl2-ttf-2.0-0 libsoundtouch1 libxpm4 \
     libasound2 libavcodec58 libavdevice58 libavfilter7 libavformat58 libavutil56 \
     libpulse0 libsamplerate0 libswresample3 libswscale5 libtag1v5 \
-    libsrt1.4-openssl bubblewrap ffmpeg liblilv-0-0
+    libsrt1.4-openssl bubblewrap ffmpeg liblilv-0-0 libjemalloc2
 
 # Audio Post-processing
 apt-get install -y --no-install-recommends ladspa-sdk


### PR DESCRIPTION
**Fixes issue:**
Fixes failing build

**Proposed changes:**
Adds the missing lib that is now required in LS


<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6389"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

