### PR TITLE
Fix #6436 - quoted URL stub bug in proxy_set_header Host for listen proxy

### DIFF
--- a/src/Nginx/ConfigWriter.php
+++ b/src/Nginx/ConfigWriter.php
@@ -35,16 +35,17 @@ final class ConfigWriter implements EventSubscriberInterface
             return;
         }
 
-        $listenBaseUrl = preg_quote(CustomUrls::getListenUrl($station), null);
+        $listenBaseUrl = CustomUrls::getListenUrl($station);
+        $listenBaseUrlForRegex = preg_quote($listenBaseUrl, null);
         $port = $station->getFrontendConfig()->getPort();
 
         $event->appendBlock(
             <<<NGINX
-            location ~ ^({$listenBaseUrl}|/radio/{$port})\$ {
+            location ~ ^({$listenBaseUrlForRegex}|/radio/{$port})\$ {
                 return 302 \$uri/;
             }
 
-            location ~ ^({$listenBaseUrl}|/radio/{$port})/(.*)\$ {
+            location ~ ^({$listenBaseUrlForRegex}|/radio/{$port})/(.*)\$ {
                 include proxy_params;
 
                 proxy_intercept_errors    on;


### PR DESCRIPTION
**Fixes issue:**
Fixes #6436

**Proposed changes:**
For the listen proxy nginx config we shouldn't use the quoted base url that we use in the location regex but the raw one to.
Using the quoted one will cause the redirect that Icecast does for Safari to end up in a 404 not found.


<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6438"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

