### PR TITLE
Chown /var/azuracast folder to match updated puid/guid

### DIFF
--- a/util/docker/web/startup_scripts/00_setup_user.sh
+++ b/util/docker/web/startup_scripts/00_setup_user.sh
@@ -11,3 +11,5 @@ usermod -o -u "$PUID" azuracast
 
 echo "Docker 'azuracast' User UID: $(id -u azuracast)"
 echo "Docker 'azuracast' User GID: $(id -g azuracast)"
+
+chown -R azuracast:azuracast /var/azuracast


### PR DESCRIPTION
**Fixes issue:**
n/a

**Proposed changes:**
If the azuracast user and group ids are changed as the result of the AZURACAST_(P|G)UID environment variables, the azuracast user no longer owns the `/var/azuracast` directory, causing permissions issues. Here I have recursively updated ownership of the directory after the new ids have been set.

Open issue: It's possible the user may have bind mounted their own directories into `/var/azuracast`, which would change ownership of their files if they did not make the mounts read-only - this could be mitigated by not recursively chowning `/var/azuracast`, and recursively chowning children of that directory that are more likely to be managed by azuracast only (stations, backups, storage, etc)
