### PR TITLE
Fix writing metadata for aac files due to bug in upstream library

### DIFF
--- a/backend/src/Media/MimeTypeExtensionMap.php
+++ b/backend/src/Media/MimeTypeExtensionMap.php
@@ -11,12 +11,15 @@ final class MimeTypeExtensionMap extends GeneratedExtensionToMimeTypeMap
     public const array ADDED_MIME_TYPES = [
         'mod' => 'audio/x-mod',
         'stm' => 'audio/x-mod',
+        // Temporary Bugfix for incorrectly mapped aac mime type in library
+        // @see https://github.com/thephpleague/mime-type-detection/pull/40
+        'aac' => 'audio/aac',
     ];
 
     public function lookupMimeType(string $extension): ?string
     {
-        return parent::lookupMimeType($extension)
-            ?? self::ADDED_MIME_TYPES[$extension]
+        return self::ADDED_MIME_TYPES[$extension]
+            ?? parent::lookupMimeType($extension)
             ?? null;
     }
 }


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**

Due to wrongly mapped `aac` mime type in the upstream library `league/mime-type-detection` which mapps `aac` to `audio/acc` instead of `audio/aac` we encounter the following error when trying to save an .aac file via the UI after editing some metadata:
> PHP Fatal error:  Uncaught RuntimeException: Cannot write tag formats based on file type.

I have already submitted a PR to the upstream repo of the library but until this is acutally merged we can fix this by adjusting the `lookupMimeType` method in our `MimeTypeExtensionMap` to first look into our `ADDED_MIME_TYPES` constant and providing our own mapping through that.
