### PR TITLE
Fixes auto DJ scheduling issues

### DIFF
--- a/backend/src/Entity/Migration/Version20240813181909.php
+++ b/backend/src/Entity/Migration/Version20240813181909.php
@@ -26,5 +26,4 @@ final class Version20240813181909 extends AbstractMigration
         $this->addSql('DROP INDEX IDX_277B005517421B18 ON station_queue');
         $this->addSql('ALTER TABLE station_queue DROP playlist_media_id');
     }
-
 }

--- a/backend/src/Entity/Migration/Version20240813181909.php
+++ b/backend/src/Entity/Migration/Version20240813181909.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20240813181909 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add playlist_media_id to station_queue';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE station_queue ADD playlist_media_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B005517421B18 FOREIGN KEY (playlist_media_id) REFERENCES station_playlist_media (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_277B005517421B18 ON station_queue (playlist_media_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE station_queue DROP FOREIGN KEY FK_277B005517421B18');
+        $this->addSql('DROP INDEX IDX_277B005517421B18 ON station_queue');
+        $this->addSql('ALTER TABLE station_queue DROP playlist_media_id');
+    }
+
+}

--- a/backend/src/Entity/Repository/StationQueueRepository.php
+++ b/backend/src/Entity/Repository/StationQueueRepository.php
@@ -211,11 +211,13 @@ final class StationQueueRepository extends AbstractStationBasedRepository
             ORDER BY sq.timestamp_played DESC
             DQL
         )->setParameter('playlist', $playlist)
-        ->setParameter('now', $now->getTimestamp())
-        ->setMaxResults(1)
-        ->getOneOrNullResult();
+            ->setParameter('now', $now->getTimestamp())
+            ->setMaxResults(1)
+            ->getOneOrNullResult();
+
         return null === $sq ? 0 : $sq->getTimestampPlayed();
     }
+
     public function getUnplayedBaseQuery(Station $station): QueryBuilder
     {
         return $this->getBaseQuery($station)

--- a/backend/src/Entity/Repository/StationQueueRepository.php
+++ b/backend/src/Entity/Repository/StationQueueRepository.php
@@ -90,26 +90,28 @@ final class StationQueueRepository extends AbstractStationBasedRepository
 
     public function isPlaylistRecentlyPlayed(
         StationPlaylist $playlist,
-        ?int $playPerSongs = null
+        ?int $playPerSongs = null,
+        int $belowId = null
     ): bool {
         $playPerSongs ??= $playlist->getPlayPerSongs();
-
-        $recentPlayedQuery = $this->em->createQuery(
-            <<<'DQL'
-                SELECT sq.playlist_id
-                FROM App\Entity\StationQueue sq
-                WHERE sq.station = :station
-                AND sq.playlist_id IS NOT NULL
-                AND (sq.playlist = :playlist OR sq.is_visible = 1)
-                ORDER BY sq.id DESC
-            DQL
-        )->setParameters([
-            'station' => $playlist->getStation(),
-            'playlist' => $playlist,
-        ])->setMaxResults($playPerSongs);
-
+        $recentPlayedQuery = $this->em->createQueryBuilder()
+        ->select('sq.playlist_id')
+        ->from(StationQueue::class, 'sq')
+        ->where('sq.station = :station')
+        ->andWhere('sq.playlist_id is not null')
+        ->andWhere('sq.playlist = :playlist OR sq.is_visible = 1');
+        if(null !== $belowId)
+        {
+            $recentPlayedQuery = $recentPlayedQuery->andWhere('sq.id < :bel')
+            ->setParameter('bel', $belowId);
+        }
+        $recentPlayedQuery = $recentPlayedQuery->orderBy('sq.id', 'desc')
+        ->setParameter('station', $playlist->getStation())
+        ->setParameter('playlist', $playlist)
+        ->setMaxResults($playPerSongs)
+        ->getQuery();
         $recentPlayedPlaylists = $recentPlayedQuery->getSingleColumnResult();
-        return in_array($playlist->getIdRequired(), (array)$recentPlayedPlaylists, true);
+    return in_array($playlist->getIdRequired(), (array)$recentPlayedPlaylists, true);
     }
 
     /**
@@ -193,6 +195,23 @@ final class StationQueueRepository extends AbstractStationBasedRepository
         return $cuedPlaylistContentCount > 0;
     }
 
+    public function getLastPlayedTimeForPlaylist(StationPlaylist $playlist,
+    CarbonInterface $now): int
+    {
+        $sq = $this->em->createQuery(
+            <<<'DQL'
+            SELECT sq
+            FROM App\Entity\StationQueue sq
+            WHERE sq.playlist_id = :playlist
+            and sq.timestamp_played < :now
+            ORDER BY sq.timestamp_played DESC
+            DQL
+        )->setParameter('playlist', $playlist)
+        ->setParameter('now', $now->getTimestamp())
+        ->setMaxResults(1)
+        ->getOneOrNullResult();
+        return null === $sq? 0 : $sq->getTimestampPlayed();
+    }
     public function getUnplayedBaseQuery(Station $station): QueryBuilder
     {
         return $this->getBaseQuery($station)

--- a/backend/src/Entity/StationPlaylistMedia.php
+++ b/backend/src/Entity/StationPlaylistMedia.php
@@ -74,7 +74,10 @@ class StationPlaylistMedia implements JsonSerializable, IdentifiableEntityInterf
     {
         return $this->last_played;
     }
-
+    public function requeue(): void
+    {
+        $this->is_queued = true;
+    }
     public function played(int $timestamp = null): void
     {
         $this->last_played = $timestamp ?? time();

--- a/backend/src/Entity/StationPlaylistMedia.php
+++ b/backend/src/Entity/StationPlaylistMedia.php
@@ -74,10 +74,12 @@ class StationPlaylistMedia implements JsonSerializable, IdentifiableEntityInterf
     {
         return $this->last_played;
     }
+
     public function requeue(): void
     {
         $this->is_queued = true;
     }
+
     public function played(int $timestamp = null): void
     {
         $this->last_played = $timestamp ?? time();

--- a/backend/src/Entity/StationQueue.php
+++ b/backend/src/Entity/StationQueue.php
@@ -48,6 +48,13 @@ class StationQueue implements
     protected ?int $media_id = null;
 
     #[ORM\ManyToOne]
+    #[ORM\JoinColumn(name: 'playlist_media_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    protected ?StationPlaylistMedia $playlistMedia = null;
+
+    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
+    protected ?int $playlist_media_id = null;
+
+    #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'request_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     protected ?StationRequest $request = null;
 
@@ -121,6 +128,16 @@ class StationQueue implements
     public function setRequest(?StationRequest $request): void
     {
         $this->request = $request;
+    }
+
+    public function getPlaylistMedia(): ?StationPlaylistMedia
+    {
+        return $this->playlistMedia;
+    }
+
+    public function setPlaylistMedia(?StationPlaylistMedia $playlistMedia): void
+    {
+        $this->playlistMedia = $playlistMedia;
     }
 
     public function getAutodjCustomUri(): ?string

--- a/backend/src/Radio/AutoDJ/QueueBuilder.php
+++ b/backend/src/Radio/AutoDJ/QueueBuilder.php
@@ -306,7 +306,7 @@ final class QueueBuilder implements EventSubscriberInterface
         $stationQueueEntry = StationQueue::fromMedia($playlist->getStation(), $mediaToPlay);
         $stationQueueEntry->setPlaylist($playlist);
         $stationQueueEntry->setPlaylistMedia($spm);
-        
+
         $this->em->persist($stationQueueEntry);
 
         return $stationQueueEntry;

--- a/backend/src/Radio/AutoDJ/QueueBuilder.php
+++ b/backend/src/Radio/AutoDJ/QueueBuilder.php
@@ -305,6 +305,8 @@ final class QueueBuilder implements EventSubscriberInterface
 
         $stationQueueEntry = StationQueue::fromMedia($playlist->getStation(), $mediaToPlay);
         $stationQueueEntry->setPlaylist($playlist);
+        $stationQueueEntry->setPlaylistMedia($spm);
+        
         $this->em->persist($stationQueueEntry);
 
         return $stationQueueEntry;

--- a/backend/src/Radio/AutoDJ/Scheduler.php
+++ b/backend/src/Radio/AutoDJ/Scheduler.php
@@ -31,7 +31,9 @@ final class Scheduler
 
     public function shouldPlaylistPlayNow(
         StationPlaylist $playlist,
-        CarbonInterface $now = null
+        CarbonInterface $now = null,
+        bool $excludeSpecialRules = false,
+        int $belowIdForOncePerXSongs = null
     ): bool {
         $this->logger->pushProcessor(
             function (LogRecord $record) use ($playlist) {
@@ -47,7 +49,7 @@ final class Scheduler
             $now = CarbonImmutable::now($playlist->getStation()->getTimezoneObject());
         }
 
-        if (!$this->isPlaylistScheduledToPlayNow($playlist, $now)) {
+        if (!$this->isPlaylistScheduledToPlayNow($playlist, $now, $excludeSpecialRules)) {
             $this->logger->debug('Playlist is not scheduled to play now.');
             $this->logger->popProcessor();
             return false;
@@ -69,7 +71,7 @@ final class Scheduler
 
             case PlaylistTypes::OncePerXSongs:
                 $playPerSongs = $playlist->getPlayPerSongs();
-                $shouldPlay = !$this->queueRepo->isPlaylistRecentlyPlayed($playlist, $playPerSongs);
+                $shouldPlay = !$this->queueRepo->isPlaylistRecentlyPlayed($playlist, $playPerSongs, $belowIdForOncePerXSongs);
 
                 $this->logger->debug(
                     sprintf(
@@ -149,7 +151,7 @@ final class Scheduler
         CarbonInterface $now,
         int $minutes
     ): bool {
-        $playedAt = $playlist->getPlayedAt();
+        $playedAt = $this->queueRepo->getLastPlayedTimeForPlaylist($playlist, $now);
         if (0 === $playedAt) {
             return false;
         }

--- a/backend/src/Radio/AutoDJ/Scheduler.php
+++ b/backend/src/Radio/AutoDJ/Scheduler.php
@@ -71,7 +71,11 @@ final class Scheduler
 
             case PlaylistTypes::OncePerXSongs:
                 $playPerSongs = $playlist->getPlayPerSongs();
-                $shouldPlay = !$this->queueRepo->isPlaylistRecentlyPlayed($playlist, $playPerSongs, $belowIdForOncePerXSongs);
+                $shouldPlay = !$this->queueRepo->isPlaylistRecentlyPlayed(
+                    $playlist,
+                    $playPerSongs,
+                    $belowIdForOncePerXSongs
+                );
 
                 $this->logger->debug(
                     sprintf(


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
#7382
**Proposed changes:**
* Prevents the auto DJ from "forgetting" to play items from scheduled playlists;
* When an item is removed from the upcoming song queue by Queue::isQueueRowStillValid(), the item is requeued on its original playlist so that it will be picked again when it is actually eligible to play, instead of simply being dropped;
* When a queue row is found to be invalid, all rows behind it are also invalidated to prevent a scheduled event from starting too late;
* This required some changes to the scheduler (such as how 'once per X songs' playlists are determined to be eligible) in order to support being rolled back;
* Queue::isQueueRowStillValid() can now detect whether 'once per X songs', 'once per X minutes' and 'once per hour' playlists would start too early and fix the queue to prevent it;
* The station_queue table has a new column, station_playlist_id.
* This should resolve most, if not all, outstanding complaints pertaining to scheduling accuracy.
* Disclosure: I am blind. Please bare with me as there could be code formatting issues I'm not aware of.
* This is also my first time working on a Symphony application. I'd be happy to make any necessary corrections to code that violates best practices or codebase protocol.