### PR TITLE
Fix RAM usage calculation error

### DIFF
--- a/src/Controller/Api/Admin/ServerStatsAction.php
+++ b/src/Controller/Api/Admin/ServerStatsAction.php
@@ -150,14 +150,20 @@ final class ServerStatsAction implements SingleActionInterface
                 'bytes' => [
                     'total' => $memoryStats->memTotal,
                     'free' => $memoryStats->memFree,
-                    'cached' => $memoryStats->cached,
+                    'buffers' => $memoryStats->buffers,
+                    'cached' => $memoryStats->getCachedMemory(),
+                    'sReclaimable' => $memoryStats->sReclaimable,
+                    'shmem' => $memoryStats->shmem,
                     'used' => $memoryStats->getUsedMemory(),
                 ],
                 'readable' => [
-                    'total' => Quota::getReadableSize($memoryStats->memTotal),
-                    'free' => Quota::getReadableSize($memoryStats->memFree),
-                    'cached' => Quota::getReadableSize($memoryStats->cached),
-                    'used' => Quota::getReadableSize($memoryStats->getUsedMemory()),
+                    'total' => Quota::getReadableSize($memoryStats->memTotal, 2),
+                    'free' => Quota::getReadableSize($memoryStats->memFree, 2),
+                    'buffers' => Quota::getReadableSize($memoryStats->buffers, 2),
+                    'cached' => Quota::getReadableSize($memoryStats->getCachedMemory(), 2),
+                    'sReclaimable' => Quota::getReadableSize($memoryStats->sReclaimable, 2),
+                    'shmem' => Quota::getReadableSize($memoryStats->shmem, 2),
+                    'used' => Quota::getReadableSize($memoryStats->getUsedMemory(), 2),
                 ],
             ],
             'swap' => [
@@ -167,9 +173,9 @@ final class ServerStatsAction implements SingleActionInterface
                     'used' => $memoryStats->getUsedSwap(),
                 ],
                 'readable' => [
-                    'total' => Quota::getReadableSize($memoryStats->swapTotal),
-                    'free' => Quota::getReadableSize($memoryStats->swapFree),
-                    'used' => Quota::getReadableSize($memoryStats->getUsedSwap()),
+                    'total' => Quota::getReadableSize($memoryStats->swapTotal, 2),
+                    'free' => Quota::getReadableSize($memoryStats->swapFree, 2),
+                    'used' => Quota::getReadableSize($memoryStats->getUsedSwap(), 2),
                 ],
             ],
             'disk' => [

--- a/src/Radio/Quota.php
+++ b/src/Radio/Quota.php
@@ -31,7 +31,7 @@ final class Quota
         $factor = (int)floor((strlen($bytesStr) - 1) / 3);
 
         if (isset($size[$factor])) {
-            $byteDivisor = Math\BigInteger::of(1000)->power($factor);
+            $byteDivisor = Math\BigInteger::of(1024)->power($factor);
             $sizeString = $bytes->toBigDecimal()
                 ->dividedBy($byteDivisor, $decimals, Math\RoundingMode::HALF_DOWN);
 
@@ -66,7 +66,7 @@ final class Quota
                 haystack: 'bkmgtpezy',
                 needle: $unit[0]
             ) ?: 0;
-            $byteMultiplier = Math\BigInteger::of(1000)->power($bytePower);
+            $byteMultiplier = Math\BigInteger::of(1024)->power($bytePower);
 
             return Math\BigDecimal::of($size)
                 ->multipliedBy($byteMultiplier)


### PR DESCRIPTION
**Fixes issue:**
X

**Proposed changes:**
I've looked into why our RAM usage panel and `htop` show so different values (see [this thread](https://github.com/AzuraCast/AzuraCast/discussions/6406#discussioncomment-6397734)) and compared our calculation to the C code of htop and implemented 3 fixes:

- Consider `buffers`, `sReclaimable` & `shmem` in calculation for RAM usage
- Set number base from `1000` to `1024` in `Quota.php`
- Increased decimals in readable values to 2 places to reduce rounding differences

I changed the number base to 1024 because all places that I looked at in the CLI (namely `df`, `htop`, `du`) showed different values than we do and after changing the base they started agreeing.

I didn't notice any place in de UI that looked wrong now so I think we were already expecting those to be base `1024` although we really calculated based on `1000`.


<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6412"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

