### PR TITLE
More scheduling anomaly fixes

### DIFF
--- a/backend/src/Controller/Api/Stations/Files/BatchAction.php
+++ b/backend/src/Controller/Api/Stations/Files/BatchAction.php
@@ -362,6 +362,7 @@ final class BatchAction implements SingleActionInterface
 
                     $newQueue = StationQueue::fromMedia($station, $media);
                     $newQueue->setTimestampCued($cuedTimestamp);
+                    $newQueue->setTimestampScheduled($cuedTimestamp);
                     $newQueue->setIsPlayed();
                     $this->em->persist($newQueue);
 

--- a/backend/src/Controller/Api/Stations/Files/BatchAction.php
+++ b/backend/src/Controller/Api/Stations/Files/BatchAction.php
@@ -310,6 +310,7 @@ final class BatchAction implements SingleActionInterface
 
                     $newQueue = StationQueue::fromMedia($stationRef, $media);
                     $newQueue->setTimestampCued($cuedTimestamp);
+                    $newQueue->setTimestampScheduled($cuedTimestamp);
                     $this->em->persist($newQueue);
                 } catch (Throwable $e) {
                     $result->errors[] = sprintf('%s: %s', $media->getPath(), $e->getMessage());

--- a/backend/src/Controller/Api/Stations/QueueController.php
+++ b/backend/src/Controller/Api/Stations/QueueController.php
@@ -14,6 +14,7 @@ use App\Http\ServerRequest;
 use App\OpenApi;
 use App\Radio\AutoDJ\Queue;
 use App\Utilities\Types;
+use InvalidArgumentException;
 use OpenApi\Attributes as OA;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\Serializer;
@@ -173,5 +174,19 @@ final class QueueController extends AbstractStationApiCrudController
         $this->queueRepo->clearUpcomingQueue($station);
 
         return $response->withJson(Status::deleted());
+    }
+
+            /**
+         * Don't delete, just cancel.
+         * This prevents playout, but keeps the record around for other decision making, bug investigation, etc.
+         */
+    protected function deleteRecord(object $record): void
+    {
+        if (!($record instanceof $this->entityClass)) {
+            throw new InvalidArgumentException(sprintf('Record must be an instance of %s.', $this->entityClass));
+        }
+        $record->setIsCancelled(true);
+        $this->em->persist($record);
+        $this->em->flush();
     }
 }

--- a/backend/src/Controller/Api/Stations/QueueController.php
+++ b/backend/src/Controller/Api/Stations/QueueController.php
@@ -176,16 +176,18 @@ final class QueueController extends AbstractStationApiCrudController
         return $response->withJson(Status::deleted());
     }
 
-            /**
-         * Don't delete, just cancel.
-         * This prevents playout, but keeps the record around for other decision making, bug investigation, etc.
-         */
+    /**
+     * Don't delete, just cancel.
+     * This prevents playout, but keeps the record around for other decision making, bug investigation, etc.
+     */
     protected function deleteRecord(object $record): void
     {
         if (!($record instanceof $this->entityClass)) {
             throw new InvalidArgumentException(sprintf('Record must be an instance of %s.', $this->entityClass));
         }
+
         $record->setIsCancelled(true);
+
         $this->em->persist($record);
         $this->em->flush();
     }

--- a/backend/src/Controller/Api/Stations/Requests/ListAction.php
+++ b/backend/src/Controller/Api/Stations/Requests/ListAction.php
@@ -119,10 +119,11 @@ final class ListAction extends AbstractSearchableListAction
             foreach ($playlists as $playlist) {
                 if (
                     $this->scheduler->isPlaylistScheduledToPlayNow(
-                        $this->scheduler->createContext()
-                        ->withPlaylist($playlist)
-                        ->withNow($now)
-                        ->withExcludeSpecialRules(true)
+                        new SchedulerContext(
+                            $playlist,
+                            $now,
+                            true
+                        )
                     )
                 ) {
                     $ids[] = $playlist->getIdRequired();

--- a/backend/src/Controller/Api/Stations/Requests/ListAction.php
+++ b/backend/src/Controller/Api/Stations/Requests/ListAction.php
@@ -15,6 +15,7 @@ use App\Http\Response;
 use App\Http\ServerRequest;
 use App\OpenApi;
 use App\Radio\AutoDJ\Scheduler;
+use App\Radio\AutoDJ\SchedulerContext;
 use Carbon\CarbonImmutable;
 use OpenApi\Attributes as OA;
 use Psr\Cache\CacheItemPoolInterface;
@@ -116,7 +117,14 @@ final class ListAction extends AbstractSearchableListAction
 
             /** @var StationPlaylist $playlist */
             foreach ($playlists as $playlist) {
-                if ($this->scheduler->isPlaylistScheduledToPlayNow($playlist, $now, true)) {
+                if (
+                    $this->scheduler->isPlaylistScheduledToPlayNow(
+                        $this->scheduler->createContext()
+                        ->withPlaylist($playlist)
+                        ->withNow($now)
+                        ->withExcludeSpecialRules(true)
+                    )
+                ) {
                     $ids[] = $playlist->getIdRequired();
                 }
             }

--- a/backend/src/Entity/Migration/Version20240901011513.php
+++ b/backend/src/Entity/Migration/Version20240901011513.php
@@ -17,15 +17,17 @@ final class Version20240901011513 extends AbstractMigration
     {
         $this->addSql('ALTER TABLE station_queue ADD timestamp_scheduled INT, ADD schedule_id INT DEFAULT NULL');
         $this->addSql('CREATE INDEX idx_timestamp_scheduled ON station_queue (timestamp_scheduled)');
+        $this->addSql('ALTER TABLE station_queue ADD CONSTRAINT FK_277B0055A40BC2D5 FOREIGN KEY (schedule_id) REFERENCES station_schedules (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_277B0055A40BC2D5 ON station_queue (schedule_id)');
         $this->addSQL('UPDATE station_queue SET timestamp_scheduled = timestamp_played');
         $this->addSQL('ALTER TABLE station_queue CHANGE timestamp_scheduled timestamp_scheduled INT NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE station CHANGE max_bitrate max_bitrate INT DEFAULT 0, CHANGE max_mounts max_mounts TINYINT(1) DEFAULT 0, CHANGE max_hls_streams max_hls_streams TINYINT(1) DEFAULT 0');
+        $this->addSql('ALTER TABLE station_queue DROP FOREIGN KEY FK_277B0055A40BC2D5');
+        $this->addSql('DROP INDEX IDX_277B0055A40BC2D5 ON station_queue');
         $this->addSql('DROP INDEX idx_timestamp_scheduled ON station_queue');
         $this->addSql('ALTER TABLE station_queue DROP timestamp_scheduled, DROP schedule_id');
     }
-
 }

--- a/backend/src/Entity/Migration/Version20240901011513.php
+++ b/backend/src/Entity/Migration/Version20240901011513.php
@@ -10,7 +10,7 @@ final class Version20240901011513 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Track timestamp_scheduled and schedule_id in station_queue.';
     }
 
     public function up(Schema $schema): void

--- a/backend/src/Entity/Migration/Version20240901011513.php
+++ b/backend/src/Entity/Migration/Version20240901011513.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20240901011513 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE station_queue ADD timestamp_scheduled INT, ADD schedule_id INT DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_timestamp_scheduled ON station_queue (timestamp_scheduled)');
+        $this->addSQL('UPDATE station_queue SET timestamp_scheduled = timestamp_played');
+        $this->addSQL('ALTER TABLE station_queue CHANGE timestamp_scheduled timestamp_scheduled INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE station CHANGE max_bitrate max_bitrate INT DEFAULT 0, CHANGE max_mounts max_mounts TINYINT(1) DEFAULT 0, CHANGE max_hls_streams max_hls_streams TINYINT(1) DEFAULT 0');
+        $this->addSql('DROP INDEX idx_timestamp_scheduled ON station_queue');
+        $this->addSql('ALTER TABLE station_queue DROP timestamp_scheduled, DROP schedule_id');
+    }
+
+}

--- a/backend/src/Entity/Migration/Version20240902155213.php
+++ b/backend/src/Entity/Migration/Version20240902155213.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20240902155213 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_cancelled field to station_queue';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE station_queue ADD is_cancelled TINYINT(1) NOT NULL DEFAULT 0');
+        $this->addSql('CREATE INDEX idx_is_cancelled ON station_queue (is_cancelled)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_is_cancelled ON station_queue');
+        $this->addSql('ALTER TABLE station_queue DROP is_cancelled');
+    }
+}

--- a/backend/src/Entity/Repository/StationQueueRepository.php
+++ b/backend/src/Entity/Repository/StationQueueRepository.php
@@ -241,15 +241,17 @@ final class StationQueueRepository extends AbstractStationBasedRepository
         int $startTime,
         bool $includeCancelled = false
     ): StationQueue|null {
-            $query = $this->getBaseQuery($station)
+        $query = $this->getBaseQuery($station)
             ->andWhere('sq.schedule = :schedule')
             ->setParameter('schedule', $schedule)
             ->andWhere('sq.timestamp_scheduled = :time')
             ->setParameter('time', $startTime);
+
         if (!$includeCancelled) {
             $query->andWhere('sq.is_cancelled = 0');
         }
-            return $query ->orderBy('sq.id', 'asc')
+
+        return $query->orderBy('sq.id', 'asc')
             ->getQuery()
             ->setMaxResults(1)
             ->getOneOrNullResult();

--- a/backend/src/Entity/StationQueue.php
+++ b/backend/src/Entity/StationQueue.php
@@ -254,7 +254,6 @@ class StationQueue implements
         $this->timestamp_scheduled = $timestampScheduled;
     }
 
-
     public function getSchedule(): StationSchedule|null
     {
         return $this->schedule;
@@ -264,6 +263,7 @@ class StationQueue implements
     {
         $this->schedule = $schedule;
     }
+
     public function __toString(): string
     {
         return (null !== $this->media)

--- a/backend/src/Entity/StationQueue.php
+++ b/backend/src/Entity/StationQueue.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
     ORM\Entity,
     ORM\Table(name: 'station_queue'),
     ORM\Index(name: 'idx_is_played', columns: ['is_played']),
+    ORM\Index(name: 'idx_is_cancelled', columns: ['is_cancelled']),
     ORM\Index(name: 'idx_timestamp_played', columns: ['timestamp_played']),
     ORM\Index(name: 'idx_timestamp_scheduled', columns: ['timestamp_scheduled']),
     ORM\Index(name: 'idx_sent_to_autodj', columns: ['sent_to_autodj']),
@@ -70,6 +71,9 @@ class StationQueue implements
 
     #[ORM\Column]
     protected bool $is_visible = true;
+
+    #[ORM\Column]
+    protected bool $is_cancelled = false;
 
     #[ORM\Column(length: 255, nullable: true)]
     protected ?string $autodj_custom_uri = null;
@@ -215,6 +219,16 @@ class StationQueue implements
         $this->is_visible = $isVisible;
     }
 
+    public function getIsCancelled(): bool
+    {
+        return $this->is_cancelled;
+    }
+
+    public function setIsCancelled(bool $isCancelled): void
+    {
+        $this->is_cancelled = $isCancelled;
+    }
+
     public function updateVisibility(): void
     {
         $this->is_visible = !($this->playlist instanceof StationPlaylist) || !$this->playlist->getIsJingle();
@@ -246,7 +260,8 @@ class StationQueue implements
         return $this->schedule;
     }
 
-    public function setSchedule(StationSchedule $schedule = null) {
+    public function setSchedule(StationSchedule $schedule = null): void
+    {
         $this->schedule = $schedule;
     }
     public function __toString(): string

--- a/backend/src/Entity/StationQueue.php
+++ b/backend/src/Entity/StationQueue.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
     ORM\Table(name: 'station_queue'),
     ORM\Index(name: 'idx_is_played', columns: ['is_played']),
     ORM\Index(name: 'idx_timestamp_played', columns: ['timestamp_played']),
+    ORM\Index(name: 'idx_timestamp_scheduled', columns: ['timestamp_scheduled']),
     ORM\Index(name: 'idx_sent_to_autodj', columns: ['sent_to_autodj']),
     ORM\Index(name: 'idx_timestamp_cued', columns: ['timestamp_cued'])
 ]
@@ -78,6 +79,16 @@ class StationQueue implements
 
     #[ORM\Column]
     protected int $timestamp_played;
+
+    #[ORM\Column]
+    protected int $timestamp_scheduled;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(name: 'schedule_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    protected ?StationSchedule $schedule = null;
+
+    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
+    protected ?int $schedule_id = null;
 
     #[ORM\Column(nullable: true)]
     protected ?int $duration = null;
@@ -219,6 +230,25 @@ class StationQueue implements
         $this->timestamp_played = $timestampPlayed;
     }
 
+    public function getTimestampScheduled(): int
+    {
+        return $this->timestamp_scheduled;
+    }
+
+    public function setTimestampScheduled(int $timestampScheduled): void
+    {
+        $this->timestamp_scheduled = $timestampScheduled;
+    }
+
+
+    public function getSchedule(): StationSchedule|null
+    {
+        return $this->schedule;
+    }
+
+    public function setSchedule(StationSchedule $schedule = null) {
+        $this->schedule = $schedule;
+    }
     public function __toString(): string
     {
         return (null !== $this->media)

--- a/backend/src/Radio/AutoDJ/Queue.php
+++ b/backend/src/Radio/AutoDJ/Queue.php
@@ -343,14 +343,11 @@ final class Queue
                 return true;
             }
         }
-
+                $ctx = new SchedulerContext($playlist, $expectedPlayTime, true);
+                $ctx->belowId = $queueRow->getId();
         return $playlist->getIsEnabled() &&
             $this->scheduler->shouldPlaylistPlayNow(
-                $this->scheduler->createContext()
-                ->withPlaylist($playlist)
-                ->withNow($expectedPlayTime)
-                ->withExcludeSpecialRules(true)
-                ->withBelowId($queueRow->getId())
+                $ctx
             );
     }
 

--- a/backend/src/Radio/AutoDJ/Queue.php
+++ b/backend/src/Radio/AutoDJ/Queue.php
@@ -117,7 +117,8 @@ final class Queue
                     }
 
                     $restOfQueueIsInvalid = true;
-                    $this->em->remove($queueRow);
+                    $queueRow->setIsCancelled(true);
+                    $this->em->persist($queueRow);
                     continue;
                 }
 
@@ -205,7 +206,7 @@ final class Queue
                 $queueRow->setTimestampCued($expectedCueTime->getTimestamp());
                 $queueRow->setTimestampPlayed($expectedPlayTime->getTimestamp());
                 if (null === $queueRow->getSchedule()) {
-                $queueRow->setTimestampScheduled($expectedPlayTime->getTimestamp());
+                    $queueRow->setTimestampScheduled($expectedPlayTime->getTimestamp());
                 }
                 $queueRow->updateVisibility();
                 $this->em->persist($queueRow);
@@ -327,11 +328,12 @@ final class Queue
         if (
             null !== $schedule
             && $queueRow->getTimestampPlayed() < $queueRow->getTimestampScheduled()
-            ) {
+        ) {
             $first = $this->queueRepo->getStartOfScheduleRun(
                 $station,
                 $schedule,
-                $queueRow->getTimestampScheduled()
+                $queueRow->getTimestampScheduled(),
+                true
             );
             //Item is exempt from being invalidated if it's not the first to come from this schedule run.
             if (
@@ -339,7 +341,6 @@ final class Queue
                 && $first->getId() !== $queueRow->getId()
             ) {
                 return true;
-
             }
         }
 

--- a/backend/src/Radio/AutoDJ/Queue.php
+++ b/backend/src/Radio/AutoDJ/Queue.php
@@ -346,10 +346,11 @@ final class Queue
 
         return $playlist->getIsEnabled() &&
             $this->scheduler->shouldPlaylistPlayNow(
-                $playlist,
-                $expectedPlayTime,
-                true,
-                $queueRow->getId()
+                $this->scheduler->createContext()
+                ->withPlaylist($playlist)
+                ->withNow($expectedPlayTime)
+                ->withExcludeSpecialRules(true)
+                ->withBelowId($queueRow->getId())
             );
     }
 

--- a/backend/src/Radio/AutoDJ/QueueBuilder.php
+++ b/backend/src/Radio/AutoDJ/QueueBuilder.php
@@ -83,7 +83,8 @@ final class QueueBuilder implements EventSubscriberInterface
         if ($playlists->isEmpty()) {
             return;
         }
-        //Find out when the last scheduled playlist played. Don't do schedule checks any earlier than this.
+
+        // Find out when the last scheduled playlist played. Don't do schedule checks any earlier than this.
         $lastScheduledTrack = $this->queueRepo->getLatestScheduledTrack($station);
         if (null !== $lastScheduledTrack) {
             $lastScheduledTime = CarbonImmutable::createFromTimestamp(

--- a/backend/src/Radio/AutoDJ/QueueBuilder.php
+++ b/backend/src/Radio/AutoDJ/QueueBuilder.php
@@ -187,7 +187,7 @@ final class QueueBuilder implements EventSubscriberInterface
          * This preserves the somewhat arbitrary precedents that were previously defined:
          * Once per hour -> Once per X songs -> Once per X minutes -> Standard, scheduled -> unscheduled.
          */
-        $scheduled = count($playlist->getScheduleItems()) > 0 ? count(PlaylistTypes::cases()) : 0;
+        $scheduled = count($playlist->getScheduleItems()) > 0 ? 1 : 0;
         return (self::LEGACY_PRIORITIES[$playlist->getType()->value] ?? 0) + $scheduled;
     }
 

--- a/backend/src/Radio/AutoDJ/QueueBuilder.php
+++ b/backend/src/Radio/AutoDJ/QueueBuilder.php
@@ -96,6 +96,7 @@ final class QueueBuilder implements EventSubscriberInterface
                 $expectedPlayTime = $lastScheduledTime;
             }
         }
+
         $ctx = new QueueBuilderContext(
             $station,
             $this,
@@ -103,9 +104,11 @@ final class QueueBuilder implements EventSubscriberInterface
             $this->logger,
             $expectedPlayTime
         );
+
         foreach ($playlists as $playlist) {
             $ctx->registerPlaylist($playlist);
         }
+
         if (0 === $ctx->getPlaylistCount()) {
             $this->logger->warning('No eligible playlists found.');
             return null;
@@ -118,6 +121,7 @@ final class QueueBuilder implements EventSubscriberInterface
             ),
             $ctx->getLogPriorities()
         );
+
         return $ctx;
     }
 

--- a/backend/src/Radio/AutoDJ/QueueBuilderContext.php
+++ b/backend/src/Radio/AutoDJ/QueueBuilderContext.php
@@ -24,6 +24,7 @@ final class QueueBuilderContext
      */
     private array $registeredSchedulerContexts;
     private int $registeredPlaylistCount = 0;
+
     public function __construct(
         public readonly Station $station,
         private readonly QueueBuilder $queueBuilder,
@@ -40,6 +41,7 @@ final class QueueBuilderContext
     {
         return $this->registeredPlaylistCount;
     }
+
     /**
      * Qualifies and registers a playlist for selection.
      */
@@ -75,6 +77,7 @@ final class QueueBuilderContext
         $this->registeredPlaylistCount++;
         return true;
     }
+
     /**
      * Generate a map of priority values to playlist names for logging purposes.
      */
@@ -88,6 +91,7 @@ final class QueueBuilderContext
         }
         return $summary;
     }
+
     /**
      * Contextual iteration over all registered playlists, organized by priority and weight.
      */
@@ -107,6 +111,7 @@ final class QueueBuilderContext
             }
         }
     }
+
     /**
      * Apply a weighted shuffle to the given array in the form:
      *  [ key1 => weight1, key2 => weight2 ]

--- a/backend/src/Radio/AutoDJ/QueueBuilderContext.php
+++ b/backend/src/Radio/AutoDJ/QueueBuilderContext.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Radio\AutoDJ;
+
+use App\Entity\Station;
+use App\Entity\StationPlaylist;
+use App\Entity\StationRequest;
+use App\Entity\StationSchedule;
+use App\Utilities\DateRange;
+use Carbon\CarbonInterface;
+use generator;
+use Monolog\Logger;
+
+final class QueueBuilderContext
+{
+    /**
+     * Maps ScheduleContexts to their playlists' priorities as they're being registered.
+     */
+    private array $registeredSchedulerContexts;
+    private int $registeredPlaylistCount = 0;
+    public function __construct(
+        private Station $station,
+        private readonly QueueBuilder $queueBuilder,
+        private readonly Scheduler $scheduler,
+        private readonly Logger $logger,
+        private CarbonInterface $now
+    ) {
+    }
+    public function getStation(): Station
+    {
+        return $this->station;
+    }
+    public function getNow(): CarbonInterface
+    {
+        return $this->now;
+    }
+
+    /**
+     * Returns a count of all successfully registered playlists.
+     */
+    public function getPlaylistCount(): int
+    {
+        return $this->registeredPlaylistCount;
+    }
+    /**
+     * Qualifies and registers a playlist for selection.
+     */
+    public function registerPlaylist(StationPlaylist $playlist): bool
+    {
+        if (!$playlist->getIsEnabled()) {
+            $this->logger->debug(
+                sprintf(
+                    'Playlist "%s" is disabled.',
+                    $playlist->getName()
+                )
+            );
+            return false;
+        }
+
+        if (0 === count($playlist->getMediaItems())) {
+            $this->logger->debug(
+                sprintf(
+                    'Playlist "%s" is empty.',
+                    $playlist->getName()
+                )
+            );
+            return false;
+        }
+        $ctx = $this->scheduler->createContext()
+            ->withPlaylist($playlist)
+            ->withNow($this->now);
+        if (!$this->scheduler->shouldPlaylistPlayNow($ctx)) {
+            return false;
+        }
+
+        $playlistId = $playlist->getId();
+        $priority = $this->queueBuilder->getPlaylistPriority($playlist);
+        $this->registeredSchedulerContexts[$priority][$playlistId] = $ctx;
+        $this->registeredPlaylistCount++;
+        return true;
+    }
+    /**
+     * Generate a map of priority values to playlist names for logging purposes.
+     */
+    public function getLogPriorities(): array
+    {
+        $summary = [];
+        foreach ($this->registeredSchedulerContexts as $priority => $group) {
+            foreach ($group as $ctx) {
+                $summary[$priority][] = $ctx->getPlaylistRequired()->getName();
+            }
+        }
+        return $summary;
+    }
+    /**
+     * Contextual iteration over all registered playlists, organized by priority and weight.
+     */
+    public function getPlaylists(): Generator
+    {
+                // Build our list of playlists, sorted first by priority, then by weight.
+        krsort($this->registeredSchedulerContexts);
+        foreach ($this->registeredSchedulerContexts as $contexts) {
+            $weights = [];
+            foreach ($contexts as $ctx) {
+                $playlist = $ctx->getPlaylistRequired();
+                $weights[$playlist->getId()] = $playlist->getWeight();
+            }
+            $weights = $this->weightedShuffle($weights);
+            foreach ($weights as $id => $weight) {
+                yield $contexts[$id];
+            }
+        }
+    }
+    /**
+     * Apply a weighted shuffle to the given array in the form:
+     *  [ key1 => weight1, key2 => weight2 ]
+     *
+     * Based on: https://gist.github.com/savvot/e684551953a1716208fbda6c4bb2f344
+     *
+     * @param array& $original
+     * @return array
+     */
+    private function weightedShuffle(array &$original): array
+    {
+        $new = $original;
+        $max = 1.0 / mt_getrandmax();
+
+        array_walk(
+            $new,
+            static function (&$value) use ($max): void {
+                $value = (mt_rand() * $max) ** (1.0 / $value);
+            }
+        );
+
+        arsort($new);
+
+        array_walk(
+            $new,
+            static function (&$value, $key) use ($original): void {
+                $value = $original[$key];
+            }
+        );
+
+        return $new;
+    }
+}

--- a/backend/src/Radio/AutoDJ/Scheduler.php
+++ b/backend/src/Radio/AutoDJ/Scheduler.php
@@ -31,6 +31,8 @@ final class Scheduler
 
     public function shouldPlaylistPlayNow(SchedulerContext $ctx): bool
     {
+        //Make sure we don't give back info from a previous run.
+        $ctx->clearForOutput();
         $playlist = $ctx->getPlaylistRequired();
         $this->logger->pushProcessor(
             function (LogRecord $record) use ($playlist) {

--- a/backend/src/Radio/AutoDJ/Scheduler.php
+++ b/backend/src/Radio/AutoDJ/Scheduler.php
@@ -34,8 +34,8 @@ final class Scheduler
         CarbonInterface $now = null,
         bool $excludeSpecialRules = false,
         int $belowIdForOncePerXSongs = null,
-        StationSchedule& $outSchedule = null,
-        DateRange& $outDateRange = null
+        StationSchedule &$outSchedule = null,
+        DateRange &$outDateRange = null
     ): bool {
         $this->logger->pushProcessor(
             function (LogRecord $record) use ($playlist) {
@@ -118,8 +118,8 @@ final class Scheduler
         StationPlaylist $playlist,
         CarbonInterface $now,
         bool $excludeSpecialRules = false,
-        StationSchedule& $outSchedule = null,
-        DateRange& $outDateRange = null
+        StationSchedule &$outSchedule = null,
+        DateRange &$outDateRange = null
     ): bool {
         $scheduleItems = $playlist->getScheduleItems();
 
@@ -128,7 +128,12 @@ final class Scheduler
             return true;
         }
 
-        $scheduleItem = $this->getActiveScheduleFromCollection($scheduleItems, $now, $excludeSpecialRules, $outDateRange);
+        $scheduleItem = $this->getActiveScheduleFromCollection(
+            $scheduleItems,
+            $now,
+            $excludeSpecialRules,
+            $outDateRange
+        );
         $outSchedule = $scheduleItem;
         return null !== $scheduleItem;
     }
@@ -216,7 +221,7 @@ final class Scheduler
         Collection $scheduleItems,
         CarbonInterface $now,
         bool $excludeSpecialRules = false,
-        DateRange& $outDateRange = null
+        DateRange &$outDateRange = null
     ): ?StationSchedule {
         if ($scheduleItems->count() > 0) {
             foreach ($scheduleItems as $scheduleItem) {
@@ -248,7 +253,7 @@ final class Scheduler
         StationSchedule $schedule,
         CarbonInterface $now,
         bool $excludeSpecialRules = false,
-        DateRange& $outDateRange = null
+        DateRange &$outDateRange = null
     ): bool {
         $startTime = StationSchedule::getDateTime($schedule->getStartTime(), $now);
         $endTime = StationSchedule::getDateTime($schedule->getEndTime(), $now);
@@ -374,7 +379,7 @@ final class Scheduler
             )
             );
         $isQueueEmpty = $this->spmRepo->isQueueEmpty($playlist);
-if (!$scheduleRunStarted) {
+        if (!$scheduleRunStarted) {
             $this->logger->debug('Playlist was not played yet.');
             $this->logger->debug('Resetting playlist queue with now override.');
             $startOfWindow = $dateRange->getStart()->subSecond();

--- a/backend/src/Radio/AutoDJ/Scheduler.php
+++ b/backend/src/Radio/AutoDJ/Scheduler.php
@@ -43,10 +43,12 @@ final class Scheduler
                 return $record;
             }
         );
+
         $this->logger->debug('Checking if playlist should play now.');
         if (null === $ctx->expectedPlayTime) {
             $ctx->expectedPlayTime = CarbonImmutable::now($playlist->getStation()->getTimezoneObject());
         }
+
         $expectedPlayTime = $ctx->getExpectedPlayTimeRequired();
         if (!$this->isPlaylistScheduledToPlayNow($ctx)) {
             $this->logger->debug('Playlist is not scheduled to play now.');
@@ -192,6 +194,7 @@ final class Scheduler
         if (null === $now) {
             $now = CarbonImmutable::now($streamer->getStation()->getTimezoneObject());
         }
+
         $scheduleItem = $this->getActiveScheduleFromCollection(
             $streamer->getScheduleItems(),
             new SchedulerContext(
@@ -199,6 +202,7 @@ final class Scheduler
                 $now
             )
         );
+
         return null !== $scheduleItem;
     }
 

--- a/backend/src/Radio/AutoDJ/SchedulerContext.php
+++ b/backend/src/Radio/AutoDJ/SchedulerContext.php
@@ -19,17 +19,20 @@ final class SchedulerContext
     public ?StationSchedule $schedule = null;
     public ?DateRange $dateRange = null;
     public ?int $belowId = null;
+
     public function __construct(
         public ?StationPlaylist $playlist = null,
         public ?CarbonInterface $expectedPlayTime = null,
         public bool $excludeSpecialRules = false
     ) {
     }
+
     public function clearForOutput(): void
     {
         $this->schedule = null;
         $this->dateRange = null;
     }
+
     /**
      * Returns playlist, or throws if null.
      */
@@ -38,13 +41,16 @@ final class SchedulerContext
         if (null === $this->playlist) {
             throw new RuntimeException('"playlist" is required but not set.');
         }
+
         return $this->playlist;
     }
+
     public function getExpectedPlayTimeRequired(): CarbonInterface
     {
         if (null === $this->expectedPlayTime) {
             throw new RuntimeException('"expectedPlayTime" is required but not set.');
         }
+
         return $this->expectedPlayTime;
     }
 }

--- a/backend/src/Radio/AutoDJ/SchedulerContext.php
+++ b/backend/src/Radio/AutoDJ/SchedulerContext.php
@@ -9,21 +9,20 @@ use App\Entity\StationPlaylist;
 use App\Entity\StationSchedule;
 use App\Utilities\DateRange;
 use Carbon\CarbonInterface;
+use RuntimeException;
 
 /**
  * Inputs and outputs for a single scheduling task.
  */
 final class SchedulerContext
 {
-    private ?StationPlaylist $playlist;
-    private ?StationSchedule $schedule;
-    private ?DateRange $dateRange;
+    private ?StationPlaylist $playlist = null;
+    private ?CarbonInterface $now = null;
+    private ?StationSchedule $schedule = null;
+    private ?DateRange $dateRange = null;
     private bool $excludeSpecialRules = false;
     private ?int $belowId = null;
     // inputs.
-    public function __construct(private CarbonInterface $now)
-    {
-    }
     public function withPlaylist(?StationPlaylist $playlist): self
     {
         $this->playlist = $playlist;
@@ -59,8 +58,22 @@ final class SchedulerContext
     {
         return $this->playlist;
     }
-    public function getNow(): CarbonInterface
+    public function getPlaylistRequired(): StationPlaylist
     {
+        if (null === $this->playlist) {
+            throw new RuntimeException("No playlist given.");
+        }
+        return $this->playlist;
+    }
+    public function getNow(): CarbonInterface|null
+    {
+        return $this->now;
+    }
+    public function getNowRequired(): CarbonInterface
+    {
+        if (null === $this->now) {
+            throw new RuntimeException("No now given.");
+        }
         return $this->now;
     }
     public function getExcludeSpecialRules(): bool

--- a/backend/src/Radio/AutoDJ/SchedulerContext.php
+++ b/backend/src/Radio/AutoDJ/SchedulerContext.php
@@ -92,4 +92,9 @@ final class SchedulerContext
     {
         return $this->dateRange;
     }
+    public function clearForOutput(): void
+    {
+        $this->schedule = null;
+        $this->dateRange = null;
+    }
 }

--- a/backend/src/Radio/AutoDJ/SchedulerContext.php
+++ b/backend/src/Radio/AutoDJ/SchedulerContext.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Radio\AutoDJ;
 
-use App\Utilities\DateRange;
 use App\Entity\Station;
-use App\Entity\StationSchedule;
 use App\Entity\StationPlaylist;
+use App\Entity\StationSchedule;
+use App\Utilities\DateRange;
 use Carbon\CarbonInterface;
 
 /**
@@ -29,7 +29,7 @@ final class SchedulerContext
         $this->playlist = $playlist;
         return $this;
     }
-    public function withNow(?CarbonInterface $now): self
+    public function withNow(CarbonInterface $now): self
     {
         $this->now = $now;
         return $this;
@@ -79,4 +79,4 @@ final class SchedulerContext
     {
         return $this->dateRange;
     }
-    }
+}

--- a/backend/src/Radio/AutoDJ/SchedulerContext.php
+++ b/backend/src/Radio/AutoDJ/SchedulerContext.php
@@ -16,85 +16,35 @@ use RuntimeException;
  */
 final class SchedulerContext
 {
-    private ?StationPlaylist $playlist = null;
-    private ?CarbonInterface $now = null;
-    private ?StationSchedule $schedule = null;
-    private ?DateRange $dateRange = null;
-    private bool $excludeSpecialRules = false;
-    private ?int $belowId = null;
-    // inputs.
-    public function withPlaylist(?StationPlaylist $playlist): self
-    {
-        $this->playlist = $playlist;
-        return $this;
-    }
-    public function withNow(CarbonInterface $now): self
-    {
-        $this->now = $now;
-        return $this;
-    }
-    public function withExcludeSpecialRules(bool $excludeSpecialRules): self
-    {
-        $this->excludeSpecialRules = $excludeSpecialRules;
-        return $this;
-    }
-    public function withBelowId(?int $belowId): self
-    {
-        $this->belowId = $belowId;
-        return $this;
-    }
-    // outputs.
-    public function withSchedule(StationSchedule $schedule): self
-    {
-        $this->schedule = $schedule;
-        return $this;
-    }
-    public function withDateRange(DateRange $dateRange): self
-    {
-        $this->dateRange = $dateRange;
-        return $this;
-    }
-    public function getPlaylist(): StationPlaylist|null
-    {
-        return $this->playlist;
-    }
-    public function getPlaylistRequired(): StationPlaylist
-    {
-        if (null === $this->playlist) {
-            throw new RuntimeException("No playlist given.");
-        }
-        return $this->playlist;
-    }
-    public function getNow(): CarbonInterface|null
-    {
-        return $this->now;
-    }
-    public function getNowRequired(): CarbonInterface
-    {
-        if (null === $this->now) {
-            throw new RuntimeException("No now given.");
-        }
-        return $this->now;
-    }
-    public function getExcludeSpecialRules(): bool
-    {
-        return $this->excludeSpecialRules;
-    }
-    public function getBelowId(): int|null
-    {
-        return $this->belowId;
-    }
-    public function getSchedule(): StationSchedule|null
-    {
-        return $this->schedule;
-    }
-    public function getDateRange(): DateRange|null
-    {
-        return $this->dateRange;
+    public ?StationSchedule $schedule = null;
+    public ?DateRange $dateRange = null;
+    public ?int $belowId = null;
+    public function __construct(
+        public ?StationPlaylist $playlist = null,
+        public ?CarbonInterface $expectedPlayTime = null,
+        public bool $excludeSpecialRules = false
+    ) {
     }
     public function clearForOutput(): void
     {
         $this->schedule = null;
         $this->dateRange = null;
+    }
+    /**
+     * Returns playlist, or throws if null.
+     */
+    public function getPlaylistRequired(): StationPlaylist
+    {
+        if (null === $this->playlist) {
+            throw new RuntimeException('"playlist" is required but not set.');
+        }
+        return $this->playlist;
+    }
+    public function getExpectedPlayTimeRequired(): CarbonInterface
+    {
+        if (null === $this->expectedPlayTime) {
+            throw new RuntimeException('"expectedPlayTime" is required but not set.');
+        }
+        return $this->expectedPlayTime;
     }
 }

--- a/backend/src/Radio/AutoDJ/SchedulerContext.php
+++ b/backend/src/Radio/AutoDJ/SchedulerContext.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Radio\AutoDJ;
+
+use App\Utilities\DateRange;
+use App\Entity\Station;
+use App\Entity\StationSchedule;
+use App\Entity\StationPlaylist;
+use Carbon\CarbonInterface;
+
+/**
+ * Inputs and outputs for a single scheduling task.
+ */
+final class SchedulerContext
+{
+    private ?StationPlaylist $playlist;
+    private ?StationSchedule $schedule;
+    private ?DateRange $dateRange;
+    private bool $excludeSpecialRules = false;
+    private ?int $belowId = null;
+    // inputs.
+    public function __construct(private CarbonInterface $now)
+    {
+    }
+    public function withPlaylist(?StationPlaylist $playlist): self
+    {
+        $this->playlist = $playlist;
+        return $this;
+    }
+    public function withNow(?CarbonInterface $now): self
+    {
+        $this->now = $now;
+        return $this;
+    }
+    public function withExcludeSpecialRules(bool $excludeSpecialRules): self
+    {
+        $this->excludeSpecialRules = $excludeSpecialRules;
+        return $this;
+    }
+    public function withBelowId(?int $belowId): self
+    {
+        $this->belowId = $belowId;
+        return $this;
+    }
+    // outputs.
+    public function withSchedule(StationSchedule $schedule): self
+    {
+        $this->schedule = $schedule;
+        return $this;
+    }
+    public function withDateRange(DateRange $dateRange): self
+    {
+        $this->dateRange = $dateRange;
+        return $this;
+    }
+    public function getPlaylist(): StationPlaylist|null
+    {
+        return $this->playlist;
+    }
+    public function getNow(): CarbonInterface
+    {
+        return $this->now;
+    }
+    public function getExcludeSpecialRules(): bool
+    {
+        return $this->excludeSpecialRules;
+    }
+    public function getBelowId(): int|null
+    {
+        return $this->belowId;
+    }
+    public function getSchedule(): StationSchedule|null
+    {
+        return $this->schedule;
+    }
+    public function getDateRange(): DateRange|null
+    {
+        return $this->dateRange;
+    }
+    }

--- a/tests/Unit/StationPlaylistTest.php
+++ b/tests/Unit/StationPlaylistTest.php
@@ -52,25 +52,27 @@ class StationPlaylistTest extends Unit
         // Sanity check: Jan 15, 2018 is a Monday, and Jan 18, 2018 is a Thursday.
         self::assertTrue($testMonday->isMonday());
         self::assertTrue($testThursday->isThursday());
-        $ctx = $this->scheduler->createContext()
-        ->withPlaylist($playlist);
+        $ctx = new SchedulerContext($playlist);
         // Playlist SHOULD play Monday evening at 10:30PM.
-        $testTime = $testMonday->setTime(22, 30);
-        self::assertTrue($this->scheduler->shouldPlaylistPlayNow($ctx->withNow($testTime)));
+        $ctx->expectedPlayTime = $testMonday->setTime(22, 30);
+        self::assertTrue($this->scheduler->shouldPlaylistPlayNow($ctx));
 
         // Playlist SHOULD play Thursday morning at 3:00AM.
-        $testTime = $testThursday->setTime(3, 0);
-        self::assertTrue($this->scheduler->shouldPlaylistPlayNow($ctx->withNow($testTime)));
+        $ctx->expectedPlayTime = $testThursday->setTime(3, 0);
+        self::assertTrue($this->scheduler->shouldPlaylistPlayNow($ctx));
 
         // Playlist SHOULD NOT play Monday morning at 3:00AM.
-        $testTime = $testMonday->setTime(3, 0);
-        self::assertFalse($this->scheduler->shouldPlaylistPlayNow($ctx->withNow($testTime)));
+        $ctx->expectedPlayTime = $testMonday->setTime(3, 0);
+        self::assertFalse($this->scheduler->shouldPlaylistPlayNow($ctx));
 
         // Playlist SHOULD NOT play Thursday evening at 10:30PM.
-        $testTime = $testThursday->setTime(22, 30);
-        self::assertFalse($this->scheduler->shouldPlaylistPlayNow($ctx->withNow($testTime)));
+        $ctx->expectedPlayTime = $testThursday->setTime(22, 30);
+        self::assertFalse($this->scheduler->shouldPlaylistPlayNow($ctx));
     }
-
+    /**
+     * This test will not pass.
+     * The scheduler was updated to query recent songs instead of relying on played_at.
+     */
     public function testOncePerXMinutesPlaylist()
     {
         /** @var Station $station */
@@ -82,15 +84,14 @@ class StationPlaylistTest extends Unit
         $playlist->setPlayPerMinutes(30);
 
         $utc = new DateTimeZone('UTC');
+        $ctx = new SchedulerContext($playlist);
         $testDay = CarbonImmutable::create(2018, 1, 15, 0, 0, 0, $utc);
-        $ctx = $this->scheduler->createContext()
-        ->withPlaylist($playlist);
-
+        $ctx->expectedTime = $testDay;
         // Last played 20 minutes ago, SHOULD NOT play again.
         $lastPlayed = $testDay->addMinutes(0 - 20);
         $playlist->setPlayedAt($lastPlayed->getTimestamp());
 
-        self::assertFalse($this->scheduler->shouldPlaylistPlayNow($ctx->withNow($testDay)));
+        self::assertFalse($this->scheduler->shouldPlaylistPlayNow($ctx));
 
         // Last played 40 minutes ago, SHOULD play again.
         $lastPlayed = $testDay->addMinutes(0 - 40);
@@ -110,24 +111,24 @@ class StationPlaylistTest extends Unit
         $playlist->setPlayPerHourMinute(50);
 
         $utc = new DateTimeZone('UTC');
+        $ctx = new SchedulerContext($playlist);
         $testDay = CarbonImmutable::create(2018, 1, 15, 0, 0, 0, $utc);
-        $ctx = $this->scheduler->createContext()
-            ->withPlaylist($playlist);
+        $ctx->expectedPlayTime = $testDay;
 
         // Playlist SHOULD try to play at 11:59 PM.
-        $testTime = $testDay->setTime(23, 59);
-        self::assertTrue($this->scheduler->shouldPlaylistPlayNow($ctx->withNow($testTime)));
+        $ctx->expectedPlayTime = $testDay->setTime(23, 59);
+        self::assertTrue($this->scheduler->shouldPlaylistPlayNow($ctx));
 
         // Playlist SHOULD try to play at 12:04 PM.
-        $testTime = $testDay->setTime(12, 4);
+        $ctx->expectedPlayTime = $testDay->setTime(12, 4);
         self::assertTrue($this->scheduler->shouldPlaylistPlayNow($ctx));
 
         // Playlist SHOULD NOT try to play at 11:49 PM.
-        $testTime = $testDay->setTime(23, 49);
+        $ctx->expectedPlayTime = $testDay->setTime(23, 49);
         self::assertFalse($this->scheduler->shouldPlaylistPlayNow($ctx));
 
         // Playlist SHOULD NOT try to play at 12:06 PM.
-        $testTime = $testDay->setTime(12, 6);
+        $ctx->expectedPlayTime = $testDay->setTime(12, 6);
         self::assertFalse($this->scheduler->shouldPlaylistPlayNow($ctx));
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->

Hopefully the last batch of significant adjustments to scheduling internals needed to resolve edge cases.

# Prevents eligibility checks from going back and forth in time

If a scheduled playlist began with a very short track (such as a 'We'll be right back' message, a random unscheduled song could sometimes be inserted in-between this and subsequent items in the scheduled playlist. This is similar in nature to the previous validation issue, in that this happens when the playout runs ahead of schedule such that the drift between expected and actual playtime is enough to make a track ineligible after already being scheduled. The system would check playlist eligibility for a time earlier than a previous schedule check, causing a playlist to rapidly go back and forth between being active and inactive.

## New fields added to station queue

* schedule_id
* timestamp_scheduled
* is_cancelled (see below).

## Necessary adjustments to scheduler internals

I added new out parameters to internal scheduler functions so that extra information (namely the specific schedule item that triggered a playlist as well as the qualifying date range) could propagate through the scheduler and be exported.

Now, when deciding what time to check eligibility for, the system will use either the current 'Expected play time' or the time of the last scheduled track, whichever is later. The timestamp_scheduled field holds either the start timestamp of the associated schedule items, or the original expectedPlayTime (for unscheduled items). This also makes 'has played since' checks more accurate.

# Soft-deletable queue items

I added the ability for queue items to be 'cancelled', or soft-deleted. If you perform a manual delete action on a queue item (or 'Clear upcoming song queue'), it will mark the items as cancelled instead of deleting. This was done for the following reasons:
* Prevents scheduled items from being immediately requeued if manually deleted by admin
* Will make investigation of future edge cases easier with some evidence left behind
* Paves the way for some of the advanced features I would like to contribute in the near future.

This finally solves all of the scheduling problems I have personally experienced. As usual, I'm sure there are some issues with spacing and the like which the test suite didn't catch. Thank you once again for this wonderful software.

