### PR TITLE
New Last.fm functionality. Update Liquidsoap to latest RR.

### DIFF
--- a/util/docker/stations/setup/liquidsoap.sh
+++ b/util/docker/stations/setup/liquidsoap.sh
@@ -18,7 +18,7 @@ if [[ "$(uname -m)" = "aarch64" ]]; then
     ARCHITECTURE=arm64
 fi
 
-wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.3.x/liquidsoap-6e56d13_2.3.1-debian-bookworm-1_${ARCHITECTURE}.deb"
+wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.3.x/liquidsoap-c0cd13a_2.3.1-debian-bookworm-1_${ARCHITECTURE}.deb"
 
 dpkg -i /tmp/liquidsoap.deb
 apt-get install -y -f --no-install-recommends


### PR DESCRIPTION
New `last.fm scrobbling` functionality `reimplemented from scratch in Liquidsoap language`.  It uses `new` last.fm protocol and is available in this Liquidsoap Rolling Release.  https://github.com/savonet/liquidsoap/blob/main/src/libs/extra/audioscrobbler.liq <sup>Old `lastfm...` functions will be removed.</sup>

<hr/>

### If you'd like to fire this up:

1. Get an API account to obtain "API Key" and "API Secret" (if you don't have them already): https://www.last.fm/api/account/create (You can check the created API applications here: https://www.last.fm/api/accounts)
2. You might want to disconnect your application to get new session key here: https://www.last.fm/settings/applications. It's not always necessary, just in case.
3. If you have any old last.fm related code in your LS config - remove it.
4. Use your credentials (`API_KEY, API_SECRET, USERNAME, PASSWORD`) and paste into the 3rd (THIRD) box of LS configuration:

```ruby
settings.audioscrobbler.api_key := "API_KEY"
settings.audioscrobbler.api_secret := "API_SECRET"

radio = audioscrobbler.submit(
  username="USERNAME",
  password="PASSWORD",
  force=true, 
  metadata_preprocessor=(fun(m) -> if m["jingle_mode"] == "true" then [] else m end),
 radio
)
```

That's it. _The One small code to rule them all._

- While track is being played it's being marked as `Scrobbling now` on last.fm page. 
- When track finishes - it becomes scrobbled. 
- Jingles are not scrobbled. 
- Tracks with no `Artist` or no `Title` are not scrobbled.

<hr/>

P.S.

1. `force=true,` -  is optional line.  If remaining time is null, the song will be assumed to be skipped or cut, and not submitted. Setting `force=true` prevents this behavior.
2. `metadata_preprocessor=` - is optional line. Setting `metadata_preprocessor=(fun(m) -> if m["jingle_mode"] == "true" then [] else m end),` will prevent jingles from scrobbling. If function retunrns `[]` - scrobbling is skipped.
3. <sup>New audioscrobbler operators are added, most importantly `audioscrobbler.api.track.updateNowPlaying` and `audioscrobbler.api.track.scrobble`. The operators are combined into `audioscrobbler.submit` which takes a source and applies `updateNowPlaying` when a track starts and `scrobble` when it ends.</sup>

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
