### PR TITLE
Live Broadcast ending fix

### DIFF
--- a/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -858,7 +858,7 @@ final class ConfigWriter implements EventSubscriberInterface
             
             radio = fallback(
                 id="live_fallback",
-                track_sensitive=false,
+                track_sensitive=true,
                 replay_metadata=true,
                 transitions=[
                     fun (_, s) -> begin


### PR DESCRIPTION
Fixes https://github.com/AzuraCast/AzuraCast/discussions/7669

...in recent versions of AzuraCast, after the Streamer/DJ disconnects, a fragment of the last song (the one playing before the live broadcast started) continues to play for a few seconds, overlapping with the track that should normally begin.

Because we have this:

```
if live.is_ready() then
        if not azuracast.to_live() then
            azuracast.to_live := true
            radio_without_live.skip()
        end
```

Which skips `radio_without_live` - we make `track_sensitive=true` because source gets skipped anyway so no need for `track_sensitive=false` as it results in the above mentioned behavior.

```
radio = fallback(
    id="live_fallback",
    # track_sensitive=false,
    track_sensitive=true,
    replay_metadata=true,
    transitions=[
        fun (_, s) -> begin
            log("executing transition to live")
            insert_latest_live_metadata()
            s
        end, 
        fun (_, s) -> begin
            s
        end
    ],
    [live, radio]
)
```

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->
