### PR TITLE
Make max. concurrent NP processes configurable

### DIFF
--- a/azuracast.sample.env
+++ b/azuracast.sample.env
@@ -137,6 +137,17 @@ MYSQL_RANDOM_ROOT_PASSWORD=yes
 # The maximum execution time (and lock timeout) for the 1-hour synchronization task.
 # SYNC_LONG_EXECUTION_TIME=1800
 
+# The delay between Now Playing checks for every station.
+# Decrease for more frequent checks at the expense of performance;
+# increase for less frequent checks but better performance (for large installations).
+# Default: 0
+# NOW_PLAYING_DELAY_TIME=0
+
+# The maximum number of concurrent processes for now playing updates.
+# Increasing this can help reduce the latency between updates now playing updates on large installations.
+# Default: 5
+# NOW_PLAYING_MAX_CONCURRENT_PROCESSES=5
+
 # Maximum number of PHP-FPM worker processes to spawn.
 # PHP_FPM_MAX_CHILDREN=5
 

--- a/src/Console/Command/Sync/NowPlayingCommand.php
+++ b/src/Console/Command/Sync/NowPlayingCommand.php
@@ -25,8 +25,6 @@ final class NowPlayingCommand extends AbstractSyncCommand
     use EntityManagerAwareTrait;
     use SettingsAwareTrait;
 
-    public final const MAX_CONCURRENT_PROCESSES = 5;
-
     public function __construct(
         private readonly NowPlayingCache $nowPlayingCache,
         LockFactory $lockFactory,
@@ -72,7 +70,7 @@ final class NowPlayingCommand extends AbstractSyncCommand
             $numProcesses = count($this->processes);
 
             if (
-                $numProcesses < self::MAX_CONCURRENT_PROCESSES
+                $numProcesses < $this->environment->getNowPlayingMaxConcurrentProcesses()
                 && time() < $threshold - 5
             ) {
                 // Ensure a process is running for every active station.
@@ -80,7 +78,7 @@ final class NowPlayingCommand extends AbstractSyncCommand
                 $npThreshold = time() - $npDelay - random_int(0, 5);
 
                 foreach ($this->getStationsToRun($npThreshold) as $shortName) {
-                    if (count($this->processes) >= self::MAX_CONCURRENT_PROCESSES) {
+                    if (count($this->processes) >= $this->environment->getNowPlayingMaxConcurrentProcesses()) {
                         break;
                     }
                     if (isset($this->processes[$shortName])) {

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -44,6 +44,7 @@ final class Environment
     public const SYNC_SHORT_EXECUTION_TIME = 'SYNC_SHORT_EXECUTION_TIME';
     public const SYNC_LONG_EXECUTION_TIME = 'SYNC_LONG_EXECUTION_TIME';
     public const NOW_PLAYING_DELAY_TIME = 'NOW_PLAYING_DELAY_TIME';
+    public const NOW_PLAYING_MAX_CONCURRENT_PROCESSES = 'NOW_PLAYING_MAX_CONCURRENT_PROCESSES';
 
     public const LOG_LEVEL = 'LOG_LEVEL';
     public const SHOW_DETAILED_ERRORS = 'SHOW_DETAILED_ERRORS';
@@ -84,6 +85,7 @@ final class Environment
         self::SYNC_SHORT_EXECUTION_TIME => 600,
         self::SYNC_LONG_EXECUTION_TIME => 1800,
         self::NOW_PLAYING_DELAY_TIME => 0,
+        self::NOW_PLAYING_MAX_CONCURRENT_PROCESSES => 5,
 
         self::PROFILING_EXTENSION_ENABLED => 0,
         self::PROFILING_EXTENSION_ALWAYS_ON => 0,
@@ -265,6 +267,13 @@ final class Environment
     {
         return (int)(
             $this->data[self::NOW_PLAYING_DELAY_TIME] ?? $this->defaults[self::NOW_PLAYING_DELAY_TIME]
+        );
+    }
+
+    public function getNowPlayingMaxConcurrentProcesses(): int
+    {
+        return (int)(
+            $this->data[self::NOW_PLAYING_MAX_CONCURRENT_PROCESSES] ?? $this->defaults[self::NOW_PLAYING_MAX_CONCURRENT_PROCESSES]
         );
     }
 

--- a/src/Installer/EnvFiles/AzuraCastEnvFile.php
+++ b/src/Installer/EnvFiles/AzuraCastEnvFile.php
@@ -218,6 +218,12 @@ final class AzuraCastEnvFile extends AbstractEnvFile
                         'The delay between Now Playing checks for every station. Decrease for more frequent checks at the expense of performance; increase for less frequent checks but better performance (for large installations).'
                     ),
                 ],
+                Environment::NOW_PLAYING_MAX_CONCURRENT_PROCESSES => [
+                    'name' => __('Now Playing Max Concurrent Processes'),
+                    'description' => __(
+                        'The maximum number of concurrent processes for now playing updates. Increasing this can help reduce the latency between updates now playing updates on large installations.'
+                    ),
+                ],
                 'PHP_FPM_MAX_CHILDREN' => [
                     'name' => __('Maximum PHP-FPM Worker Processes'),
                     'default' => 5,


### PR DESCRIPTION
**Fixes issue:**
Related to https://github.com/AzuraCast/AzuraCast/issues/6426

**Proposed changes:**
I've added a new env var to control the max. number of concurrent processes for the now playing update so that large installations have the possibility to manually override our default of 5 when they see that it can't keep up with the amount of stations.


<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6427"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

