### PR TITLE
Fix RadioRed typo and add RadioReg API key label and description

### DIFF
--- a/frontend/components/Stations/Webhooks/Form/RadioReg.vue
+++ b/frontend/components/Stations/Webhooks/Form/RadioReg.vue
@@ -9,13 +9,15 @@
                 class="col-md-12"
                 :field="v$.config.webhookurl"
                 :label="$gettext('RadioReg Webhook URL')"
+                :description="$gettext('Found under the settings page for the corresponding RadioReg station.')"
             />
 
             <form-group-field
                 id="form_config_apikey"
                 class="col-md-6"
                 :field="v$.config.apikey"
-                :label="$gettext('RadioRed Organization API Key')"
+                :label="$gettext('RadioReg Organization API Key')"
+                :description="$gettext('An API token is issued on a per-organization basis and are found on the org. settings page.')"
             />
         </div>
     </tab>


### PR DESCRIPTION
This pull request fixes the RadioRed typo and adds a label and description for the RadioReg API key field. The RadioReg Webhook URL field now has a description indicating where to find it in the settings page for the corresponding RadioReg station. The RadioReg Organization API Key field also has a description indicating that the API token is issued on a per-organization basis and can be found on the org. settings page within RadioReg.