### PR TITLE
feat: optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,16 +32,9 @@ FROM ghcr.io/azuracast/icecast-kh-ac:2024-02-13 AS icecast
 #
 FROM mlocati/php-extension-installer AS php-extension-installer
 
-#
-# Final build image
-#
-FROM php:8.3-fpm-bookworm AS pre-final
+# ---
 
-ENV TZ="UTC" \
-    LANGUAGE="en_US.UTF-8" \
-    LC_ALL="en_US.UTF-8" \
-    LANG="en_US.UTF-8" \
-    LC_TYPE="en_US.UTF-8"
+FROM scratch AS dependencies
 
 # Add PHP extension installer tool
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
@@ -58,6 +51,19 @@ COPY --from=mariadb /usr/local/bin/docker-entrypoint.sh /usr/local/bin/db_entryp
 # Add Icecast
 COPY --from=icecast /usr/local/bin/icecast /usr/local/bin/icecast
 COPY --from=icecast /usr/local/share/icecast /usr/local/share/icecast
+
+#
+# Final build image
+#
+FROM php:8.3-fpm-bookworm AS pre-final
+
+ENV TZ="UTC" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LC_TYPE="en_US.UTF-8"
+
+COPY --from=dependencies / /
 
 # Run base build process
 COPY ./util/docker/common /bd_build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 #
 # Golang dependencies build step
 #
@@ -63,46 +65,45 @@ ENV TZ="UTC" \
     LANG="en_US.UTF-8" \
     LC_TYPE="en_US.UTF-8"
 
-COPY --from=dependencies / /
+COPY --link --from=dependencies / /
 
 # Run base build process
-COPY ./util/docker/common /bd_build/
+RUN --mount=type=bind,source=./util/docker/common,target=/bd_build,rw \
+    bash /bd_build/prepare.sh && \
+    bash /bd_build/add_user.sh && \
+    bash /bd_build/cleanup.sh
 
-RUN bash /bd_build/prepare.sh \
-    && bash /bd_build/add_user.sh \
-    && bash /bd_build/cleanup.sh
+# Build each set of dependencies in their own step for cacheability.
+RUN --mount=type=bind,source=./util/docker/common,target=/bd_build,rw \
+    --mount=type=bind,source=./util/docker/supervisor,target=/bd_build/supervisor,rw \
+    bash /bd_build/supervisor/setup.sh && \
+    bash /bd_build/cleanup.sh
+
+RUN --mount=type=bind,source=./util/docker/common,target=/bd_build,rw \
+    --mount=type=bind,source=./util/docker/stations,target=/bd_build/stations,rw \
+    bash /bd_build/stations/setup.sh && \
+    bash /bd_build/cleanup.sh
+
+RUN --mount=type=bind,source=./util/docker/common,target=/bd_build,rw \
+    --mount=type=bind,source=./util/docker/web,target=/bd_build/web,rw \
+    bash /bd_build/web/setup.sh && \
+    bash /bd_build/cleanup.sh
+
+RUN --mount=type=bind,source=./util/docker/common,target=/bd_build,rw \
+    --mount=type=bind,source=./util/docker/mariadb,target=/bd_build/mariadb,rw \
+    bash /bd_build/mariadb/setup.sh && \
+    bash /bd_build/cleanup.sh
+
+RUN --mount=type=bind,source=./util/docker/common,target=/bd_build,rw \
+    --mount=type=bind,source=./util/docker/redis,target=/bd_build/redis,rw \
+    bash /bd_build/redis/setup.sh && \
+    bash /bd_build/cleanup.sh
+
+RUN --mount=type=bind,source=./util/docker/common,target=/bd_build,rw \
+    bash /bd_build/chown_dirs.sh
 
 # Add built-in docs
 COPY --from=docs --chown=azuracast:azuracast /dist /var/azuracast/docs
-
-# Build each set of dependencies in their own step for cacheability.
-COPY ./util/docker/supervisor /bd_build/supervisor/
-RUN bash /bd_build/supervisor/setup.sh \
-    && bash /bd_build/cleanup.sh \
-    && rm -rf /bd_build/supervisor
-
-COPY ./util/docker/stations /bd_build/stations/
-RUN bash /bd_build/stations/setup.sh \
-    && bash /bd_build/cleanup.sh \
-    && rm -rf /bd_build/stations
-
-COPY ./util/docker/web /bd_build/web/
-RUN bash /bd_build/web/setup.sh \
-    && bash /bd_build/cleanup.sh \
-    && rm -rf /bd_build/web
-
-COPY ./util/docker/mariadb /bd_build/mariadb/
-RUN bash /bd_build/mariadb/setup.sh \
-    && bash /bd_build/cleanup.sh \
-    && rm -rf /bd_build/mariadb
-
-COPY ./util/docker/redis /bd_build/redis/
-RUN bash /bd_build/redis/setup.sh \
-    && bash /bd_build/cleanup.sh \
-    && rm -rf /bd_build/redis
-
-RUN bash /bd_build/chown_dirs.sh \
-    && rm -rf /bd_build
 
 USER azuracast
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN go install github.com/aptible/supercronic@v0.2.32
 
 RUN go install github.com/centrifugal/centrifugo/v5@v5.4.5
 
+RUN strip /go/bin/*
+
 #
 # MariaDB dependencies build step
 #


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Proposed changes:**
This is a refactor of the Dockerfile.

- `strip` go binaries to remove unneeded debug symbols (saves ~30MB)
- move `COPY` into a single layer run `dependencies`
- Use `--mount bind` to avoid copying the build scripts into the Docker layers 
- Move `docs` copy to the end (in case there is a change in docs, the packages build will be rebuilt)

Although my main goal is to try squeeze the image size (currently about 1.8GB), I haven't played enough to see what else may be candidate for cleanup...
