### PR TITLE
Resolve conflict between autocue protocol and metadata resolver

### DIFF
--- a/backend/src/Radio/AutoDJ/Annotations.php
+++ b/backend/src/Radio/AutoDJ/Annotations.php
@@ -37,7 +37,6 @@ final class Annotations implements EventSubscriberInterface
                 ['annotateForLiquidsoap', 15],
                 ['annotatePlaylist', 10],
                 ['annotateRequest', 5],
-                ['enableAutoCue', -5],
                 ['postAnnotation', -10],
             ],
         ];
@@ -191,13 +190,6 @@ final class Annotations implements EventSubscriberInterface
             $event->addAnnotations([
                 'request_id' => $request->getId(),
             ]);
-        }
-    }
-
-    public function enableAutoCue(AnnotateNextSong $event): void
-    {
-        if ($event->getStation()->getBackendConfig()->getEnableAutoCue()) {
-            $event->setProtocol('autocue');
         }
     }
 

--- a/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -272,8 +272,6 @@ final class ConfigWriter implements EventSubscriberInterface
             $station->getRadioTempDir()
         );
 
-        $prefetchRequests = $backendConfig->getEnableAutoCue() ? 2 : 1;
-
         $event->appendBlock(
             <<<LIQ
             # AzuraCast Common Runtime Functions
@@ -300,7 +298,6 @@ final class ConfigWriter implements EventSubscriberInterface
             
             settings.azuracast.live_broadcast_text := "{$liveBroadcastText}"
             
-            settings.request.prefetch := {$prefetchRequests}
             LIQ
         );
 


### PR DESCRIPTION
The Autocue protocol is unnecessary when `enable_autocue_metadata()` is in use. In fact, it causes a conflict in our case.

**Fixes issue:**
https://github.com/AzuraCast/AzuraCast/issues/7513
