### PR TITLE
Add toRawString wrapper on further strings in LS config

### DIFF
--- a/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -1014,10 +1014,12 @@ final class ConfigWriter implements EventSubscriberInterface
                         $stereoToolProcess .= ' -k "' . $stereoToolLicenseKey . '"';
                     }
 
+                    $stereoToolProcessString = self::toRawString($stereoToolProcess);
+
                     $event->appendBlock(
                         <<<LIQ
                         # Stereo Tool Pipe
-                        radio = pipe(replay_delay=1.0, process='{$stereoToolProcess}', radio)
+                        radio = pipe(replay_delay=1.0, process={$stereoToolProcessString}, radio)
                         LIQ
                     );
                 } else {
@@ -1040,13 +1042,16 @@ final class ConfigWriter implements EventSubscriberInterface
                         }
                     }
 
+                    $stereoToolLicenseKeyString = self::toRawString($stereoToolLicenseKey ?? '');
+                    $stereoToolConfigurationString = self::toRawString($stereoToolConfiguration);
+
                     $event->appendBlock(
                         <<<LIQ
                         # Stereo Tool Pipe
                         radio = stereotool(
                             library_file="{$stereoToolLibrary}",
-                            license_key="{$stereoToolLicenseKey}",
-                            preset="{$stereoToolConfiguration}",
+                            license_key={$stereoToolLicenseKeyString},
+                            preset={$stereoToolConfigurationString},
                             radio
                         )
                         LIQ

--- a/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
+++ b/backend/src/Radio/Backend/Liquidsoap/ConfigWriter.php
@@ -554,8 +554,8 @@ final class ConfigWriter implements EventSubscriberInterface
             'port = ' . $this->liquidsoap->getStreamPort($station),
             'auth = azuracast.dj_auth',
             'icy = true',
-            'icy_metadata_charset = "' . $charset . '"',
-            'metadata_charset = "' . $charset . '"',
+            'icy_metadata_charset = ' . self::toRawString($charset),
+            'metadata_charset = ' . self::toRawString($charset),
         ];
 
         $djBuffer = $settings->dj_buffer;
@@ -1237,7 +1237,7 @@ final class ConfigWriter implements EventSubscriberInterface
         }
 
         $outputParams[] = 'public = ' . ($source->isPublic ? 'true' : 'false');
-        $outputParams[] = 'encoding = "' . $charset . '"';
+        $outputParams[] = 'encoding = ' . self::toRawString($charset);
 
         if (StreamProtocols::Https === $source->protocol) {
             $outputParams[] = 'transport = https_transport';


### PR DESCRIPTION
**Fixes issue:**
X

**Proposed changes:**
This PR adds the `toRawString` string wrapper to the remaining places in the config where potentially user controlled strings are written into LS.