### PR TITLE
Fix error in dev fixtures due to missing explicit flag

### DIFF
--- a/backend/src/Entity/Fixture/PodcastFixture.php
+++ b/backend/src/Entity/Fixture/PodcastFixture.php
@@ -27,6 +27,7 @@ final class PodcastFixture extends AbstractFixture implements DependentFixtureIn
         $podcast->description = 'The unofficial testing podcast for the AzuraCast development team.';
         $podcast->author = 'AzuraCast';
         $podcast->email = 'demo@azuracast.com';
+        $podcast->explicit = false;
         $manager->persist($podcast);
 
         $category = new PodcastCategory($podcast, 'Technology');


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
When running the dev setup the process fails due to an error caused by the new `explicit` flag for whole podcasts not being set in the respective fixture thus causing an exception stopping the dev setup:
> An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'explicit' cannot be null

This PR adds the missing flag on the podcast fixture.