### PR TITLE
Allow users to choose color for embeds to the Discord webhook

### DIFF
--- a/backend/src/Webhook/Connector/Discord.php
+++ b/backend/src/Webhook/Connector/Discord.php
@@ -106,7 +106,7 @@ final class Discord extends AbstractConnector
                 'title' => $vars['title'] ?? '',
                 'description' => $vars['description'] ?? '',
                 'url' => $this->getValidUrl($vars['url']) ?? '',
-                'color' => $colorDecimal, 
+                'color' => $colorDecimal,
             ]
         );
 

--- a/backend/src/Webhook/Connector/Discord.php
+++ b/backend/src/Webhook/Connector/Discord.php
@@ -87,9 +87,18 @@ final class Discord extends AbstractConnector
             'author' => $config['author'] ?? '',
             'thumbnail' => $config['thumbnail'] ?? '',
             'footer' => $config['footer'] ?? '',
+            'color' => $config['color'] ?? '',
         ];
 
         $vars = $this->replaceVariables($rawVars, $np);
+
+        // Convert hex color to decimal if valid. Otherwise use default.
+        $colorInput = trim($vars['color'] ?? '');
+        if (!empty($colorInput) && preg_match('/^#[0-9A-F]{6}$/', $colorInput)) {
+            $colorDecimal = hexdec(ltrim($colorInput, '#'));
+        } else {
+            $colorDecimal = 2201331; // #2196f3
+        }
 
         // Compose webhook
         $embed = array_filter(
@@ -97,7 +106,7 @@ final class Discord extends AbstractConnector
                 'title' => $vars['title'] ?? '',
                 'description' => $vars['description'] ?? '',
                 'url' => $this->getValidUrl($vars['url']) ?? '',
-                'color' => 2201331, // #2196f3
+                'color' => $colorDecimal, 
             ]
         );
 

--- a/frontend/components/Stations/Webhooks/Form/Discord.vue
+++ b/frontend/components/Stations/Webhooks/Form/Discord.vue
@@ -69,6 +69,13 @@
                 :field="v$.config.footer"
                 :label="$gettext('Footer Text')"
             />
+
+            <form-group-field
+                id="form_config_color" 
+                class="col-md-6" 
+                :field="v$.config.color"
+                :label="$gettext('Embed Color (Hex)')"
+            />
         </div>
     </tab>
 </template>
@@ -77,7 +84,7 @@
 import FormGroupField from "~/components/Form/FormGroupField.vue";
 import CommonFormattingInfo from "~/components/Stations/Webhooks/Form/Common/FormattingInfo.vue";
 import {useVuelidateOnFormTab} from "~/functions/useVuelidateOnFormTab";
-import {required} from "@vuelidate/validators";
+import {required, helpers} from "@vuelidate/validators";
 import {useTranslate} from "~/vendor/gettext";
 import Tab from "~/components/Common/Tab.vue";
 import {WebhookComponentProps} from "~/components/Stations/Webhooks/EditModal.vue";
@@ -85,9 +92,14 @@ import {ApiGenericForm} from "~/entities/ApiInterfaces.ts";
 
 defineProps<WebhookComponentProps>();
 
-const form = defineModel<ApiGenericForm>('form', {required: true});
+const form = defineModel<ApiGenericForm>('form', { required: true });
+
 
 const {$gettext} = useTranslate();
+const hexColor = helpers.withMessage(
+    $gettext('This field must be a valid, non-transparent 6-character hex color.'),
+    (value: string) => /^#[0-9A-F]{6}$/i.test(value)
+);
 
 const {v$, tabClass} = useVuelidateOnFormTab(
     form,
@@ -101,6 +113,7 @@ const {v$, tabClass} = useVuelidateOnFormTab(
             author: {},
             thumbnail: {},
             footer: {},
+            color: {hexColor}
         }
     },
     () => ({
@@ -116,6 +129,7 @@ const {v$, tabClass} = useVuelidateOnFormTab(
             author: '{{ live.streamer_name }}',
             thumbnail: '{{ now_playing.song.art }}',
             footer: $gettext('Powered by AzuraCast'),
+            color: '#3498DB'
         }
     })
 );

--- a/frontend/components/Stations/Webhooks/Form/Discord.vue
+++ b/frontend/components/Stations/Webhooks/Form/Discord.vue
@@ -98,7 +98,7 @@ const form = defineModel<ApiGenericForm>('form', { required: true });
 const {$gettext} = useTranslate();
 const hexColor = helpers.withMessage(
     $gettext('This field must be a valid, non-transparent 6-character hex color.'),
-    (value: string) => /^#[0-9A-F]{6}$/i.test(value)
+    (value: string) => value === '' || /^#?[0-9A-F]{6}$/i.test(value)
 );
 
 const {v$, tabClass} = useVuelidateOnFormTab(


### PR DESCRIPTION
**Proposed changes:**

- Discord supports a `color` param to use as the accent color for embeds. This PR lets users select the (hex) color to use, converting it to decimal before passing it into the request. If left empty, defaults to blue (as it did previously).