### PR TITLE
OpenAPI.yml errors resolved

### DIFF
--- a/backend/src/Controller/Api/Stations/Art/DeleteArtAction.php
+++ b/backend/src/Controller/Api/Stations/Art/DeleteArtAction.php
@@ -22,7 +22,7 @@ use Psr\Http\Message\ResponseInterface;
     parameters: [
         new OA\Parameter(ref: OpenApi::REF_STATION_ID_REQUIRED),
         new OA\Parameter(
-            name: 'id',
+            name: 'media_id',
             description: 'Media ID',
             in: 'path',
             required: true,

--- a/backend/src/Controller/Api/Stations/Art/PostArtAction.php
+++ b/backend/src/Controller/Api/Stations/Art/PostArtAction.php
@@ -24,7 +24,7 @@ use Psr\Http\Message\ResponseInterface;
     parameters: [
         new OA\Parameter(ref: OpenApi::REF_STATION_ID_REQUIRED),
         new OA\Parameter(
-            name: 'id',
+            name: 'media_id',
             description: 'Media ID',
             in: 'path',
             required: true,

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -858,8 +858,10 @@ paths:
       description: 'Sets the album art for a track.'
       operationId: postMediaArt
       parameters:
-        - $ref: '#/components/parameters/StationIdRequired'
-        - name: media_id
+        -
+          $ref: '#/components/parameters/StationIdRequired'
+        -
+          name: media_id
           in: path
           description: 'Media ID'
           required: true
@@ -2754,7 +2756,7 @@ paths:
           name: action
           in: path
           description: 'The action to perform (start, stop, restart)'
-          required: true
+          required: false
           schema:
             type: string
             default: restart
@@ -2783,7 +2785,7 @@ paths:
           name: action
           in: path
           description: 'The action to perform (for all: start, stop, restart, skip, disconnect)'
-          required: true
+          required: false
           schema:
             type: string
             default: restart

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -858,10 +858,8 @@ paths:
       description: 'Sets the album art for a track.'
       operationId: postMediaArt
       parameters:
-        -
-          $ref: '#/components/parameters/StationIdRequired'
-        -
-          name: id
+        - $ref: '#/components/parameters/StationIdRequired'
+        - name: media_id
           in: path
           description: 'Media ID'
           required: true
@@ -893,7 +891,7 @@ paths:
         -
           $ref: '#/components/parameters/StationIdRequired'
         -
-          name: id
+          name: media_id
           in: path
           description: 'Media ID'
           required: true
@@ -2756,7 +2754,7 @@ paths:
           name: action
           in: path
           description: 'The action to perform (start, stop, restart)'
-          required: false
+          required: true
           schema:
             type: string
             default: restart
@@ -2785,7 +2783,7 @@ paths:
           name: action
           in: path
           description: 'The action to perform (for all: start, stop, restart, skip, disconnect)'
-          required: false
+          required: true
           schema:
             type: string
             default: restart


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->
As far as I know, no one has made an issue relating to this specific problem.

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
- Fixes OpenAPI structural errors and semantic errors.

These errors include:
```
Semantic error at paths./station/{station_id}/art/{media_id}
Declared path parameter "media_id" needs to be defined within every operation in the path (missing in "post", "delete"), or moved to the path-level parameters object
line 788

Semantic error at paths./station/{station_id}/art/{media_id}.post.parameters.1.name
Path parameter "id" must have the corresponding {id} segment in the "/station/{station_id}/art/{media_id}" path
line 814

Semantic error at paths./station/{station_id}/art/{media_id}.delete.parameters.1.name
Path parameter "id" must have the corresponding {id} segment in the "/station/{station_id}/art/{media_id}" path
line 841

Structural error at paths./station/{station_id}/frontend/{action}.post.parameters.1.required
should be equal to one of the allowed values
allowedValues: true
line 2530

Structural error at paths./station/{station_id}/backend/{action}.post.parameters.1.required
should be equal to one of the allowed values
allowedValues: true
line 2556
```

**Why?**
I'm working on an API client for Azuracast, and I was using OpenAPI Generator, which had given errors because of the syntax used in the openapi.yml file, after updating the YML, it has fixed the generator, which I believe Azuracast should have the updated YML.