### PR TITLE
Add permission for media deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ release channel, you can take advantage of these new features and fixes.
 - The "album" property for `SongInterface`-type items (station timelines, queues, media, etc.) is now supported as a
   first-class property for all tracks.
 
+- Media management permissions have been split into "manage station media" and "delete station media", allowing you to
+  assign permissions to users to add media without being able to remove it. If migrating from a previous version, users
+  who have the "manage" permission will automatically receive the "delete" permission; when assigning new permissions,
+  this new permission will need to be manually assigned.
+
 ## Code Quality/Technical Changes
 
 - We have removed the "Hide Advanced Features" setting from the system settings panel. Often, this setting was disabled

--- a/backend/config/routes/api_station.php
+++ b/backend/config/routes/api_station.php
@@ -198,7 +198,7 @@ return static function (RouteCollectorProxy $group) {
                                             $group->delete(
                                                 '',
                                                 Controller\Api\Stations\PodcastEpisodesController::class
-                                                . ':deleteAction'
+                                                    . ':deleteAction'
                                             );
 
                                             $group->get(
@@ -315,25 +315,25 @@ return static function (RouteCollectorProxy $group) {
                                     $group->get(
                                         '',
                                         Controller\Api\Stations\FilesController::class . ':getAction'
-                                    )->setName('api:stations:file');
+                                    )->setName('api:stations:file')
+                                        ->add(new Middleware\Permissions(StationPermissions::Media, true));
 
                                     $group->put(
                                         '',
                                         Controller\Api\Stations\FilesController::class . ':editAction'
-                                    );
+                                    )->add(new Middleware\Permissions(StationPermissions::Media, true));
 
                                     $group->delete(
                                         '',
                                         Controller\Api\Stations\FilesController::class . ':deleteAction'
-                                    );
+                                    )->add(new Middleware\Permissions(StationPermissions::DeleteMedia, true));
 
                                     $group->get('/play', Controller\Api\Stations\Files\PlayAction::class)
                                         ->setName('api:stations:files:play');
                                 }
                             );
                         }
-                    )->add(new Middleware\StationSupportsFeature(StationFeatures::Media))
-                        ->add(new Middleware\Permissions(StationPermissions::Media, true));
+                    )->add(new Middleware\StationSupportsFeature(StationFeatures::Media));
 
                     // SFTP Users
                     $group->group(
@@ -734,7 +734,7 @@ return static function (RouteCollectorProxy $group) {
                                     $group->get(
                                         '/broadcast/{broadcast_id}/download',
                                         Controller\Api\Stations\Streamers\BroadcastsController::class
-                                        . ':downloadAction'
+                                            . ':downloadAction'
                                     )->setName('api:stations:streamer:broadcast:download');
 
                                     $group->delete(

--- a/backend/src/Controller/Api/Stations/Files/BatchAction.php
+++ b/backend/src/Controller/Api/Stations/Files/BatchAction.php
@@ -18,7 +18,9 @@ use App\Entity\StationPlaylistFolder;
 use App\Entity\StationQueue;
 use App\Entity\StationRequest;
 use App\Entity\StorageLocation;
+use App\Enums\StationPermissions;
 use App\Event\Radio\AnnotateNextSong;
+use App\Exception\Http\PermissionDeniedException;
 use App\Flysystem\ExtendedFilesystemInterface;
 use App\Flysystem\StationFilesystems;
 use App\Http\Response;
@@ -114,6 +116,10 @@ final class BatchAction implements SingleActionInterface
         StorageLocation $storageLocation,
         ExtendedFilesystemInterface $fs
     ): MediaBatchResult {
+        if (!$request->getAcl()->isAllowed(StationPermissions::DeleteMedia, $station)) {
+            throw PermissionDeniedException::create($request);
+        }
+
         $result = $this->parseRequest($request, $fs, true);
 
         $successfulFiles = [];

--- a/backend/src/Entity/Migration/Version20250707074157.php
+++ b/backend/src/Entity/Migration/Version20250707074157.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20250707074157 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add new "delete station media" permission.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $permissions = $this->connection->fetchAllAssociative(
+            <<<SQL
+            SELECT role_id, station_id FROM role_permissions
+            WHERE action_name = :name
+            SQL,
+            [
+                'name' => 'manage station media',
+            ]
+        );
+
+        foreach ($permissions as $row) {
+            $this->addSql(
+                <<<'SQL'
+                INSERT INTO role_permissions
+                SET role_id=:role_id, station_id=:station_id,
+                    action_name=:action_name
+                SQL,
+                [
+                    'role_id' => $row['role_id'],
+                    'station_id' => $row['station_id'] ?? null,
+                    'action_name' => 'delete station media',
+                ]
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(
+            <<<'SQL'
+            DELETE FROM role_permissions
+            WHERE action_name = :action_name
+            SQL,
+            [
+                'action_name' => 'delete station media',
+            ]
+        );
+    }
+}

--- a/backend/src/Enums/StationPermissions.php
+++ b/backend/src/Enums/StationPermissions.php
@@ -19,6 +19,7 @@ enum StationPermissions: string implements PermissionInterface
     case MountPoints = 'manage station mounts';
     case RemoteRelays = 'manage station remotes';
     case Media = 'manage station media';
+    case DeleteMedia = 'delete station media';
     case Automation = 'manage station automation';
     case WebHooks = 'manage station web hooks';
     case Podcasts = 'manage station podcasts';
@@ -36,6 +37,7 @@ enum StationPermissions: string implements PermissionInterface
             self::MountPoints => __('Manage Station Mount Points'),
             self::RemoteRelays => __('Manage Station Remote Relays'),
             self::Media => __('Manage Station Media'),
+            self::DeleteMedia => __('Delete Station Media'),
             self::Automation => __('Manage Station Automation'),
             self::WebHooks => __('Manage Station Web Hooks'),
             self::Podcasts => __('Manage Station Podcasts'),


### PR DESCRIPTION
Prevents certain users from deleting station media.

Introduce a new permission for deleting media and enforce it in the relevant controller actions. Update the permissions enum to include the new deletion permission.