### PR TITLE
Fixes #7202 - Include podcasts, recordings & uploaded custom assets in backups

### DIFF
--- a/backend/src/Console/Command/Backup/BackupCommand.php
+++ b/backend/src/Console/Command/Backup/BackupCommand.php
@@ -117,6 +117,9 @@ final class BackupCommand extends AbstractDatabaseCommand
         $filesToBackup[] = $pathDbDump;
         $io->newLine();
 
+        // Backup uploaded custom assets
+        $filesToBackup[] = $this->environment->getUploadsDirectory();
+
         // Include station media if specified.
         if ($includeMedia) {
             $stations = $this->em->createQuery(
@@ -130,6 +133,16 @@ final class BackupCommand extends AbstractDatabaseCommand
                 $mediaAdapter = $station->getMediaStorageLocation();
                 if ($mediaAdapter->isLocal()) {
                     $filesToBackup[] = $mediaAdapter->getPath();
+                }
+
+                $podcastsAdapter = $station->getPodcastsStorageLocation();
+                if ($podcastsAdapter->isLocal()) {
+                    $filesToBackup[] = $podcastsAdapter->getPath();
+                }
+
+                $recordingsAdapter = $station->getRecordingsStorageLocation();
+                if ($recordingsAdapter->isLocal()) {
+                    $filesToBackup[] = $recordingsAdapter->getPath();
                 }
             }
         }


### PR DESCRIPTION
**Fixes issue:**
Fixes #7202 

**Proposed changes:**
This PR adds the directories for:
- uploads
- recordings
- podcasts

to the list of files to backup in the `BackupCommand`.

@BusterNeece I didn't see any special handling in the `RestoreCommand` for the media location so I'm assuming that this is already automatically handled in the unpacking process.
