### PR TITLE
Allow for setting a Last.fm API key in azuracast.env for dev environment initialization

### DIFF
--- a/azuracast.dev.env
+++ b/azuracast.dev.env
@@ -27,6 +27,7 @@ INIT_MUSIC_PATH=/var/azuracast/www/util/fixtures/init_music
 INIT_PODCASTS_PATH=/var/azuracast/www/util/fixtures/init_podcasts
 
 INIT_GEOLITE_LICENSE_KEY=
+INIT_LASTFM_API_KEY=
 
 # Debugging
 MYSQL_SLOW_QUERY_LOG=1

--- a/backend/src/Entity/Fixture/SettingsFixture.php
+++ b/backend/src/Entity/Fixture/SettingsFixture.php
@@ -21,6 +21,7 @@ final class SettingsFixture extends AbstractFixture
         $settings->setBaseUrl((string)(getenv('INIT_BASE_URL') ?: 'http://docker.local'));
         $settings->setInstanceName((string)(getenv('INIT_INSTANCE_NAME') ?: 'local test'));
         $settings->setGeoliteLicenseKey((string)(getenv('INIT_GEOLITE_LICENSE_KEY') ?: ''));
+        $settings->setLastFmApiKey((string)(getenv('INIT_LASTFM_API_KEY') ?: ''));
 
         $settings->setSetupCompleteTime(time());
         $settings->setPreferBrowserUrl(true);


### PR DESCRIPTION
**Fixes issue:**
N/A

**Proposed changes:**
Populates `lastFmApiKey` using `INIT_LASTFM_API_KEY` in `azuracast.env`. Useful for dev environments and testing Last.fm related functionality.