### PR TITLE
Add extra limits to RateLimitFields.vue

### DIFF
--- a/frontend/vue/components/Stations/Webhooks/Form/Common/RateLimitFields.vue
+++ b/frontend/vue/components/Stations/Webhooks/Form/Common/RateLimitFields.vue
@@ -42,6 +42,7 @@ const {$gettext, interpolate} = useTranslate();
 
 const langSeconds = $gettext('%{ seconds } seconds');
 const langMinutes = $gettext('%{ minutes } minutes');
+const langHours   = $gettext('%{ hours } hours');
 
 const rateLimitOptions = [
     {
@@ -83,6 +84,22 @@ const rateLimitOptions = [
     {
         text: interpolate(langMinutes, {minutes: 60}),
         value: 3600,
-    }
+    },
+    {
+        text: interpolate(langHours, {hours: 2}),
+        value: 7200,
+    },
+    {
+        text: interpolate(langHours, {hours: 3}),
+        value: 10800,
+    },
+    {
+        text: interpolate(langHours, {hours: 6}),
+        value: 21600,
+    },
+    {
+        text: interpolate(langHours, {hours: 12}),
+        value: 43200,
+     }
 ];
 </script>


### PR DESCRIPTION
2 hours, 3 hours, 6 hours, 12 hours

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Proposed changes:**
Add extra delays for the rate limiting of webhooks, currently options only limit upto 60 minutes, but when posting to some services like mastodon hosts prefer less frequently, so I have added 2 hours, 3 hours, 6 hours and 12 hours to help prevent an account being muted for spamming.

<a href="https://gitpod.io/#https://github.com/AzuraCast/AzuraCast/pull/6604"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

