### PR TITLE
fix: rename `id` parame to `media_id` in PlayAction and FilesController for consistency in API paths

### DIFF
--- a/backend/src/Controller/Api/Stations/Files/PlayAction.php
+++ b/backend/src/Controller/Api/Stations/Files/PlayAction.php
@@ -42,7 +42,8 @@ final class PlayAction implements SingleActionInterface
     public function __construct(
         private readonly StationMediaRepository $mediaRepo,
         private readonly StationFilesystems $stationFilesystems
-    ) {}
+    ) {
+    }
 
     public function __invoke(
         ServerRequest $request,

--- a/backend/src/Controller/Api/Stations/Files/PlayAction.php
+++ b/backend/src/Controller/Api/Stations/Files/PlayAction.php
@@ -22,7 +22,7 @@ use Psr\Http\Message\ResponseInterface;
         parameters: [
             new OA\Parameter(ref: OpenApi::REF_STATION_ID_REQUIRED),
             new OA\Parameter(
-                name: 'id',
+                name: 'media_id',
                 description: 'Media ID',
                 in: 'path',
                 required: true,
@@ -42,8 +42,7 @@ final class PlayAction implements SingleActionInterface
     public function __construct(
         private readonly StationMediaRepository $mediaRepo,
         private readonly StationFilesystems $stationFilesystems
-    ) {
-    }
+    ) {}
 
     public function __invoke(
         ServerRequest $request,

--- a/backend/src/Controller/Api/Stations/FilesController.php
+++ b/backend/src/Controller/Api/Stations/FilesController.php
@@ -81,7 +81,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
         parameters: [
             new OA\Parameter(ref: OpenApi::REF_STATION_ID_REQUIRED),
             new OA\Parameter(
-                name: 'id',
+                name: 'media_id',
                 description: 'Media ID',
                 in: 'path',
                 required: true,
@@ -108,7 +108,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
         parameters: [
             new OA\Parameter(ref: OpenApi::REF_STATION_ID_REQUIRED),
             new OA\Parameter(
-                name: 'id',
+                name: 'media_id',
                 description: 'Media ID',
                 in: 'path',
                 required: true,
@@ -130,7 +130,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
         parameters: [
             new OA\Parameter(ref: OpenApi::REF_STATION_ID_REQUIRED),
             new OA\Parameter(
-                name: 'id',
+                name: 'media_id',
                 description: 'Media ID',
                 in: 'path',
                 required: true,

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -2452,7 +2452,7 @@ paths:
         -
           $ref: '#/components/parameters/StationIdRequired'
         -
-          name: id
+          name: media_id
           in: path
           description: 'Media ID'
           required: true
@@ -2542,7 +2542,7 @@ paths:
         -
           $ref: '#/components/parameters/StationIdRequired'
         -
-          name: id
+          name: media_id
           in: path
           description: 'Media ID'
           required: true
@@ -2571,7 +2571,7 @@ paths:
         -
           $ref: '#/components/parameters/StationIdRequired'
         -
-          name: id
+          name: media_id
           in: path
           description: 'Media ID'
           required: true
@@ -2601,7 +2601,7 @@ paths:
         -
           $ref: '#/components/parameters/StationIdRequired'
         -
-          name: id
+          name: media_id
           in: path
           description: 'Media ID'
           required: true
@@ -6822,10 +6822,12 @@ components:
           description: 'The stable-equivalent branch your installation currently appears to be on.'
           type: string
           example: 0.20.3
+          nullable: true
         latest_release:
           description: 'The current latest stable release of the software.'
           type: string
           example: 0.20.4
+          nullable: true
         needs_rolling_update:
           description: 'If you are on the Rolling Release, whether your installation needs to be updated.'
           type: boolean
@@ -8570,10 +8572,6 @@ components:
           description: 'The UNIX timestamp when the Maxmind Geolite was last downloaded.'
           type: integer
           example: 1609480800
-        enable_advanced_features:
-          description: "Whether to enable 'advanced' functionality in the system that is intended for power users."
-          type: boolean
-          example: false
         mail_enabled:
           description: 'Enable e-mail delivery across the application.'
           type: boolean
@@ -9031,6 +9029,9 @@ components:
           type: string
           nullable: true
         title:
+          type: string
+          nullable: true
+        album:
           type: string
           nullable: true
       type: object


### PR DESCRIPTION
Assuming media items should be referred to by `media_id` (matching `GET` & `POST` `/station/{station_id}/waveform/{media_id}`, `POST` & `DELETE` `/station/{station_id}/art/{media_id}`)