### PR TITLE
Fix for issues #6918 and #6956

### DIFF
--- a/src/Service/Acme.php
+++ b/src/Service/Acme.php
@@ -131,7 +131,7 @@ final class Acme
             && empty(array_diff($domains, $acme->getSAN('file://' . $acmeDir . '/acme.crt')))
             && $acme->getRemainingDays('file://' . $acmeDir . '/acme.crt') > self::THRESHOLD_DAYS
         ) {
-            if (!$this->checkLinks($acmeDir)){
+            if (!$this->checkLinks($acmeDir)) {
                 $this->reloadServices();
             }
 
@@ -172,7 +172,7 @@ final class Acme
         $this->checkLinks($acmeDir);
 
         $this->reloadServices();
-        
+
         $this->logger->notice('ACME certificate process successful.');
     }
 

--- a/src/Service/Acme.php
+++ b/src/Service/Acme.php
@@ -131,7 +131,9 @@ final class Acme
             && empty(array_diff($domains, $acme->getSAN('file://' . $acmeDir . '/acme.crt')))
             && $acme->getRemainingDays('file://' . $acmeDir . '/acme.crt') > self::THRESHOLD_DAYS
         ) {
-            $this->checkLinks($acmeDir);
+            if (!$this->checkLinks($acmeDir)){
+                $this->reloadServices();
+            }
 
             throw new RuntimeException('Certificate does not need renewal.');
         }
@@ -169,10 +171,12 @@ final class Acme
         // Symlink to the shared SSL cert.
         $this->checkLinks($acmeDir);
 
+        $this->reloadServices();
+        
         $this->logger->notice('ACME certificate process successful.');
     }
 
-    private function checkLinks(string $acmeDir): void
+    private function checkLinks(string $acmeDir): bool
     {
         $fs = new Filesystem();
 
@@ -180,7 +184,7 @@ final class Acme
             $fs->readlink($acmeDir . '/ssl.crt', true) === $acmeDir . '/acme.crt'
             && $fs->readlink($acmeDir . '/ssl.key', true) === $acmeDir . '/acme.key'
         ) {
-            return;
+            return true;
         }
 
         $fs->remove([
@@ -191,7 +195,7 @@ final class Acme
         $fs->symlink($acmeDir . '/acme.crt', $acmeDir . '/ssl.crt');
         $fs->symlink($acmeDir . '/acme.key', $acmeDir . '/ssl.key');
 
-        $this->reloadServices();
+        return false;
     }
 
     private function reloadServices(): void


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
#6918 and #6956
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
- call to `reloadServices` was missing after renewal
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->

In case of renewal (where the symlinks are already present) the `checkLinks` method did not call `reloadServices`. So the certificate got successfully renewed but the webserver reload was missing.

I rearranged the code to make sure `reloadServices` is called on renewal and when the certificate is still valid but the symlinks are missing.

This was introduced by commit 5acf5d7f2ae5e50ecbd432753a895dddfc58e5e0
