### PR TITLE
Use %ffmpeg encoder in LS for opus & vorbis to enable in-stream metadata again

### DIFF
--- a/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -1499,10 +1499,10 @@ final class ConfigWriter implements EventSubscriberInterface
                 return '%fdkaac(channels=2, samplerate=44100, bitrate=' . $bitrate . ', afterburner=' . $afterburner . ', aot="' . $aot . '", sbr_mode=true)';
 
             case StreamFormats::Ogg:
-                return '%vorbis.cbr(samplerate=44100, channels=2, bitrate=' . $bitrate . ')';
+                return '%ffmpeg(format="ogg", %audio(codec="libvorbis", samplerate=48000, b="' . $bitrate . 'k", channels=2))';
 
             case StreamFormats::Opus:
-                return '%opus(samplerate=48000, bitrate=' . $bitrate . ', vbr="constrained", application="audio", channels=2, signal="music", complexity=10, max_bandwidth="full_band")';
+                return '%ffmpeg(format="ogg", %audio(codec="libopus", samplerate=48000, b="' . $bitrate . 'k", vbr="constrained", application="audio", channels=2, compression_level=10, cutoff=20000))';
 
             case StreamFormats::Flac:
                 return '%ogg(%flac(samplerate=48000, channels=2, compression=4, bits_per_sample=24))';

--- a/backend/src/Radio/Enums/StreamFormats.php
+++ b/backend/src/Radio/Enums/StreamFormats.php
@@ -32,7 +32,7 @@ enum StreamFormats: string
     public function sendIcyMetadata(): bool
     {
         return match ($this) {
-            self::Opus, self::Flac => true,
+            self::Flac => true,
             default => false,
         };
     }


### PR DESCRIPTION
**Fixes issue:**
Fixes #7240

**Proposed changes:**
This PR switches the encoder used for the `ogg/opus` and `ogg/vorbis` format over to use the `%ffmpeg` operator in LS which fixes an issue that lead some players (notably browsers) to stop playback on song transitions when in-stream metadata was provided which we circumvented until now by setting `send_icy_metadata=true` which in turn removed all in-stream metadata from those streaming formats.

With this PR the in-stream metadata is back and does not break song transitions anymore.

On the mentioned issue thread I'll post my analysis of what happens when playing those streams in different players.