### PR TITLE
Fix Issue #8172 - Use composable to return userAllowedForStation function to fix composable usage outside of setup when calling useStationId

### DIFF
--- a/frontend/acl.ts
+++ b/frontend/acl.ts
@@ -16,37 +16,33 @@ export function userAllowed(permission: GlobalPermissions): boolean {
     }
 }
 
-export function userAllowedForStation(permission: StationPermissions, id: number | null = null): boolean {
-    if (id === null) {
-        try {
-            const stationId = useStationId();
-            id = stationId.value;
-        } catch {
-            return false;
+export function useUserAllowedForStation() {
+    const {permissions} = useAzuraCastUser();
+    const stationId = useStationId();
+
+    return {
+        userAllowedForStation: (permission: StationPermissions) => {
+            try {
+                if (userAllowed(GlobalPermissions.Stations)) {
+                    return true;
+                }
+
+                const thisStationPermissions = permissions.station.find(
+                    (row) => row.id === stationId.value
+                );
+
+                if (thisStationPermissions === undefined) {
+                    return false;
+                }
+
+                if (thisStationPermissions.permissions.indexOf(StationPermissions.All) !== -1) {
+                    return true;
+                }
+
+                return thisStationPermissions.permissions.indexOf(permission) !== -1;
+            } catch {
+                return false;
+            }
         }
-    }
-
-    if (userAllowed(GlobalPermissions.Stations)) {
-        return true;
-    }
-
-    try {
-        const {permissions} = useAzuraCastUser();
-
-        const thisStationPermissions = permissions.station.find(
-            (row) => row.id === id
-        );
-
-        if (thisStationPermissions === undefined) {
-            return false;
-        }
-
-        if (thisStationPermissions.permissions.indexOf(StationPermissions.All) !== -1) {
-            return true;
-        }
-
-        return thisStationPermissions.permissions.indexOf(permission) !== -1;
-    } catch {
-        return false;
-    }
+    };
 }

--- a/frontend/components/Stations/Profile/BackendPanel.vue
+++ b/frontend/components/Stations/Profile/BackendPanel.vue
@@ -85,7 +85,7 @@ import RunningBadge from "~/components/Common/Badges/RunningBadge.vue";
 import {useTranslate} from "~/vendor/gettext";
 import {computed} from "vue";
 import CardPage from "~/components/Common/CardPage.vue";
-import {userAllowedForStation} from "~/acl";
+import {useUserAllowedForStation} from "~/acl";
 import useMakeApiCall from "~/components/Stations/Profile/useMakeApiCall.ts";
 import {BackendAdapters, StationPermissions} from "~/entities/ApiInterfaces.ts";
 import {getStationApiUrl} from "~/router.ts";
@@ -97,6 +97,8 @@ import IconIcUpdate from "~icons/ic/baseline-update";
 
 const stationData = useStationData();
 const profileData = useStationProfileData();
+
+const {userAllowedForStation} = useUserAllowedForStation();
 
 const backendRestartUri = getStationApiUrl('/backend/restart');
 const backendStartUri = getStationApiUrl('/backend/start');

--- a/frontend/components/Stations/Profile/FrontendPanel.vue
+++ b/frontend/components/Stations/Profile/FrontendPanel.vue
@@ -175,7 +175,7 @@ import RunningBadge from "~/components/Common/Badges/RunningBadge.vue";
 import {computed} from "vue";
 import {useTranslate} from "~/vendor/gettext";
 import CardPage from "~/components/Common/CardPage.vue";
-import {userAllowedForStation} from "~/acl";
+import {useUserAllowedForStation} from "~/acl";
 import useOptionalStorage from "~/functions/useOptionalStorage";
 import useMakeApiCall from "~/components/Stations/Profile/useMakeApiCall.ts";
 import {FrontendAdapters, StationPermissions} from "~/entities/ApiInterfaces.ts";
@@ -189,6 +189,8 @@ import IconIcUpdate from "~icons/ic/baseline-update";
 
 const stationData = useStationData();
 const profileData = useStationProfileData();
+
+const {userAllowedForStation} = useUserAllowedForStation();
 
 const frontendRestartUri = getStationApiUrl('/frontend/restart');
 const frontendStartUri = getStationApiUrl('/frontend/start');

--- a/frontend/components/Stations/Profile/HeaderPanel.vue
+++ b/frontend/components/Stations/Profile/HeaderPanel.vue
@@ -45,7 +45,7 @@
 
 <script setup lang="ts">
 import PlayButton from "~/components/Common/Audio/PlayButton.vue";
-import {userAllowedForStation} from "~/acl";
+import {useUserAllowedForStation} from "~/acl";
 import {StationPermissions} from "~/entities/ApiInterfaces.ts";
 import {useStationData} from "~/functions/useStationQuery.ts";
 import {useStationProfileData} from "~/components/Stations/Profile/useProfileQuery.ts";
@@ -53,4 +53,6 @@ import IconIcEdit from "~icons/ic/baseline-edit";
 
 const stationData = useStationData();
 const profileData = useStationProfileData();
+
+const {userAllowedForStation} = useUserAllowedForStation();
 </script>

--- a/frontend/components/Stations/Profile/NowPlayingPanel.vue
+++ b/frontend/components/Stations/Profile/NowPlayingPanel.vue
@@ -247,7 +247,7 @@ import {useTranslate} from "~/vendor/gettext";
 import useNowPlaying from "~/functions/useNowPlaying";
 import CardPage from "~/components/Common/CardPage.vue";
 import {useLightbox} from "~/vendor/lightbox";
-import {userAllowedForStation} from "~/acl";
+import {useUserAllowedForStation} from "~/acl";
 import UpdateMetadataModal from "~/components/Stations/Profile/UpdateMetadataModal.vue";
 import useMakeApiCall from "~/components/Stations/Profile/useMakeApiCall.ts";
 import {BackendAdapters, StationPermissions} from "~/entities/ApiInterfaces.ts";
@@ -266,6 +266,8 @@ import IconIcVolumeOff from "~icons/ic/baseline-volume-off";
 const stationData = useStationData();
 const profileData = useStationProfileData();
 const {nowPlayingProps} = toRefs(profileData);
+
+const {userAllowedForStation} = useUserAllowedForStation();
 
 const backendSkipSongUri = getStationApiUrl('/backend/skip');
 const backendDisconnectStreamerUri = getStationApiUrl('/backend/disconnect');

--- a/frontend/components/Stations/Profile/PublicPagesPanel.vue
+++ b/frontend/components/Stations/Profile/PublicPagesPanel.vue
@@ -127,7 +127,7 @@ import EnabledBadge from "~/components/Common/Badges/EnabledBadge.vue";
 import {computed, useTemplateRef} from "vue";
 import EmbedModal from "~/components/Stations/Profile/EmbedModal.vue";
 import CardPage from "~/components/Common/CardPage.vue";
-import {userAllowedForStation} from "~/acl";
+import {useUserAllowedForStation} from "~/acl";
 import useToggleFeature from "~/components/Stations/Profile/useToggleFeature";
 import {StationPermissions} from "~/entities/ApiInterfaces.ts";
 import {useStationData} from "~/functions/useStationQuery.ts";
@@ -139,6 +139,8 @@ import IconIcCode from "~icons/ic/baseline-code";
 
 const stationData = useStationData();
 const profileData = useStationProfileData();
+
+const {userAllowedForStation} = useUserAllowedForStation();
 
 const $embedModal = useTemplateRef('$embedModal');
 

--- a/frontend/components/Stations/Profile/RequestsPanel.vue
+++ b/frontend/components/Stations/Profile/RequestsPanel.vue
@@ -59,7 +59,7 @@
 <script setup lang="ts">
 import EnabledBadge from "~/components/Common/Badges/EnabledBadge.vue";
 import CardPage from "~/components/Common/CardPage.vue";
-import {userAllowedForStation} from "~/acl";
+import {useUserAllowedForStation} from "~/acl";
 import useToggleFeature from "~/components/Stations/Profile/useToggleFeature";
 import {computed} from "vue";
 import {StationPermissions} from "~/entities/ApiInterfaces.ts";
@@ -69,6 +69,8 @@ import IconIcClose from "~icons/ic/baseline-close";
 import IconIcAssignment from "~icons/ic/baseline-assignment";
 
 const stationData = useStationData();
+
+const {userAllowedForStation} = useUserAllowedForStation();
 
 const toggleRequests = useToggleFeature(
     'enable_requests',

--- a/frontend/components/Stations/Profile/StationDisabledPanel.vue
+++ b/frontend/components/Stations/Profile/StationDisabledPanel.vue
@@ -35,11 +35,13 @@
     </card-page>
 </template>
 <script setup lang="ts">
-import {userAllowedForStation} from "~/acl.ts";
+import {useUserAllowedForStation} from "~/acl.ts";
 import CardPage from "~/components/Common/CardPage.vue";
 import {StationPermissions} from "~/entities/ApiInterfaces.ts";
 import {useStationData} from "~/functions/useStationQuery.ts";
 import IconIcEdit from "~icons/ic/baseline-edit";
 
 const stationData = useStationData();
+
+const {userAllowedForStation} = useUserAllowedForStation();
 </script>

--- a/frontend/components/Stations/Profile/StreamersPanel.vue
+++ b/frontend/components/Stations/Profile/StreamersPanel.vue
@@ -59,7 +59,7 @@
 <script setup lang="ts">
 import EnabledBadge from "~/components/Common/Badges/EnabledBadge.vue";
 import CardPage from "~/components/Common/CardPage.vue";
-import {userAllowedForStation} from "~/acl";
+import {useUserAllowedForStation} from "~/acl";
 import useToggleFeature from "~/components/Stations/Profile/useToggleFeature";
 import {computed} from "vue";
 import {StationPermissions} from "~/entities/ApiInterfaces.ts";
@@ -69,6 +69,8 @@ import IconIcClose from "~icons/ic/baseline-close";
 import IconIcSettings from "~icons/ic/baseline-settings";
 
 const stationData = useStationData();
+
+const {userAllowedForStation} = useUserAllowedForStation();
 
 const toggleStreamers = useToggleFeature(
     'enable_streamers',

--- a/frontend/components/Stations/Sidebar.vue
+++ b/frontend/components/Stations/Sidebar.vue
@@ -65,7 +65,7 @@ import {ref} from "vue";
 import SidebarMenu from "~/components/Common/SidebarMenu.vue";
 import {toRefs, useIntervalFn} from "@vueuse/core";
 import {useStationsMenu} from "~/components/Stations/menu";
-import {userAllowedForStation} from "~/acl";
+import {useUserAllowedForStation} from "~/acl";
 import useStationDateTimeFormatter from "~/functions/useStationDateTimeFormatter.ts";
 import {useLuxon} from "~/vendor/luxon.ts";
 import {StationPermissions} from "~/entities/ApiInterfaces.ts";
@@ -73,6 +73,7 @@ import {useStationData} from "~/functions/useStationQuery.ts";
 import IconIcEdit from "~icons/ic/baseline-edit";
 
 const menuItems = useStationsMenu();
+const {userAllowedForStation} = useUserAllowedForStation();
 
 const stationData = useStationData();
 const {name, hasStarted, needsRestart, timezone} = toRefs(stationData);

--- a/frontend/components/Stations/menu.ts
+++ b/frontend/components/Stations/menu.ts
@@ -1,6 +1,6 @@
 import {useTranslate} from "~/vendor/gettext.ts";
 import {filterMenu, MenuCategory, RawMenuCategory} from "~/functions/filterMenu.ts";
-import {userAllowedForStation} from "~/acl.ts";
+import {useUserAllowedForStation} from "~/acl.ts";
 import {shallowRef, watch} from "vue";
 import {StationPermissions} from "~/entities/ApiInterfaces.ts";
 import {useStationData} from "~/functions/useStationQuery.ts";
@@ -19,6 +19,7 @@ export function useStationsMenu() {
     const {$gettext} = useTranslate();
 
     const station = useStationData();
+    const {userAllowedForStation} = useUserAllowedForStation();
 
     const fullMenu: RawMenuCategory[] = [
         {


### PR DESCRIPTION
**Fixes issue:**
Fixes #8172 

**Proposed changes:**
This PR moves the `userAllowedForStation` into a composable function that returns the `userAllowedForStation` function in order to fix the call to `useStationId` causing an error to be thrown when it is used outside of the initial setup rendering pass of the UI cycle which causes the `visible()` calls for the menu items to fail as `false` in the catch.

This is what I got in the browser console when investigating this problem:
```
[Vue warn]: inject() can only be used inside setup() or functional components.
```

This is the error that is being `catch`'ed when this happens:
```
TypeError: (intermediate value)() is undefined
useStationId useStationQuery.ts:10
userAllowedForStation acl.ts:22
...
```