### PR TITLE
Add configurable timestamp option for Discord webhook

### DIFF
--- a/backend/src/Webhook/Connector/Discord.php
+++ b/backend/src/Webhook/Connector/Discord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Webhook\Connector;
 
+use DateTime;
 use App\Entity\Api\NowPlaying\NowPlaying;
 use App\Entity\Station;
 use App\Entity\StationWebhook;
@@ -113,7 +114,7 @@ final class Discord extends AbstractConnector
         );
 
         if ($includeTimestamp) {
-            $embed['timestamp'] = (new \DateTime())->format(\DateTime::ATOM);
+            $embed['timestamp'] = (new DateTime())->format(DateTime::ATOM);
         }
 
         if (!empty($vars['author'])) {

--- a/backend/src/Webhook/Connector/Discord.php
+++ b/backend/src/Webhook/Connector/Discord.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace App\Webhook\Connector;
 
-use DateTime;
-
 use App\Entity\Api\NowPlaying\NowPlaying;
 use App\Entity\Station;
 use App\Entity\StationWebhook;
+use DateTime;
 
 /*
  * https://discordapp.com/developers/docs/resources/webhook#execute-webhook

--- a/backend/src/Webhook/Connector/Discord.php
+++ b/backend/src/Webhook/Connector/Discord.php
@@ -101,6 +101,8 @@ final class Discord extends AbstractConnector
         }
 
         // Compose webhook
+        $includeTimestamp = !empty($config['include_timestamp']);
+
         $embed = array_filter(
             [
                 'title' => $vars['title'] ?? '',
@@ -109,6 +111,10 @@ final class Discord extends AbstractConnector
                 'color' => $colorDecimal,
             ]
         );
+
+        if ($includeTimestamp) {
+            $embed['timestamp'] = (new \DateTime())->format(\DateTime::ATOM);
+        }
 
         if (!empty($vars['author'])) {
             $embed['author'] = [

--- a/backend/src/Webhook/Connector/Discord.php
+++ b/backend/src/Webhook/Connector/Discord.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Webhook\Connector;
 
 use DateTime;
+
 use App\Entity\Api\NowPlaying\NowPlaying;
 use App\Entity\Station;
 use App\Entity\StationWebhook;

--- a/backend/src/Webhook/Connector/Discord.php
+++ b/backend/src/Webhook/Connector/Discord.php
@@ -7,7 +7,8 @@ namespace App\Webhook\Connector;
 use App\Entity\Api\NowPlaying\NowPlaying;
 use App\Entity\Station;
 use App\Entity\StationWebhook;
-use DateTime;
+use App\Utilities\Time;
+use App\Utilities\Types;
 
 /*
  * https://discordapp.com/developers/docs/resources/webhook#execute-webhook
@@ -102,7 +103,7 @@ final class Discord extends AbstractConnector
         }
 
         // Compose webhook
-        $includeTimestamp = !empty($config['include_timestamp']);
+        $includeTimestamp = Types::bool($config['include_timestamp'] ?? false, false, true);
 
         $embed = array_filter(
             [
@@ -114,7 +115,7 @@ final class Discord extends AbstractConnector
         );
 
         if ($includeTimestamp) {
-            $embed['timestamp'] = (new DateTime())->format(DateTime::ATOM);
+            $embed['timestamp'] = Time::nowUtc()->toAtomString();
         }
 
         if (!empty($vars['author'])) {

--- a/frontend/components/Stations/Webhooks/Form/Discord.vue
+++ b/frontend/components/Stations/Webhooks/Form/Discord.vue
@@ -131,7 +131,7 @@ const {v$, tabClass} = useVuelidateOnFormTab(
             thumbnail: {},
             footer: {},
             color: {hexColor},
-            include_timestamp: {}
+            include_timestamp: false
         }
     },
     () => ({

--- a/frontend/components/Stations/Webhooks/Form/Discord.vue
+++ b/frontend/components/Stations/Webhooks/Form/Discord.vue
@@ -101,7 +101,7 @@
 import FormGroupField from "~/components/Form/FormGroupField.vue";
 import CommonFormattingInfo from "~/components/Stations/Webhooks/Form/Common/FormattingInfo.vue";
 import {useVuelidateOnFormTab} from "~/functions/useVuelidateOnFormTab";
-import {required, helpers} from "@vuelidate/validators";
+import {helpers, required} from "@vuelidate/validators";
 import {useTranslate} from "~/vendor/gettext";
 import Tab from "~/components/Common/Tab.vue";
 import {WebhookComponentProps} from "~/components/Stations/Webhooks/EditModal.vue";
@@ -131,7 +131,7 @@ const {v$, tabClass} = useVuelidateOnFormTab(
             thumbnail: {},
             footer: {},
             color: {hexColor},
-            include_timestamp: false
+            include_timestamp: {}
         }
     },
     () => ({

--- a/frontend/components/Stations/Webhooks/Form/Discord.vue
+++ b/frontend/components/Stations/Webhooks/Form/Discord.vue
@@ -76,6 +76,23 @@
                 :field="v$.config.color"
                 :label="$gettext('Embed Color (Hex)')"
             />
+
+            <div class="col-md-12">
+                <div class="form-check mb-2">
+                    <input 
+                        id="form_config_include_timestamp"
+                        class="form-check-input" 
+                        type="checkbox" 
+                        v-model="v$.config.include_timestamp.$model"
+                    >
+                    <label class="form-check-label" for="form_config_include_timestamp">
+                        {{ $gettext('Include Timestamp') }}
+                    </label>
+                </div>
+                <small class="form-text text-muted">
+                    {{ $gettext('If set, the time sent will be included in the embed footer.') }}
+                </small>
+            </div>
         </div>
     </tab>
 </template>
@@ -113,7 +130,8 @@ const {v$, tabClass} = useVuelidateOnFormTab(
             author: {},
             thumbnail: {},
             footer: {},
-            color: {hexColor}
+            color: {hexColor},
+            include_timestamp: {}
         }
     },
     () => ({
@@ -129,7 +147,8 @@ const {v$, tabClass} = useVuelidateOnFormTab(
             author: '{{ live.streamer_name }}',
             thumbnail: '{{ now_playing.song.art }}',
             footer: $gettext('Powered by AzuraCast'),
-            color: '#3498DB'
+            color: '#3498DB',
+            include_timestamp: true
         }
     })
 );


### PR DESCRIPTION
Introduce a checkbox in the Discord webhook form to include a timestamp in the payload, set to true by default. 