### PR TITLE
Bulk media export/import: add columns & add endpoint to download by `song_id`

### DIFF
--- a/backend/src/Controller/Api/Stations/BulkMedia/DownloadAction.php
+++ b/backend/src/Controller/Api/Stations/BulkMedia/DownloadAction.php
@@ -51,7 +51,8 @@ final class DownloadAction implements SingleActionInterface
     public function __construct(
         private readonly CustomFieldRepository $customFieldRepo,
         private readonly StationPlaylistRepository $playlistRepo,
-    ) {}
+    ) {
+    }
 
     public function __invoke(
         ServerRequest $request,

--- a/backend/src/Controller/Api/Stations/BulkMedia/DownloadAction.php
+++ b/backend/src/Controller/Api/Stations/BulkMedia/DownloadAction.php
@@ -51,8 +51,7 @@ final class DownloadAction implements SingleActionInterface
     public function __construct(
         private readonly CustomFieldRepository $customFieldRepo,
         private readonly StationPlaylistRepository $playlistRepo,
-    ) {
-    }
+    ) {}
 
     public function __invoke(
         ServerRequest $request,
@@ -96,6 +95,8 @@ final class DownloadAction implements SingleActionInterface
          */
         $headerRow = [
             'id',
+            'unique_id',
+            'song_id',
             'path',
             'title',
             'artist',
@@ -134,7 +135,9 @@ final class DownloadAction implements SingleActionInterface
             }
 
             $bodyRow = [
+                $row['id'] ?? '',
                 $row['unique_id'] ?? '',
+                $row['song_id'] ?? '',
                 $row['path'] ?? '',
                 $row['title'] ?? '',
                 $row['artist'] ?? '',

--- a/backend/src/Controller/Api/Stations/BulkMedia/UploadAction.php
+++ b/backend/src/Controller/Api/Stations/BulkMedia/UploadAction.php
@@ -53,6 +53,9 @@ final class UploadAction implements SingleActionInterface
     use EntityManagerAwareTrait;
 
     private const array ALLOWED_MEDIA_FIELDS = [
+        'id',
+        'unique_id',
+        'song_id',
         'title',
         'artist',
         'album',

--- a/backend/src/Controller/Api/Stations/BulkMedia/UploadAction.php
+++ b/backend/src/Controller/Api/Stations/BulkMedia/UploadAction.php
@@ -53,9 +53,6 @@ final class UploadAction implements SingleActionInterface
     use EntityManagerAwareTrait;
 
     private const array ALLOWED_MEDIA_FIELDS = [
-        'id',
-        'unique_id',
-        'song_id',
         'title',
         'artist',
         'album',

--- a/backend/src/Controller/Api/Stations/BulkMedia/UploadAction.php
+++ b/backend/src/Controller/Api/Stations/BulkMedia/UploadAction.php
@@ -130,8 +130,8 @@ final class UploadAction implements SingleActionInterface
 
         foreach ($reader->getRecords() as $row) {
             $row = (array)$row;
-            if (isset($row['id'], $mediaByUniqueId[$row['id']])) {
-                $mediaId = $mediaByUniqueId[$row['id']];
+            if (isset($row['unique_id'], $mediaByUniqueId[$row['unique_id']])) {
+                $mediaId = $mediaByUniqueId[$row['unique_id']];
             } elseif (isset($row['path'], $mediaByPath[md5($row['path'])])) {
                 $mediaId = $mediaByPath[md5($row['path'])];
             } else {

--- a/backend/src/Controller/Api/Stations/Files/PlayAction.php
+++ b/backend/src/Controller/Api/Stations/Files/PlayAction.php
@@ -37,6 +37,30 @@ use Psr\Http\Message\ResponseInterface;
         ]
     )
 ]
+#[
+    OA\Get(
+        path: '/station/{station_id}/file/{song_id}/play',
+        operationId: 'getPlayFileSongId',
+        summary: 'Download or play a given file by song_id.',
+        tags: [OpenApi::TAG_STATIONS_MEDIA],
+        parameters: [
+            new OA\Parameter(ref: OpenApi::REF_STATION_ID_REQUIRED),
+            new OA\Parameter(
+                name: 'song_id',
+                description: 'Media ID',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string', format: 'guid')
+            ),
+        ],
+        responses: [
+            new OpenApi\Response\SuccessWithDownload(),
+            new OpenApi\Response\AccessDenied(),
+            new OpenApi\Response\NotFound(),
+            new OpenApi\Response\GenericError(),
+        ]
+    )
+]
 final class PlayAction implements SingleActionInterface
 {
     public function __construct(

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -2472,7 +2472,7 @@ paths:
     get:
       tags:
         - 'Stations: Media'
-      summary: 'Download or play a given file by `song_id`.'
+      summary: 'Download or play a given file by song_id.'
       operationId: getPlayFileSongId
       parameters:
         -

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -2468,6 +2468,32 @@ paths:
           $ref: '#/components/responses/RecordNotFound'
         '500':
           $ref: '#/components/responses/GenericError'
+  '/station/{station_id}/file/{song_id}/play':
+    get:
+      tags:
+        - 'Stations: Media'
+      summary: 'Download or play a given file by `song_id`.'
+      operationId: getPlayFileSongId
+      parameters:
+        -
+          $ref: '#/components/parameters/StationIdRequired'
+        -
+          name: song_id
+          in: path
+          description: 'Media ID'
+          required: true
+          schema:
+            type: string
+            format: guid
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessWithDownload'
+        '403':
+          $ref: '#/components/responses/AccessDenied'
+        '404':
+          $ref: '#/components/responses/RecordNotFound'
+        '500':
+          $ref: '#/components/responses/GenericError'
   '/station/{station_id}/files/rename':
     put:
       tags:
@@ -6822,10 +6848,12 @@ components:
           description: 'The stable-equivalent branch your installation currently appears to be on.'
           type: string
           example: 0.20.3
+          nullable: true
         latest_release:
           description: 'The current latest stable release of the software.'
           type: string
           example: 0.20.4
+          nullable: true
         needs_rolling_update:
           description: 'If you are on the Rolling Release, whether your installation needs to be updated.'
           type: boolean
@@ -8570,10 +8598,6 @@ components:
           description: 'The UNIX timestamp when the Maxmind Geolite was last downloaded.'
           type: integer
           example: 1609480800
-        enable_advanced_features:
-          description: "Whether to enable 'advanced' functionality in the system that is intended for power users."
-          type: boolean
-          example: false
         mail_enabled:
           description: 'Enable e-mail delivery across the application.'
           type: boolean
@@ -9031,6 +9055,9 @@ components:
           type: string
           nullable: true
         title:
+          type: string
+          nullable: true
+        album:
           type: string
           nullable: true
       type: object


### PR DESCRIPTION
* Introduce `unique_id` and `song_id` fields for bulk export and upload actions. Makes it so that `id` is actually the `id` and not the `unique_id`
* Add an OpenAPI endpoint to facilitate downloading or playing files using `song_id`. Previously this could only be done with the song's `id` - this addition opens up more options for programmatic media management.