### PR TITLE
Update to latest 2.3.x RR for LS, prevent Autocue from running twice

### DIFF
--- a/util/docker/stations/setup/liquidsoap.sh
+++ b/util/docker/stations/setup/liquidsoap.sh
@@ -18,8 +18,8 @@ if [[ "$(uname -m)" = "aarch64" ]]; then
     ARCHITECTURE=arm64
 fi
 
-# wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap/releases/download/v2.3.0-rc1/liquidsoap_2.3.0-debian-bookworm-1_${ARCHITECTURE}.deb"
-wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.3.x/liquidsoap-49f617f_2.3.0-debian-bookworm-1_${ARCHITECTURE}.deb"
+# wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.3.x/liquidsoap-49f617f_2.3.0-debian-bookworm-1_${ARCHITECTURE}.deb"
+wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.3.x/liquidsoap-9ab21ac_2.3.0-debian-bookworm-1_${ARCHITECTURE}.deb"
 
 dpkg -i /tmp/liquidsoap.deb
 apt-get install -y -f --no-install-recommends


### PR DESCRIPTION
Prevents autocue from running twice when the `autocue:` protocol and `enable_autocue_metadata()` are used in parallel.