### PR TITLE
Fixes #7565 -- Splitting long GroupMe messages into chunks and adding a small delay to prevent sending out of order

### DIFF
--- a/backend/src/Webhook/Connector/GroupMe.php
+++ b/backend/src/Webhook/Connector/GroupMe.php
@@ -47,26 +47,32 @@ final class GroupMe extends AbstractConnector
 
         $webhookUrl = $apiUrl . '/bots/post';
 
-        $requestParams = [
-            'bot_id' => $botId,
-            'text' => $messages['text'],
-        ];
+        $text = $messages['text'];
+        $chunks = str_split($text, 1000);
 
-        $response = $this->httpClient->request(
-            'POST',
-            $webhookUrl,
-            [
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                ],
-                'json' => $requestParams,
-            ]
-        );
+        foreach ($chunks as $chunk) {
+            $requestParams = [
+                'bot_id' => $botId,
+                'text' => $chunk,
+            ];
 
-        $this->logHttpResponse(
-            $webhook,
-            $response,
-            $requestParams
-        );
+            $response = $this->httpClient->request(
+                'POST',
+                $webhookUrl,
+                [
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                    ],
+                    'json' => $requestParams,
+                ]
+            );
+
+            $this->logHttpResponse(
+                $webhook,
+                $response,
+                $requestParams
+            );
+            usleep(100000); // Delay to prevent sending out of order
+        }
     }
 }


### PR DESCRIPTION
**Fixes issue:**
#7565

**Proposed changes:**
* Segment message into chunks of 1000 characters each (the limit per GroupMe's API) and send each separately