### PR TITLE
Fix issue #8462 - Ensure we don't add a duplicated "dB" to the amplify annotation

### DIFF
--- a/backend/src/Radio/AutoDJ/Annotations.php
+++ b/backend/src/Radio/AutoDJ/Annotations.php
@@ -195,7 +195,12 @@ final class Annotations implements EventSubscriberInterface
 
         // Liquidsoap expects amplify to be in dB.
         if (isset($annotations[Meta::AMPLIFY])) {
-            $annotations[Meta::AMPLIFY] .= ' dB';
+            $amplify = trim((string) $annotations[Meta::AMPLIFY]);
+            if (!str_ends_with($amplify, 'dB')) {
+                $amplify .= ' dB';
+            }
+
+            $annotations[Meta::AMPLIFY] = $amplify;
 
             // If only amplify is specified, return just it to use it in other AutoCue/amplify functions.
             if (1 === count($annotations)) {


### PR DESCRIPTION
**Fixes issue:**
Fixes #8462

**Proposed changes:**
This PR adds a guard in the annotation processing for aplify data preventing accidentally adding a duplicated `dB` string at the end when it is already present.
