### PR TITLE
Remove unneeded option from format config

### DIFF
--- a/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -232,13 +232,13 @@ final class ConfigWriter implements EventSubscriberInterface
             # Track live transition for crossfades.
             to_live = ref(false)
             ignore(to_live)
-            
+
             # Reimplement LS's now-deprecated drop_metadata function.
             def drop_metadata(~id=null(), s)
                 let {metadata=_, ...tracks} = source.tracks(s)
                 source(id=id, tracks)
             end
-            
+
             # Transport for HTTPS outputs.
             https_transport = http.transport.ssl()
             ignore(https_transport)
@@ -1362,7 +1362,7 @@ final class ConfigWriter implements EventSubscriberInterface
                 return '%ogg(%flac(samplerate=48000, channels=2, compression=4, bits_per_sample=24))';
 
             case StreamFormats::Mp3:
-                return '%mp3(samplerate=44100, stereo=true, bitrate=' . $bitrate . ', id3v2=true)';
+                return '%mp3(samplerate=44100, stereo=true, bitrate=' . $bitrate . ')';
         }
 
         throw new RuntimeException(sprintf('Unsupported stream format: %s', $format->value));


### PR DESCRIPTION
**Fixes issue:**
X

**Proposed changes:**
While investigating a different thing with the LS team it was pointed out that we don't need the `id3v2` option on the mp3 format since it is handled via the icy metadata.


<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6397"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

