### PR TITLE
Make SFTP Connection URL hint the server URL, not the browser URL

### DIFF
--- a/frontend/components/Stations/SftpUsers.vue
+++ b/frontend/components/Stations/SftpUsers.vue
@@ -50,7 +50,7 @@
                         <dt class="mb-1">
                             {{ $gettext('Server:') }}
                         </dt>
-                        <dd><code>{{ connectionInfo.url }}</code></dd>
+                        <dd><code>{{ connectionInfo.serverUrl }}</code></dd>
 
                         <dd v-if="connectionInfo.ip">
                             {{ $gettext('You may need to connect directly to your IP address:') }}


### PR DESCRIPTION
**Proposed changes:**
* Make the URL hint for SFTP connections [the same as Streamer URL](https://github.com/yasiupl/AzuraCast/blob/e38fa383b58a2cb9a739f8ccdf32008501e6c662/frontend/components/Stations/Streamers/ConnectionInfo.vue#L24C30-L24C54).
* I believe `serverURL` is the Azuracast prefered domain name, regardles of what domain the user uses in the browser. This is the domain name that will expose the actual server hosting Azuracast. The browser URL is routed via web proxies that might block SFTP/SSH (Cloudflare for example).  Thus, `serverURL` is the right choice here.