### PR TITLE
Specify logging driver in docker-compose.sample.yml

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -191,6 +191,7 @@ services:
         soft: 65536
         hard: 65536
     logging:
+      driver: "json-file"
       options:
         max-size: "1m"
         max-file: "5"


### PR DESCRIPTION
This single-line addition specifies that the "json-file" driver is relied upon for AzuraCast. Since the script downloads and modifies this file, this should help address #5402.

**Fixes issue:** #5402 

**Proposed changes:**
- Specifies the "json-file" logging driver in the base Docker compose configuration, which is modified by the installer script.