### PR TITLE
Fix issue #7367 - Add overflow ellipsis

### DIFF
--- a/frontend/components/Common/SidebarMenu.vue
+++ b/frontend/components/Common/SidebarMenu.vue
@@ -51,21 +51,21 @@
                         <router-link
                             v-if="isRouteLink(item)"
                             :to="item.url"
-                            class="nav-link might-overflow ps-4 py-2"
+                            class="nav-link ps-4 py-2"
                             :class="getLinkClass(item)"
                             :title="item.title"
                         >
-                            {{ item.label }}
+                            <span class="might-overflow">{{ item.label }}</span>
                         </router-link>
                         <a
                             v-else
-                            class="nav-link might-overflow ps-4 py-2"
+                            class="nav-link ps-4 py-2"
                             :class="item.class"
                             :href="item.url"
                             :target="(item.external) ? '_blank' : ''"
                             :title="item.title"
                         >
-                            {{ item.label }}
+                            <span class="might-overflow">{{ item.label }}</span>
                             <icon
                                 v-if="item.external"
                                 class="sm ms-2"

--- a/frontend/components/Common/SidebarMenu.vue
+++ b/frontend/components/Common/SidebarMenu.vue
@@ -15,7 +15,7 @@
                     class="navdrawer-nav-icon"
                     :icon="category.icon"
                 />
-                {{ category.label }}
+                <span class="might-overflow">{{ category.label }}</span>
             </router-link>
             <a
                 v-else
@@ -27,7 +27,7 @@
                     class="navdrawer-nav-icon"
                     :icon="category.icon"
                 />
-                {{ category.label }}
+                <span class="might-overflow">{{ category.label }}</span>
                 <icon
                     v-if="category.external"
                     class="sm ms-2"
@@ -46,28 +46,24 @@
                     <li
                         v-for="item in category.items"
                         :key="item.key"
-                        class="nav-item overflow-hidden text-truncate"
+                        class="nav-item"
                     >
                         <router-link
                             v-if="isRouteLink(item)"
                             :to="item.url"
-                            class="nav-link d-block ps-4 py-2"
+                            class="nav-link might-overflow ps-4 py-2"
                             :class="getLinkClass(item)"
                             :title="item.title"
-                            data-bs-toggle="tooltip"
-                            data-bs-placement="top"
                         >
                             {{ item.label }}
                         </router-link>
                         <a
                             v-else
-                            class="nav-link d-block ps-4 py-2"
+                            class="nav-link might-overflow ps-4 py-2"
                             :class="item.class"
                             :href="item.url"
                             :target="(item.external) ? '_blank' : ''"
                             :title="item.title"
-                            data-bs-toggle="tooltip"
-                            data-bs-placement="top"
                         >
                             {{ item.label }}
                             <icon
@@ -141,3 +137,11 @@ const getCategoryLink = (item) => {
     return linkAttrs;
 }
 </script>
+
+<style lang="scss">
+@import "~/scss/_mixins.scss";
+
+.might-overflow {
+    @include might-overflow();
+}
+</style>

--- a/frontend/components/Common/SidebarMenu.vue
+++ b/frontend/components/Common/SidebarMenu.vue
@@ -46,23 +46,28 @@
                     <li
                         v-for="item in category.items"
                         :key="item.key"
-                        class="nav-item"
+                        class="nav-item overflow-hidden text-truncate"
                     >
                         <router-link
                             v-if="isRouteLink(item)"
                             :to="item.url"
-                            class="nav-link ps-4 py-2"
+                            class="nav-link d-block ps-4 py-2"
                             :class="getLinkClass(item)"
+                            :title="item.title"
+                            data-bs-toggle="tooltip"
+                            data-bs-placement="top"
                         >
                             {{ item.label }}
                         </router-link>
                         <a
                             v-else
-                            class="nav-link ps-4 py-2"
+                            class="nav-link d-block ps-4 py-2"
                             :class="item.class"
                             :href="item.url"
                             :target="(item.external) ? '_blank' : ''"
                             :title="item.title"
+                            data-bs-toggle="tooltip"
+                            data-bs-placement="top"
                         >
                             {{ item.label }}
                             <icon

--- a/frontend/scss/overrides/_icons.scss
+++ b/frontend/scss/overrides/_icons.scss
@@ -1,4 +1,5 @@
 .icon {
+  min-width: 1em;
   width: 1em;
   height: 1em;
   display: inline-block;


### PR DESCRIPTION
**Fixes issue:**
Fixes #7367

**Proposed changes:**
This PR aims to fix the problem with overlong link texts in the sidebar in other languages. For this I've added some classes on the nav items & links that add ellipsis when the text would overflow.

There is currently one problem that still needs to be fixed there, namely that I can't set the `title` attribute on `router-link` in order to get tooltips to work on those elements which is why this is a draft PR for now.
