### PR TITLE
RadioReg WebHook integration

### DIFF
--- a/frontend/src/components/Stations/Webhooks/EditModal.vue
+++ b/frontend/src/components/Stations/Webhooks/EditModal.vue
@@ -50,6 +50,7 @@ import {getTriggers, WebhookType} from "~/entities/Webhooks";
 import Tabs from "~/components/Common/Tabs.vue";
 import RadioDe from "~/components/Stations/Webhooks/Form/RadioDe.vue";
 import GetMeRadio from "~/components/Stations/Webhooks/Form/GetMeRadio.vue";
+import RadioReg from "~/components/Stations/Webhooks/Form/RadioReg.vue";
 
 const props = defineProps({
     ...baseEditModalProps,
@@ -80,6 +81,7 @@ const webhookComponents = {
     [WebhookType.Email]: Email,
     [WebhookType.TuneIn]: Tunein,
     [WebhookType.RadioDe]: RadioDe,
+    [WebhookType.RadioReg]: RadioReg,
     [WebhookType.GetMeRadio]: GetMeRadio,
     [WebhookType.Discord]: Discord,
     [WebhookType.Telegram]: Telegram,

--- a/frontend/src/components/Stations/Webhooks/Form/RadioReg.vue
+++ b/frontend/src/components/Stations/Webhooks/Form/RadioReg.vue
@@ -1,0 +1,60 @@
+<template>
+    <tab
+        :label="title"
+        :item-header-class="tabClass"
+    >
+        <div class="row g-3">
+            <form-group-field
+                id="form_config_webhookurl"
+                class="col-md-12"
+                :field="v$.config.broadcastsubdomain"
+                :label="$gettext('RadioReg Webhook URL')"
+            />
+
+            <form-group-field
+                id="form_config_apikey"
+                class="col-md-6"
+                :field="v$.config.apikey"
+                :label="$gettext('RadioRed Organization API Key')"
+            />
+        </div>
+    </tab>
+</template>
+
+<script setup lang="ts">
+import FormGroupField from "~/components/Form/FormGroupField.vue";
+import {useVModel} from "@vueuse/core";
+import {useVuelidateOnFormTab} from "~/functions/useVuelidateOnFormTab";
+import {required} from "@vuelidate/validators";
+import Tab from "~/components/Common/Tab.vue";
+
+const props = defineProps({
+    title: {
+        type: String,
+        required: true
+    },
+    form: {
+        type: Object,
+        required: true
+    }
+});
+
+const emit = defineEmits(['update:form']);
+const form = useVModel(props, 'form', emit);
+
+const {v$, tabClass} = useVuelidateOnFormTab(
+    {
+        config: {
+            webhookurl: {required},
+            apikey: {required}
+        }
+    },
+    form,
+    {
+        config: {
+            webhookurl: '',
+            apikey: ''
+        }
+    }
+);
+</script>

--- a/frontend/src/components/Stations/Webhooks/Form/TypeSelect.vue
+++ b/frontend/src/components/Stations/Webhooks/Form/TypeSelect.vue
@@ -26,6 +26,7 @@
                 :types="buildTypeInfo([
                     WebhookType.TuneIn,
                     WebhookType.RadioDe,
+                    WebhookType.RadioReg,
                     WebhookType.GetMeRadio
                 ])"
                 @select="selectType"

--- a/frontend/src/entities/Webhooks.ts
+++ b/frontend/src/entities/Webhooks.ts
@@ -75,6 +75,7 @@ export enum WebhookType {
     Email = 'email',
     TuneIn = 'tunein',
     RadioDe = 'radiode',
+    RadioReg = 'radioreg',
     GetMeRadio = 'getmeradio',
     Discord = 'discord',
     Telegram = 'telegram',
@@ -102,6 +103,10 @@ export function useTypeDetails() {
         [WebhookType.RadioDe]: {
             title: $gettext('Radio.de'),
             description: $gettext('Send song metadata changes to %{service}.', {service: 'Radio.de'})
+        },
+        [WebhookType.RadioReg]: {
+            title: $gettext('RadioReg.net'),
+            description: $gettext('Send song metadata changes to %{service}.', {service: 'RadioReg'})
         },
         [WebhookType.GetMeRadio]: {
             title: $gettext('GetMeRadio'),
@@ -134,6 +139,7 @@ export function getTriggers(type: WebhookType) {
     switch(type) {
         case WebhookType.TuneIn:
         case WebhookType.RadioDe:
+        case WebhookType.RadioReg:
         case WebhookType.GetMeRadio:
         case WebhookType.GoogleAnalyticsV4:
         case WebhookType.MatomoAnalytics:

--- a/src/Webhook/Connector/RadioReg.php
+++ b/src/Webhook/Connector/RadioReg.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Webhook\Connector;
+
+use App\Entity\Api\NowPlaying\NowPlaying;
+use App\Entity\Station;
+use App\Entity\StationWebhook;
+use App\Webhook\Enums\WebhookTriggers;
+
+final class RadioReg extends AbstractConnector
+{
+    protected function webhookShouldTrigger(StationWebhook $webhook, array $triggers = []): bool
+    {
+        return in_array(WebhookTriggers::SongChanged->value, $triggers, true);
+    }
+
+    /**
+     * @optischa
+     */
+    public function dispatch(
+        Station $station,
+        StationWebhook $webhook,
+        NowPlaying $np,
+        array $triggers
+    ): void {
+        $config = $webhook->getConfig();
+
+        if (
+            empty($config['apikey']) || empty($config['webhookurl'])
+        ) {
+            throw $this->incompleteConfigException($webhook);
+        }
+
+        $this->logger->debug('Dispatching RadioReg API call...');
+
+        $messageBody = [
+            'title' => $np->now_playing?->song?->title,
+            'artist' => $np->now_playing?->song?->artist,
+        ];
+
+        $response = $this->httpClient->post(
+            $config['webhookurl'],
+            [
+                'query' => $messageBody,
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'X-API-KEY' => $config['apikey'],
+                ],
+            ],
+        );
+
+        $this->logHttpResponse($webhook, $response, $messageBody);
+    }
+}

--- a/src/Webhook/Enums/WebhookTypes.php
+++ b/src/Webhook/Enums/WebhookTypes.php
@@ -12,6 +12,7 @@ use App\Webhook\Connector\GoogleAnalyticsV4;
 use App\Webhook\Connector\Mastodon;
 use App\Webhook\Connector\MatomoAnalytics;
 use App\Webhook\Connector\RadioDe;
+use App\Webhook\Connector\RadioReg;
 use App\Webhook\Connector\Telegram;
 use App\Webhook\Connector\TuneIn;
 
@@ -22,6 +23,7 @@ enum WebhookTypes: string
 
     case TuneIn = 'tunein';
     case RadioDe = 'radiode';
+    case RadioReg = 'radioreg';
     case GetMeRadio = 'getmeradio';
 
     case Discord = 'discord';
@@ -44,6 +46,7 @@ enum WebhookTypes: string
             self::Generic => Generic::class,
             self::Email => Email::class,
             self::TuneIn => TuneIn::class,
+            self::RadioReg => RadioReg::class,
             self::RadioDe => RadioDe::class,
             self::GetMeRadio => GetMeRadio::class,
             self::Discord => Discord::class,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
This proposal outlines the pre-release implementation of a Webhook functionality for the upcoming Radio Registry website. The incorporation of this feature aims to ensure its availability upon the website's initial release, providing broadcasters with immediate access to streamlined stream metadata management. This proactive approach aligns with our commitment to delivering a comprehensive and user-friendly platform from the outset.

For further questions please contact @Optischa on Discord or join the Discord <a>http://dc.radioreg.net</a>