### PR TITLE
Add itunes:type to podcast feed response

### DIFF
--- a/backend/src/Controller/Frontend/PublicPages/PodcastFeedAction.php
+++ b/backend/src/Controller/Frontend/PublicPages/PodcastFeedAction.php
@@ -85,6 +85,7 @@ final readonly class PodcastFeedAction implements SingleActionInterface
                         ];
                 }
             )->getValues(),
+            'itunes:type' => 'serial',
             'atom:link' => [
                 '@rel' => 'self',
                 '@type' => 'application/rss+xml',


### PR DESCRIPTION
Add line 88,
When a RSS file is generated :

Sequence Episodes Manually (The Metadata Fix)Even without the <itunes:type>serial</itunes:type> tag, you can force a "Serial" behavior by ensuring your metadata is perfect in AzuraCast

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
'itunes:type' => 'serial',
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
