### PR TITLE
refactor: property descriptions in StationMedia for clarity and consistency

### DIFF
--- a/backend/src/Entity/Api/StationMedia.php
+++ b/backend/src/Entity/Api/StationMedia.php
@@ -21,26 +21,26 @@ class StationMedia
     use HasLinks;
 
     #[OA\Property(
-        description: 'The media\'s identifier.',
+        description: "The media's identifier.",
         example: 1
     )]
     public int $id;
 
     #[OA\Property(
-        description: "A unique identifier associated with this record.",
+        description: "A unique identifier for this specific media item in the station's library. Each entry in the media table has a unique ID, even if it refers to a song that already exists elsewhere.",
         example: "69b536afc7ebbf16457b8645"
     )]
     public string $unique_id = '';
 
     #[OA\Property(
-        description: 'The media file\'s 32-character unique song identifier hash',
-        example: '9f33bbc912c19603e51be8e0987d076b'
+        description: "The media file's 32-character unique song identifier hash. This hash is based on the audio content, so the same song uploaded multiple times will have the same `song_id`.",
+        example: "9f33bbc912c19603e51be8e0987d076b"
     )]
     public string $song_id = '';
 
     #[OA\Property(
-        description: 'URL to the album art.',
-        example: 'https://picsum.photos/1200/1200'
+        description: "URL to the album art.",
+        example: "https://picsum.photos/1200/1200"
     )]
     public string $art = '';
 

--- a/backend/src/Entity/Api/StationMedia.php
+++ b/backend/src/Entity/Api/StationMedia.php
@@ -27,13 +27,15 @@ class StationMedia
     public int $id;
 
     #[OA\Property(
-        description: "A unique identifier for this specific media item in the station's library. Each entry in the media table has a unique ID, even if it refers to a song that already exists elsewhere.",
+        description: "A unique identifier for this specific media item in the station's library. " .
+            "Each entry in the media table has a unique ID, even if it refers to a song that exists elsewhere.",
         example: "69b536afc7ebbf16457b8645"
     )]
     public string $unique_id = '';
 
     #[OA\Property(
-        description: "The media file's 32-character unique song identifier hash. This hash is based on the audio content, so the same song uploaded multiple times will have the same `song_id`.",
+        description: "The media file's 32-character unique song identifier hash. This hash is based " .
+            "on the audio content, so the same song uploaded multiple times will have the same `song_id`.",
         example: "9f33bbc912c19603e51be8e0987d076b"
     )]
     public string $song_id = '';

--- a/backend/src/Entity/Api/StationMedia.php
+++ b/backend/src/Entity/Api/StationMedia.php
@@ -35,7 +35,7 @@ class StationMedia
 
     #[OA\Property(
         description: "The media file's 32-character unique song identifier hash. This hash is based " .
-            "on the audio content, so the same song uploaded multiple times will have the same `song_id`.",
+        "on track metadata, so the same song uploaded multiple times will have the same `song_id`.",
         example: "9f33bbc912c19603e51be8e0987d076b"
     )]
     public string $song_id = '';

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -6822,10 +6822,12 @@ components:
           description: 'The stable-equivalent branch your installation currently appears to be on.'
           type: string
           example: 0.20.3
+          nullable: true
         latest_release:
           description: 'The current latest stable release of the software.'
           type: string
           example: 0.20.4
+          nullable: true
         needs_rolling_update:
           description: 'If you are on the Rolling Release, whether your installation needs to be updated.'
           type: boolean
@@ -7721,11 +7723,11 @@ components:
               type: integer
               example: 1
             unique_id:
-              description: 'A unique identifier associated with this record.'
+              description: "A unique identifier for this specific media item in the station's library. Each entry in the media table has a unique ID, even if it refers to a song that already exists elsewhere."
               type: string
               example: 69b536afc7ebbf16457b8645
             song_id:
-              description: "The media file's 32-character unique song identifier hash"
+              description: "The media file's 32-character unique song identifier hash. This hash is based on the audio content, so the same song uploaded multiple times will have the same `song_id`."
               type: string
               example: 9f33bbc912c19603e51be8e0987d076b
             art:
@@ -8570,10 +8572,6 @@ components:
           description: 'The UNIX timestamp when the Maxmind Geolite was last downloaded.'
           type: integer
           example: 1609480800
-        enable_advanced_features:
-          description: "Whether to enable 'advanced' functionality in the system that is intended for power users."
-          type: boolean
-          example: false
         mail_enabled:
           description: 'Enable e-mail delivery across the application.'
           type: boolean
@@ -9031,6 +9029,9 @@ components:
           type: string
           nullable: true
         title:
+          type: string
+          nullable: true
+        album:
           type: string
           nullable: true
       type: object

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -7723,11 +7723,11 @@ components:
               type: integer
               example: 1
             unique_id:
-              description: "A unique identifier for this specific media item in the station's library. Each entry in the media table has a unique ID, even if it refers to a song that already exists elsewhere."
+              description: "A unique identifier for this specific media item in the station's library. Each entry in the media table has a unique ID, even if it refers to a song that exists elsewhere."
               type: string
               example: 69b536afc7ebbf16457b8645
             song_id:
-              description: "The media file's 32-character unique song identifier hash. This hash is based on the audio content, so the same song uploaded multiple times will have the same `song_id`."
+              description: "The media file's 32-character unique song identifier hash. This hash is based on track metadata, so the same song uploaded multiple times will have the same `song_id`."
               type: string
               example: 9f33bbc912c19603e51be8e0987d076b
             art:


### PR DESCRIPTION
If I understand correctly,
* `song_id` is a hash that identifies the actual audio file. If you were to upload the same song twice, both files will have the same `song_id`, useful for detecting duplicate media files.
* `unique_id` is for the specific database record of a media file in a station's library. Each entry in the media table gets its own `unique_id`, even if it points to a song that already exists elsewhere (sharing a `song_id`).

This wasn't initially clear in the API docs, so I propose these updates to help clarify things for future users.