### PR TITLE
 Update to LS RR 1eaf75e 

### DIFF
--- a/util/docker/stations/setup/liquidsoap.sh
+++ b/util/docker/stations/setup/liquidsoap.sh
@@ -22,7 +22,6 @@ fi
 wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.3.x/
 liquidsoap-1eaf75e_2.3.4-debian-bookworm-ocaml5.3.0-1_${ARCHITECTURE}.deb"
 
-
 dpkg -i /tmp/liquidsoap.deb
 apt-get install -y -f --no-install-recommends
 rm -f /tmp/liquidsoap.deb

--- a/util/docker/stations/setup/liquidsoap.sh
+++ b/util/docker/stations/setup/liquidsoap.sh
@@ -20,7 +20,7 @@ fi
 
 # wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap/releases/download/v2.3.2/liquidsoap_2.3.2-debian-bookworm-2_${ARCHITECTURE}.deb"
 wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.3.x/
-liquidsoap-1eaf75e-dbgsym_2.3.4-debian-bookworm-ocaml5.3.0-1_${ARCHITECTURE}.deb"
+liquidsoap-1eaf75e_2.3.4-debian-bookworm-ocaml5.3.0-1_${ARCHITECTURE}.deb"
 
 
 dpkg -i /tmp/liquidsoap.deb

--- a/util/docker/stations/setup/liquidsoap.sh
+++ b/util/docker/stations/setup/liquidsoap.sh
@@ -19,7 +19,9 @@ if [[ "$(uname -m)" = "aarch64" ]]; then
 fi
 
 # wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap/releases/download/v2.3.2/liquidsoap_2.3.2-debian-bookworm-2_${ARCHITECTURE}.deb"
-wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.3.x/liquidsoap-97c7c56_2.3.3-debian-bookworm-1_${ARCHITECTURE}.deb"
+wget -O /tmp/liquidsoap.deb "https://github.com/savonet/liquidsoap-release-assets/releases/download/rolling-release-v2.3.x/
+liquidsoap-1eaf75e-dbgsym_2.3.4-debian-bookworm-ocaml5.3.0-1_${ARCHITECTURE}.deb"
+
 
 dpkg -i /tmp/liquidsoap.deb
 apt-get install -y -f --no-install-recommends


### PR DESCRIPTION
**Proposed changes:**
[liquidsoap 2.3.3](https://github.com/savonet/liquidsoap-release-assets/releases/tag/v2.3.3) [Latest](https://github.com/savonet/liquidsoap-release-assets/releases/latest)

This is the third bug-fix release of the 2.3.x release cycle! 🎉

This release was triggered by a segfault caused by a memory corruption in the new lufs C code that was introduced with release 2.3.2. If you are using this code and this release, please consider upgrading.