### PR TITLE
Ensure extra metadata for vorbiscomment is given as multi-line string instead of an array

### DIFF
--- a/backend/src/Media/Metadata/Writer.php
+++ b/backend/src/Media/Metadata/Writer.php
@@ -40,7 +40,12 @@ final class Writer
         $tagwriter->tagformats = $tagFormats;
 
         $writeTags = $metadata->getKnownTags();
-        $writeTags['text'] = $metadata->getExtraTags();
+
+        // GetID3 requires all tags for vorbiscomment to have string values
+        // so we explicitly need to convert the extra tags into a multiline string
+        $writeTags['text'] = in_array('vorbiscomment', $tagFormats)
+            ? implode(PHP_EOL, $metadata->getExtraTags())
+            : $metadata->getExtraTags();
 
         $artContents = $metadata->getArtwork();
         if (null !== $artContents) {


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
While looking over an installation of a friend I encountered some write errors for .ogg files that caused a type error in the GetID3 Writer:
```
AzuraCast.ERROR: Cannot write metadata for file "/var/azuracast/stations/radio/media/dj_set_1996503003.ogg":
strstr(): Argument #1 ($haystack) must be of type string, array given
{
    "path" : "/var/azuracast/stations/radio/media/dj_set_1996503003.ogg",
    "exception" : "[object] (TypeError(code: 0): strstr(): Argument #1 ($haystack) must be of type string, array given at /var/azuracast/www/vendor/james-heinrich/getid3/src/WriteTags.php:705)"
} []
```

When lookin at the metadata contained in the `$tag_data_vorbiscomment` of the `getid3/src/WriteTags.php` in the method where this crashes I saw the following data in the `TEXT` tag:
```
[TEXT] => Array
(
    [0] => Array
        (
            [handler_name] => SoundHandler
            [major_brand] => isom
            [minor_version] => 512
            [compatible_brands] => isomiso2mp41
        )

)
```

The `FormatDataForVorbisComment` method of GetID3 however requires all tags to be of type string: https://github.com/JamesHeinrich/getID3/blob/9f83bdd8c772283a46b8e2664bf2a862a2ced0e8/getid3/write.php#L734

However due to the strict typing and the unchecked call to `strstr` this crashes before it can even handle the wrong type, leaving us with a type error.

In order to fix this problem I've added an explizit implode of the `extraTags` into a multiline string which is what GetID3 would expect there.