### PR TITLE
bug(hls): Removing AacLowDelay and AacEnhancedLowDelay from HlsStreamProfiles

### DIFF
--- a/backend/src/Radio/Enums/HlsStreamProfiles.php
+++ b/backend/src/Radio/Enums/HlsStreamProfiles.php
@@ -12,8 +12,6 @@ enum HlsStreamProfiles: string
     case AacLowComplexity = 'aac';
     case AacHighEfficiencyV1 = 'aac_he';
     case AacHighEfficiencyV2 = 'aac_he_v2';
-    case AacLowDelay = 'aac_ld';
-    case AacEnhancedLowDelay = 'aac_eld';
 
     public function getProfileName(): string
     {

--- a/frontend/components/Stations/HlsStreams/Form/BasicInfo.vue
+++ b/frontend/components/Stations/HlsStreams/Form/BasicInfo.vue
@@ -69,14 +69,6 @@ const formatOptions = [
     {
         value: HlsStreamProfiles.AacHighEfficiencyV2,
         text: 'AAC High Efficiency V2 (HE-AACv2)'
-    },
-    {
-        value: HlsStreamProfiles.AacEnhancedLowDelay,
-        text: 'AAC Low Delay (LD)'
-    },
-    {
-        value: HlsStreamProfiles.AacEnhancedLowDelay,
-        text: 'AAC Enhanced Low Delay (ELD)'
     }
 ];
 

--- a/frontend/entities/ApiInterfaces.ts
+++ b/frontend/entities/ApiInterfaces.ts
@@ -66,8 +66,6 @@ export enum HlsStreamProfiles {
   AacLowComplexity = "aac",
   AacHighEfficiencyV1 = "aac_he",
   AacHighEfficiencyV2 = "aac_he_v2",
-  AacLowDelay = "aac_ld",
-  AacEnhancedLowDelay = "aac_eld",
 }
 
 export enum FrontendAdapters {

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -9780,14 +9780,10 @@ components:
         - aac
         - aac_he
         - aac_he_v2
-        - aac_ld
-        - aac_eld
       x-enumNames:
         - AacLowComplexity
         - AacHighEfficiencyV1
         - AacHighEfficiencyV2
-        - AacLowDelay
-        - AacEnhancedLowDelay
     MasterMePresets:
       type: string
       enum:


### PR DESCRIPTION
**Fixes issue:**
1. At the actual form, both AAC Low Delay (LD) and AAC Enhanced Low Delay (ELD) was pointing to the same value.
2. Regardless, both of those aren't supported by ADTS which is the mainstream (and probably only widely supported) for HLS.
Selecting any of those will cause Liquidsoap to fail.

**Proposed changes:**
Remove those two..
