### PR TITLE
LS ConfigWriter.php - Move Amplify/Replaygain past CUSTOM_PRE_FADE

### DIFF
--- a/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -783,24 +783,9 @@ final class ConfigWriter implements EventSubscriberInterface
             end
 
             add_skip_command(radio)
-
-            # Apply amplification metadata (if supplied)
-            radio = amplify(override="liq_amplify", 1., radio)
             LIQ
         );
 
-        // Replaygain metadata
-        $settings = $event->getBackendConfig();
-
-        if ($settings->useReplayGain()) {
-            $event->appendBlock(
-                <<<LIQ
-                # Replaygain Metadata
-                enable_replaygain_metadata()
-                radio = replaygain(radio)
-                LIQ
-            );
-        }
     }
 
     /**
@@ -918,6 +903,30 @@ final class ConfigWriter implements EventSubscriberInterface
 
         // Write pre-crossfade section.
         $this->writeCustomConfigurationSection($event, StationBackendConfiguration::CUSTOM_PRE_FADE);
+
+        // Need to move amplify & Replaygain after CUSTOM_PRE_FADE
+        // in case user has defined own fallbacks/switches
+
+        // Amplify
+        $event->appendBlock(
+            <<<LIQ
+            # Apply amplification metadata (if supplied)
+            radio = amplify(override="liq_amplify", 1., radio)
+            LIQ
+        );
+
+        // Replaygain metadata
+        $settings = $event->getBackendConfig();
+
+        if ($settings->useReplayGain()) {
+            $event->appendBlock(
+                <<<LIQ
+                # Replaygain Metadata
+                enable_replaygain_metadata()
+                radio = replaygain(radio)
+                LIQ
+            );
+        }
 
         // Show metadata, used with and without Autocue
         $showMetaFunc = <<<LS


### PR DESCRIPTION
This change moves Amplify/Replaygain further down, past the CUSTOM_PRE_FADE input block.

In case users wish to define their own fallbacks/switches in CUSTOM_PRE_FADE, this ensures proper amplification.

Use cases: Exactly timed advanced playlists, ads, news, etc. and any user-defined fallbacks and switches.

Tested with/without Autocue, with/without master_me, all Crossfade settings.

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
