### PR TITLE
Switch to Upstream Icecast 2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM ghcr.io/azuracast/azuracast.com:builtin@sha256:f7c41278613d113375ca285ba85f
 #
 # Icecast-KH with AzuraCast customizations build step
 #
-FROM ghcr.io/azuracast/icecast-kh-ac:2025-08-29 AS icecast
+FROM ghcr.io/azuracast/icecast-ac:feat-switch-to-upstream AS icecast
 
 #
 # PHP Extension Installer build step
@@ -34,6 +34,7 @@ COPY --from=mariadb /usr/local/bin/docker-entrypoint.sh /usr/local/bin/db_entryp
 # Add Icecast
 COPY --from=icecast /usr/local/bin/icecast /usr/local/bin/icecast
 COPY --from=icecast /usr/local/share/icecast /usr/local/share/icecast
+COPY --from=icecast /usr/local/lib/libigloo* /usr/local/lib/
 
 #
 # Final build image

--- a/backend/src/Radio/AbstractLocalAdapter.php
+++ b/backend/src/Radio/AbstractLocalAdapter.php
@@ -63,6 +63,7 @@ abstract class AbstractLocalAdapter
             $configPath,
             $newConfig
         );
+        $fsUtils->chmod($configPath, 0o600);
 
         return 0 !== strcmp($currentConfig, $newConfig);
     }

--- a/backend/src/Radio/Frontend/Icecast.php
+++ b/backend/src/Radio/Frontend/Icecast.php
@@ -207,8 +207,8 @@ class Icecast extends AbstractFrontend
                 'prng-seed' => [
                     '@type' => 'read-write',
                     '@size' => '1024',
-                    '_' => $configDir.'/icecast.prng-seed',
-                ]
+                    '_' => $configDir . '/icecast.prng-seed',
+                ],
             ],
         ];
 

--- a/util/docker/stations/setup/icecast.sh
+++ b/util/docker/stations/setup/icecast.sh
@@ -4,4 +4,4 @@ set -x
 
 # Icecast is built and imported in its own Docker container.
 
-apt-get install -q -y --no-install-recommends libxml2 libxslt1.1 openssl
+apt-get install -q -y --no-install-recommends librhash1 libxml2 libxslt1.1 openssl


### PR DESCRIPTION
This is still currently a work in progress pending additional development on the part of the Xiph Icecast team, but we'd like to get back to using the "upstream" Icecast (Icecast itself, not the now-largely-unmaintained KH branch) for AzuraCast.

This PR (along with changes to the build process that adds our custom HTML and MP3 files) switches us back to Icecast's latest commit version.

Some pending items that need addressing:
 - The `<x-forwarded-for>127.0.0.1</x-forwarded-for>` option does not exist in upstream Icecast yet, but is currently in the process of being reviewed for inclusion. It will be absolutely necessary for us to operate Icecast in the containerized environment we're in.
 - The `<deny-agents>` list, which KH let us supply as a single flatfile to avoid URL authentication for this scenario, doesn't exist in upstream Icecast, forcing us to go back to using URL-based authentication for all users if a user-agent deny-list is in place on the station's configuration.
 - For some reason, there appears to be a bug where Liquidsoap attempting to call `listclients` on a source that (until it later broadcasts to it) doesn't exist counts as one "source" broadcasting, so the actual connection attempt it makes hits the source limit; the quick workaround is to just make the source limit double what the mount point count is, but this is probably something to review with Xiph.