### PR TITLE
OpenAPI.yml errors resolved pt2

### DIFF
--- a/backend/src/Controller/Api/Stations/ServicesController.php
+++ b/backend/src/Controller/Api/Stations/ServicesController.php
@@ -69,7 +69,7 @@ use Psr\Http\Message\ResponseInterface;
                 name: 'action',
                 description: 'The action to perform (start, stop, restart)',
                 in: 'path',
-                required: false,
+                required: true,
                 schema: new OA\Schema(type: 'string', default: 'restart')
             ),
         ],
@@ -92,7 +92,7 @@ use Psr\Http\Message\ResponseInterface;
                 name: 'action',
                 description: 'The action to perform (for all: start, stop, restart, skip, disconnect)',
                 in: 'path',
-                required: false,
+                required: true,
                 schema: new OA\Schema(type: 'string', default: 'restart')
             ),
         ],

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -2756,7 +2756,7 @@ paths:
           name: action
           in: path
           description: 'The action to perform (start, stop, restart)'
-          required: false
+          required: true
           schema:
             type: string
             default: restart
@@ -2785,7 +2785,7 @@ paths:
           name: action
           in: path
           description: 'The action to perform (for all: start, stop, restart, skip, disconnect)'
-          required: false
+          required: true
           schema:
             type: string
             default: restart


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
No issue related
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
This PR fixes the two remaining errors in the OpenAPI.yml, the issues were:
```
Structural error at paths./station/{station_id}/frontend/{action}.post.parameters.1.required
should be equal to one of the allowed values
allowedValues: true
Jump to line 2759

Structural error at paths./station/{station_id}/backend/{action}.post.parameters.1.required
should be equal to one of the allowed values
allowedValues: true
Jump to line 2788
```

**Explanation**
I am trying to generate a PHP client for the Azuracast API, which gives the error messages due to the structural errors.
![image](https://github.com/user-attachments/assets/b61a1405-7564-49d6-a589-fa6420c64174)
Here is the errors being shown in the console whilst generating, I believe the only option is to set the ".required" values to true, since it does say that it can only be set to true.