### PR TITLE
Fix issue #8481 - Refactor entities to replace direct identifier access with virtual computed properties with get hooks

### DIFF
--- a/backend/src/Controller/Api/Stations/Files/ListAction.php
+++ b/backend/src/Controller/Api/Stations/Files/ListAction.php
@@ -176,11 +176,11 @@ final class ListAction implements SingleActionInterface
                         );
                     } elseif ('unassigned' === $special) {
                         $mediaQueryBuilder->andWhere(
-                            'sm.id NOT IN (SELECT spm2.media_id FROM App\Entity\StationPlaylistMedia spm2)'
+                            'sm.id NOT IN (SELECT IDENTITY(spm2.media) FROM App\Entity\StationPlaylistMedia spm2)'
                         );
                     } elseif (null !== $playlist) {
                         $mediaQueryBuilder->andWhere(
-                            'sm.id IN (SELECT spm2.media_id FROM App\Entity\StationPlaylistMedia spm2 '
+                            'sm.id IN (SELECT IDENTITY(spm2.media) FROM App\Entity\StationPlaylistMedia spm2 '
                             . 'WHERE spm2.playlist = :playlist)'
                         )->setParameter('playlist', $playlist);
                     }

--- a/backend/src/Entity/Listener.php
+++ b/backend/src/Entity/Listener.php
@@ -28,33 +28,33 @@ final class Listener implements
     #[ORM\JoinColumn(name: 'station_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly Station $station;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[ORM\ManyToOne(targetEntity: StationMount::class)]
     #[ORM\JoinColumn(name: 'mount_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     public readonly ?StationMount $mount;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $mount_id = null;
+    public ?int $mount_id {
+        get => $this->mount?->id;
+    }
 
     #[ORM\ManyToOne(targetEntity: StationRemote::class)]
     #[ORM\JoinColumn(name: 'remote_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     public readonly ?StationRemote $remote;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $remote_id = null;
+    public ?int $remote_id {
+        get => $this->remote?->id;
+    }
 
     #[ORM\ManyToOne(targetEntity: StationHlsStream::class)]
     #[ORM\JoinColumn(name: 'hls_stream_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     public readonly ?StationHlsStream $hls_stream;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $hls_stream_id = null;
+    public ?int $hls_stream_id {
+        get => $this->hls_stream?->id;
+    }
 
     #[ORM\Column]
     public int $listener_uid;

--- a/backend/src/Entity/Podcast.php
+++ b/backend/src/Entity/Podcast.php
@@ -27,17 +27,18 @@ final class Podcast implements Interfaces\IdentifiableEntityInterface
     #[ORM\JoinColumn(name: 'storage_location_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly StorageLocation $storage_location;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $storage_location_id;
+    public int $storage_location_id {
+        get => $this->storage_location->id;
+    }
 
     #[DeepNormalize(true)]
     #[ORM\ManyToOne(inversedBy: 'podcasts')]
     #[ORM\JoinColumn(name: 'playlist_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     public ?StationPlaylist $playlist = null;
 
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $playlist_id = null;
+    public ?int $playlist_id {
+        get => $this->playlist?->id;
+    }
 
     #[ORM\Column(type: 'string', length: 50, enumType: PodcastSources::class)]
     public PodcastSources $source = PodcastSources::Manual;

--- a/backend/src/Entity/PodcastEpisode.php
+++ b/backend/src/Entity/PodcastEpisode.php
@@ -29,9 +29,9 @@ final class PodcastEpisode implements IdentifiableEntityInterface
     #[ORM\JoinColumn(name: 'playlist_media_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     public ?StationMedia $playlist_media = null;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $playlist_media_id = null;
+    public ?int $playlist_media_id {
+        get => $this->playlist_media?->id;
+    }
 
     #[ORM\OneToOne(mappedBy: 'episode')]
     public ?PodcastMedia $media = null;

--- a/backend/src/Entity/SongHistory.php
+++ b/backend/src/Entity/SongHistory.php
@@ -36,25 +36,25 @@ final class SongHistory implements
     #[ORM\JoinColumn(name: 'station_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly Station $station;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'playlist_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     public ?StationPlaylist $playlist = null;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $playlist_id = null;
+    public ?int $playlist_id {
+        get => $this->playlist?->id;
+    }
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'streamer_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     public ?StationStreamer $streamer = null;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $streamer_id = null;
+    public ?int $streamer_id {
+        get => $this->streamer?->id;
+    }
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'media_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
@@ -68,17 +68,17 @@ final class SongHistory implements
         }
     }
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $media_id = null;
+    public ?int $media_id {
+        get => $this->media?->id;
+    }
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'request_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     public ?StationRequest $request = null;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $request_id = null;
+    public ?int $request_id {
+        get => $this->request?->id;
+    }
 
     #[ORM\Column(type: 'datetime_immutable', precision: 6)]
     public readonly DateTimeImmutable $timestamp_start;

--- a/backend/src/Entity/StationHlsStream.php
+++ b/backend/src/Entity/StationHlsStream.php
@@ -44,9 +44,9 @@ final class StationHlsStream implements
         $this->station = $station;
     }
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[
         OA\Property(example: "aac_lofi"),

--- a/backend/src/Entity/StationMedia.php
+++ b/backend/src/Entity/StationMedia.php
@@ -39,9 +39,9 @@ final class StationMedia implements
     ]
     public readonly StorageLocation $storage_location;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $storage_location_id;
+    public int $storage_location_id {
+        get => $this->storage_location->id;
+    }
 
     #[ORM\Column(length: 25, nullable: false)]
     public string $unique_id;

--- a/backend/src/Entity/StationMediaCustomField.php
+++ b/backend/src/Entity/StationMediaCustomField.php
@@ -20,17 +20,17 @@ final class StationMediaCustomField implements IdentifiableEntityInterface
     #[ORM\JoinColumn(name: 'media_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly StationMedia $media;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $media_id;
+    public int $media_id {
+        get => $this->media->id;
+    }
 
     #[ORM\ManyToOne(inversedBy: 'media_fields')]
     #[ORM\JoinColumn(name: 'field_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly CustomField $field;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $field_id;
+    public int $field_id {
+        get => $this->field->id;
+    }
 
     #[ORM\Column(name: 'field_value', length: 255, nullable: true)]
     public ?string $value = null {

--- a/backend/src/Entity/StationMount.php
+++ b/backend/src/Entity/StationMount.php
@@ -52,9 +52,9 @@ final class StationMount implements
         $this->station = $station;
     }
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[
         OA\Property(example: "/radio.mp3"),

--- a/backend/src/Entity/StationPlaylist.php
+++ b/backend/src/Entity/StationPlaylist.php
@@ -55,9 +55,9 @@ final class StationPlaylist implements
         $this->station = $station;
     }
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[
         OA\Property(example: "Test Playlist"),

--- a/backend/src/Entity/StationPlaylistFolder.php
+++ b/backend/src/Entity/StationPlaylistFolder.php
@@ -34,9 +34,9 @@ final class StationPlaylistFolder implements
     #[ORM\JoinColumn(name: 'playlist_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public StationPlaylist $playlist;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $playlist_id;
+    public int $playlist_id {
+        get => $this->playlist->id;
+    }
 
     #[ORM\Column(length: 500)]
     public string $path {

--- a/backend/src/Entity/StationPlaylistMedia.php
+++ b/backend/src/Entity/StationPlaylistMedia.php
@@ -20,25 +20,25 @@ final class StationPlaylistMedia implements JsonSerializable, IdentifiableEntity
     #[ORM\JoinColumn(name: 'media_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly StationMedia $media;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $media_id;
+    public int $media_id {
+        get => $this->media->id;
+    }
 
     #[ORM\ManyToOne(fetch: 'EAGER', inversedBy: 'media_items')]
     #[ORM\JoinColumn(name: 'playlist_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public StationPlaylist $playlist;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $playlist_id;
+    public int $playlist_id {
+        get => $this->playlist->id;
+    }
 
     #[ORM\ManyToOne(fetch: 'EAGER', inversedBy: 'media_items')]
     #[ORM\JoinColumn(name: 'folder_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     public ?StationPlaylistFolder $folder = null;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $folder_id = null;
+    public ?int $folder_id {
+        get => $this->folder?->id;
+    }
 
     #[ORM\Column]
     public int $weight = 0;

--- a/backend/src/Entity/StationQueue.php
+++ b/backend/src/Entity/StationQueue.php
@@ -31,17 +31,17 @@ final class StationQueue implements
     #[ORM\JoinColumn(name: 'station_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly Station $station;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'playlist_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     public ?StationPlaylist $playlist = null;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $playlist_id = null;
+    public ?int $playlist_id {
+        get => $this->playlist?->id;
+    }
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'media_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
@@ -55,17 +55,17 @@ final class StationQueue implements
         }
     }
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $media_id = null;
+    public ?int $media_id {
+        get => $this->media?->id;
+    }
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'request_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     public ?StationRequest $request = null;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $request_id = null;
+    public ?int $request_id {
+        get => $this->request?->id;
+    }
 
     #[ORM\Column]
     public bool $sent_to_autodj = false;

--- a/backend/src/Entity/StationRemote.php
+++ b/backend/src/Entity/StationRemote.php
@@ -48,17 +48,17 @@ final class StationRemote implements
         $this->station = $station;
     }
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[ORM\ManyToOne(inversedBy: 'remotes')]
     #[ORM\JoinColumn(name: 'relay_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     public ?Relay $relay = null;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: true, insertable: false, updatable: false)]
-    public private(set) ?int $relay_id = null;
+    public ?int $relay_id {
+        get => $this->relay?->id;
+    }
 
     #[
         ORM\Column(length: 255, nullable: false),

--- a/backend/src/Entity/StationRequest.php
+++ b/backend/src/Entity/StationRequest.php
@@ -24,17 +24,17 @@ final class StationRequest implements
     #[ORM\JoinColumn(name: 'station_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly Station $station;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'track_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly StationMedia $track;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $track_id;
+    public int $track_id {
+        get => $this->track->id;
+    }
 
     #[ORM\Column(type: 'datetime_immutable', precision: 6)]
     public readonly DateTimeImmutable $timestamp;

--- a/backend/src/Entity/StationStreamer.php
+++ b/backend/src/Entity/StationStreamer.php
@@ -52,9 +52,9 @@ final class StationStreamer implements
         $this->station = $station;
     }
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[
         OA\Property(example: "dj_test"),

--- a/backend/src/Entity/StationWebhook.php
+++ b/backend/src/Entity/StationWebhook.php
@@ -40,9 +40,9 @@ final class StationWebhook implements
         $this->station = $station;
     }
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $station_id;
+    public int $station_id {
+        get => $this->station->id;
+    }
 
     #[
         OA\Property(

--- a/backend/src/Entity/UnprocessableMedia.php
+++ b/backend/src/Entity/UnprocessableMedia.php
@@ -24,9 +24,9 @@ final class UnprocessableMedia implements PathAwareInterface, IdentifiableEntity
     #[ORM\JoinColumn(name: 'storage_location_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     public readonly StorageLocation $storage_location;
 
-    /* TODO Remove direct identifier access. */
-    #[ORM\Column(nullable: false, insertable: false, updatable: false)]
-    public private(set) int $storage_location_id;
+    public int $storage_location_id {
+        get => $this->storage_location->id;
+    }
 
     #[ORM\Column(length: 500)]
     public string $path {


### PR DESCRIPTION
**Fixes issue:**
Fixes #8481 

**Proposed changes:**
This PR refactors our entities to replace the `*_id` properties that we used for directly accessing the identifiers of the entities (and relations) with virtual computed properties with get hooks.

The problem described in the issue was caused by the normalizer trying to access the playlists station_id field when normalizing the created entity for the response, but using the entity from the memory without hydrating this field since it the entity has not been initialized from doctrine itself.

I could have tried to let it hydrate those entities but since this would have just been a crutch for fixing an error caused by an implementation that we wanted to replace anyways I opted for just refactoring the TODOs instead.

Only found 2 DQL queries that used the scalar fields and adjusted them to use the IDENTITY function. 
