### PR TITLE
Update LS to version with lower memory usage

### DIFF
--- a/util/docker/stations/setup/liquidsoap.sh
+++ b/util/docker/stations/setup/liquidsoap.sh
@@ -20,7 +20,7 @@ if [[ "$(uname -m)" = "aarch64" ]]; then
 fi
 
 # wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap/releases/download/v2.1.4/liquidsoap_2.1.4-ubuntu-jammy-1_${ARCHITECTURE}.deb"
-wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.2.x/liquidsoap-66914f5_2.2.0-ubuntu-jammy-1_${ARCHITECTURE}.deb"
+wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.2.x/liquidsoap-b0db4b0_2.2.0-ubuntu-jammy-1_${ARCHITECTURE}.deb"
 
 dpkg -i /tmp/liquidsoap.deb
 apt-get install -y -f --no-install-recommends


### PR DESCRIPTION
**Fixes issue:**
X

**Proposed changes:**
After extensive testing and tuning together with the LS team via Discord we've reached a point where the latest Rolling Release 2.2.0 of LS is using much less memory again.

This PR brings us to that LS version.


<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6401"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

