### PR TITLE
Fixes error from #7201 - Don't try to process empty files in CheckMediaTask

### DIFF
--- a/backend/src/Sync/Task/CheckMediaTask.php
+++ b/backend/src/Sync/Task/CheckMediaTask.php
@@ -118,6 +118,10 @@ final class CheckMediaTask extends AbstractTask
                 continue;
             }
 
+            if ($size === 0) {
+                continue;
+            }
+
             if (MimeType::isPathProcessable($file->path())) {
                 $pathHash = md5($file->path());
                 $musicFiles[$pathHash] = [


### PR DESCRIPTION
**Fixes issue:**
Fixes the error related to empty files from #7201

**Proposed changes:**
This PR let's the `CheckMediaTask` skip processing for files that are 0 byte 
