### PR TITLE
Update ServicesTab.vue with additional email log information and link to System Logs page

### DIFF
--- a/frontend/components/Admin/Settings/ServicesTab.vue
+++ b/frontend/components/Admin/Settings/ServicesTab.vue
@@ -91,6 +91,14 @@
             </template>
             <template #description>
                 {{ $gettext('Used for "Forgot Password" functionality, web hooks and other functions.') }}
+                <br>
+                {{ $gettext('Mailer errors are logged at the Queue Worker Log in System Logs.') }}
+                <a
+                    href="/admin/logs"
+                    target="_blank"
+                >
+                    {{ $gettext('System Logs') }}
+                </a>
             </template>
 
             <div class="row g-3">


### PR DESCRIPTION
**Proposed changes:**
Let users know where to look to find Symfony's Mailer logs.
