### PR TITLE
Fix issue #8479 - Use batch iterator for playlist file writing to prevent doctrine from keeping all entities in memory leading to OOMs for large media libraries

### DIFF
--- a/backend/src/Radio/Backend/Liquidsoap/PlaylistFileWriter.php
+++ b/backend/src/Radio/Backend/Liquidsoap/PlaylistFileWriter.php
@@ -6,6 +6,7 @@ namespace App\Radio\Backend\Liquidsoap;
 
 use App\Container\EntityManagerAwareTrait;
 use App\Container\LoggerAwareTrait;
+use App\Doctrine\ReadOnlyBatchIteratorAggregate;
 use App\Entity\Station;
 use App\Entity\StationMedia;
 use App\Entity\StationPlaylist;
@@ -136,7 +137,7 @@ final class PlaylistFileWriter implements EventSubscriberInterface
         )->setParameter('playlist', $playlist);
 
         /** @var StationMedia $mediaFile */
-        foreach ($mediaQuery->toIterable() as $mediaFile) {
+        foreach (ReadOnlyBatchIteratorAggregate::fromQuery($mediaQuery, 1000) as $mediaFile) {
             $event = new AnnotateNextSong(
                 station: $station,
                 media: $mediaFile,


### PR DESCRIPTION
**Fixes issue:**
Fixes #8479

**Proposed changes:**
Uses the batch iterator to prevent doctrine from OOM when writing large playlists when restarting all stations on startup.
