### PR TITLE
Update API link in Generic.vue to use local docs

### DIFF
--- a/frontend/components/Stations/Webhooks/Form/Generic.vue
+++ b/frontend/components/Stations/Webhooks/Form/Generic.vue
@@ -21,7 +21,7 @@
             <ul>
                 <li>
                     <a
-                        href="https://azuracast.com/api"
+                        href="/api"
                         target="_blank"
                     >
                         {{ $gettext('NowPlaying API Response') }}


### PR DESCRIPTION
**Proposed changes:**

- Bring users to the locally hosted API docs rather than the live docs.