### PR TITLE
Icecast mounts chartset based on AutoDJ selected charset

### DIFF
--- a/backend/src/Radio/Frontend/Icecast.php
+++ b/backend/src/Radio/Frontend/Icecast.php
@@ -178,13 +178,18 @@ final class Icecast extends AbstractFrontend
         $bannedCountries = $station->getFrontendConfig()->getBannedCountries() ?? [];
         $allowedIps = $this->getIpsAsArray($station->getFrontendConfig()->getAllowedIps());
         $useListenerAuth = !empty($bannedCountries) || !empty($allowedIps);
+        $charset = match ($station->getBackendConfig()->getCharset()) {
+            'UTF-8' => 'UTF8',
+            'ISO-8859-1' => 'ISO8859-1',
+            default => 'UTF8',
+        };
 
         /** @var StationMount $mountRow */
         foreach ($station->getMounts() as $mountRow) {
             $mount = [
                 '@type' => 'normal',
                 'mount-name' => $mountRow->getName(),
-                'charset' => 'UTF8',
+                'charset' => $charset,
                 'stream-name' => $station->getName(),
                 'listenurl' => $this->getUrlForMount($station, $mountRow),
             ];


### PR DESCRIPTION
This tried address the situation in which Liquidsoap charset is set to ISO and live broadcast is connected to Liquidsoap providing an ISO metadata, since Icecast is hardcoded to UTF-8, the metadata transmission from Liquidsoap to Icecast is encoded in ISO while Icecast expects UTF-8 causing certain characters to not be displayed correctly.
https://github.com/AzuraCast/AzuraCast/issues/7546
_**Untested, couldn't get my dev env up and running at the moment.**_


