### PR TITLE
Don't invalidate station queue items in the middle of a merged playlist.

### DIFF
--- a/backend/src/Entity/Repository/StationQueueRepository.php
+++ b/backend/src/Entity/Repository/StationQueueRepository.php
@@ -228,6 +228,7 @@ final class StationQueueRepository extends AbstractStationBasedRepository
             ->setMaxResults(1)
             ->getOneOrNullResult();
     }
+
     public function getUnplayedBaseQuery(Station $station): QueryBuilder
     {
         return $this->getBaseQuery($station)

--- a/backend/src/Entity/Repository/StationQueueRepository.php
+++ b/backend/src/Entity/Repository/StationQueueRepository.php
@@ -218,6 +218,16 @@ final class StationQueueRepository extends AbstractStationBasedRepository
         return null === $sq ? 0 : $sq->getTimestampPlayed();
     }
 
+    public function getPreviousItem(Station $station, StationQueue $currentItem): ?StationQueue
+    {
+        return $this->getBaseQuery($station)
+            ->andWhere('sq.id < :id')
+            ->setParameter('id', $currentItem->getId())
+            ->orderBy('sq.id', 'desc')
+            ->getQuery()
+            ->setMaxResults(1)
+            ->getOneOrNullResult();
+    }
     public function getUnplayedBaseQuery(Station $station): QueryBuilder
     {
         return $this->getBaseQuery($station)

--- a/backend/src/Radio/AutoDJ/Queue.php
+++ b/backend/src/Radio/AutoDJ/Queue.php
@@ -331,7 +331,6 @@ final class Queue
     }
     /**
      * A queue item is exempt from validation if:
-     * The playlist it belongs to is not 'General Rotation';
      * The playlist it belongs to has the merge setting enabled;
      * The item is not the first track to play from that playlist.
      * @param StationQueue $queueRow


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->
#7407
**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
As per the referenced issue, my validation of 'once per' queue items was not taking 'Merge playlist to play as a single track' into account. When the 'Once per X' checks would re-run on the subsequent items, it would determine that the playlist had already played and delete the tracks. This adds a new rule which exempts such items from validation.
