### PR TITLE
perf: Add covering indexes to listener and song_history for analytics and API performance

### DIFF
--- a/backend/src/Entity/Listener.php
+++ b/backend/src/Entity/Listener.php
@@ -12,6 +12,8 @@ use NowPlaying\Result\Client;
     ORM\Entity,
     ORM\Table(name: 'listener'),
     ORM\Index(name: 'idx_timestamps', columns: ['timestamp_end', 'timestamp_start']),
+    ORM\Index(name: 'idx_timestamp_start', columns: ['timestamp_start']),
+    ORM\Index(name: 'idx_station_timestamps_hash', columns: ['station_id', 'timestamp_end', 'timestamp_start', 'listener_hash']),
     ORM\Index(name: 'idx_statistics_country', columns: ['location_country']),
     ORM\Index(name: 'idx_statistics_os', columns: ['device_os_family']),
     ORM\Index(name: 'idx_statistics_browser', columns: ['device_browser_family'])

--- a/backend/src/Entity/Migration/Version20260408060000.php
+++ b/backend/src/Entity/Migration/Version20260408060000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20260408060000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add covering indexes to listener and song_history for analytics and API query performance.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX idx_timestamp_start ON listener (timestamp_start)');
+        $this->addSql('CREATE INDEX idx_station_timestamps_hash ON listener (station_id, timestamp_end, timestamp_start, listener_hash)');
+        $this->addSql('CREATE INDEX idx_station_visible_id ON song_history (station_id, is_visible, id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_timestamp_start ON listener');
+        $this->addSql('DROP INDEX idx_station_timestamps_hash ON listener');
+        $this->addSql('DROP INDEX idx_station_visible_id ON song_history');
+    }
+}

--- a/backend/src/Entity/SongHistory.php
+++ b/backend/src/Entity/SongHistory.php
@@ -14,7 +14,8 @@ use Doctrine\ORM\Mapping as ORM;
     ORM\Table(name: 'song_history'),
     ORM\Index(name: 'idx_is_visible', columns: ['is_visible']),
     ORM\Index(name: 'idx_timestamp_start', columns: ['timestamp_start']),
-    ORM\Index(name: 'idx_timestamp_end', columns: ['timestamp_end'])
+    ORM\Index(name: 'idx_timestamp_end', columns: ['timestamp_end']),
+    ORM\Index(name: 'idx_station_visible_id', columns: ['station_id', 'is_visible', 'id'])
 ]
 final class SongHistory implements
     Interfaces\SongInterface,


### PR DESCRIPTION
## Problem

The hourly `RunAnalyticsTask` causes sustained high disk I/O (50+ MB/s reads, 85%+ disk utilization) on instances with moderate listener counts (~1M rows in `listener`, ~300k rows in `song_history`). This is caused by missing composite indexes that force MariaDB to perform expensive data page lookups for several frequently executed queries.

### Root Cause Analysis

**1. `ListenerRepository::getUniqueListeners()`** — Called ~250 times per analytics run (10 stations × 24 hours + daily aggregates), plus on every song transition via `changeCurrentSong()`:
```sql
SELECT COUNT(DISTINCT l.listener_hash) FROM listener l
WHERE l.station_id = :station
AND l.timestamp_start <= :time_end
AND l.timestamp_end >= :time_start
```
Uses only the `station_id` single-column index → scans ~100k+ rows per station, then fetches each data page to read `timestamp_start`, `timestamp_end`, and `listener_hash`.

**2. `ListenerRepository::cleanup()`** — Called hourly by `CleanupHistoryTask`:
```sql
DELETE FROM listener WHERE timestamp_start <= :threshold
```
No usable index on `timestamp_start` alone. The existing `idx_timestamps(timestamp_end, timestamp_start)` composite has `timestamp_start` as the second column, so it cannot be used for range scans on `timestamp_start`. This results in a **full table scan of ~1M rows every hour**, even when 0 rows match.

**3. `SongHistoryRepository::getVisibleHistory()`** — Called on every API/page load:
```sql
SELECT sh.* FROM song_history sh
WHERE sh.station = :station AND sh.is_visible = 1
ORDER BY sh.id DESC LIMIT :n
```
Uses only `station_id` index → scans ~80k rows, then filters and sorts in memory.

## Solution

Add three targeted indexes:

- `idx_timestamp_start` on `listener(timestamp_start)` — fixes `cleanup()` full table scan
- `idx_station_timestamps_hash` on `listener(station_id, timestamp_end, timestamp_start, listener_hash)` — covering index for `getUniqueListeners()`, index-only scan
- `idx_station_visible_id` on `song_history(station_id, is_visible, id)` — composite covers filter + ORDER BY for `getVisibleHistory()`

## Measured Impact (production, 10 stations, ~1M listener rows)

- Disk reads during analytics: **~52 MB/s sustained → < 1 MB/s**
- Disk utilization: **85-87% → 4-6%**
- `getUniqueListeners` EXPLAIN rows: **121,004 (Using where) → 823 (Using index)**
- `cleanup` listener EXPLAIN: **ALL / 974,780 rows (full scan) → range / 1 row**
- `getVisibleHistory` EXPLAIN rows: **79,722 → direct index lookup**

## Changes

- `backend/src/Entity/Listener.php` — Added 2 `ORM\Index` attributes
- `backend/src/Entity/SongHistory.php` — Added 1 `ORM\Index` attribute
- `backend/src/Entity/Migration/Version20260408060000.php` — Migration with `CREATE INDEX` / `DROP INDEX`

## Notes

- The covering index `idx_station_timestamps_hash` also benefits `iterateLiveListenersArray()` and the `update()` existing-clients lookup as a bonus (both use `station_id` + `timestamp_end IS NULL` + `listener_hash`).
- Index storage overhead is ~50-80 MB on a 1M row listener table — well worth the trade-off.
- No schema changes to existing columns; purely additive indexes.
