### PR TITLE
Fix issue #7806 - Prevent automatic int cast in findOneBy / SQL execution when fetching file if non-numeric id is supplied

### DIFF
--- a/backend/src/Controller/Api/Stations/FilesController.php
+++ b/backend/src/Controller/Api/Stations/FilesController.php
@@ -423,6 +423,10 @@ final class FilesController extends AbstractStationApiCrudController
         $repo = $this->em->getRepository($this->entityClass);
 
         foreach (['id', 'unique_id', 'song_id'] as $field) {
+            if ($field === 'id' && !is_numeric($id)) {
+                continue;
+            }
+
             $record = $repo->findOneBy(
                 [
                     'storage_location' => $mediaStorage,


### PR DESCRIPTION
**Fixes issue:**
Fixes #7806

**Proposed changes:**
Due to the order of the fields in the foreach loop when looking for the file associated with the provided `id` param a `song_id` or `unique_id` can be mistakenly be related to a primary `id` of a file, causing it to return the wrong file. Since the DB knows the field is an integer it will cast the given string of a `song_id` into an integer when looking it up causing it to look for a wrong id.

We can prevent this by checking if the `id` param is actually numeric before quering the DB on the primary `id` field.