### PR TITLE
Adjust DQLs with array hydration to fix them not including *_id virtual properties

### DIFF
--- a/backend/src/Controller/Api/Stations/BulkMedia/DownloadAction.php
+++ b/backend/src/Controller/Api/Stations/BulkMedia/DownloadAction.php
@@ -72,14 +72,47 @@ final class DownloadAction implements SingleActionInterface
         }
 
         $query = $this->em->createQuery(
-            <<<DQL
-                SELECT sm, spm, smcf
+            <<<'DQL'
+                SELECT sm
                 FROM App\Entity\StationMedia sm
-                LEFT JOIN sm.playlists spm
-                LEFT JOIN sm.custom_fields smcf
                 WHERE sm.storage_location = :storageLocation
             DQL
         )->setParameter('storageLocation', $station->media_storage_location);
+
+        $playlistIdsByMediaId = [];
+        $playlistMediaRaw = $this->em->createQuery(
+            <<<'DQL'
+                SELECT
+                    IDENTITY(spm.media) AS media_id,
+                    IDENTITY(spm.playlist) AS playlist_id
+                FROM App\Entity\StationPlaylistMedia spm
+                JOIN spm.media m
+                WHERE m.storage_location = :storageLocation
+            DQL
+        )->setParameter('storageLocation', $station->media_storage_location)
+            ->getScalarResult();
+
+        foreach ($playlistMediaRaw as $row) {
+            $playlistIdsByMediaId[$row['media_id']][] = $row['playlist_id'];
+        }
+
+        $customFieldsByMediaId = [];
+        $customFieldsRaw = $this->em->createQuery(
+            <<<'DQL'
+                SELECT
+                    IDENTITY(smcf.media) AS media_id,
+                    IDENTITY(smcf.field) AS field_id,
+                    smcf.value
+                FROM App\Entity\StationMediaCustomField smcf
+                JOIN smcf.media m
+                WHERE m.storage_location = :storageLocation
+            DQL
+        )->setParameter('storageLocation', $station->media_storage_location)
+            ->getScalarResult();
+
+        foreach ($customFieldsRaw as $row) {
+            $customFieldsByMediaId[$row['media_id']][$row['field_id']] = $row['value'];
+        }
 
         $filename = $station->short_name . '_all_media.csv';
 
@@ -123,15 +156,12 @@ final class DownloadAction implements SingleActionInterface
                 $extraMetadata[] = $row['extra_metadata_raw'][$fieldName] ?? '';
             }
 
-            $customFieldsById = [];
-            foreach ($row['custom_fields'] ?? [] as $rowCustomField) {
-                $customFieldsById[$rowCustomField['field_id']] = $rowCustomField['value'];
-            }
+            $customFieldsById = $customFieldsByMediaId[$row['id']] ?? [];
 
             $playlists = [];
-            foreach ($row['playlists'] ?? [] as $rowPlaylistMedia) {
-                if (isset($playlistsById[$rowPlaylistMedia['playlist_id']])) {
-                    $playlists[] = $playlistsById[$rowPlaylistMedia['playlist_id']];
+            foreach ($playlistIdsByMediaId[$row['id']] ?? [] as $playlistId) {
+                if (isset($playlistsById[$playlistId])) {
+                    $playlists[] = $playlistsById[$playlistId];
                 }
             }
 

--- a/backend/src/Controller/Api/Stations/Files/ListAction.php
+++ b/backend/src/Controller/Api/Stations/Files/ListAction.php
@@ -472,24 +472,28 @@ final class ListAction implements SingleActionInterface
         // Fetch playlists for all shown media.
         $allPlaylistsRaw = $this->em->createQuery(
             <<<'DQL'
-            SELECT spm, sp, spf
+            SELECT
+                IDENTITY(spm.media) AS media_id,
+                sp.id AS playlist_id,
+                sp.name AS playlist_name,
+                spf.path AS folder_path
             FROM App\Entity\StationPlaylistMedia spm
             JOIN spm.playlist sp
             LEFT JOIN spm.folder spf
-            WHERE sp.station = :station AND IDENTITY(spm.media) IN (:ids) 
+            WHERE sp.station = :station AND IDENTITY(spm.media) IN (:ids)
             DQL
         )->setParameter('station', $station)
             ->setParameter('ids', $mediaIds)
-            ->getArrayResult();
+            ->getScalarResult();
 
         $allPlaylists = [];
         foreach ($allPlaylistsRaw as $row) {
             $allPlaylists[$row['media_id']] ??= [];
             $allPlaylists[$row['media_id']][] = new StationMediaPlaylist(
-                id: $row['playlist']['id'],
-                name: $row['playlist']['name'],
-                short_name: StationPlaylist::generateShortName($row['playlist']['name']),
-                folder: $row['folder']['path'] ?? null
+                id: (int) $row['playlist_id'],
+                name: $row['playlist_name'],
+                short_name: StationPlaylist::generateShortName($row['playlist_name']),
+                folder: $row['folder_path'] ?? null
             );
         }
 

--- a/backend/src/Controller/Api/Stations/ListenersAction.php
+++ b/backend/src/Controller/Api/Stations/ListenersAction.php
@@ -90,9 +90,13 @@ final class ListenersAction implements SingleActionInterface
 
             $range = $dateRange->format('Y-m-d_H-i-s', '_to_');
 
-            $listenersIterator = $this->em->createQuery(
+            $query = $this->em->createQuery(
                 <<<'DQL'
-                    SELECT l
+                    SELECT
+                        l,
+                        IDENTITY(l.mount) AS mount_id,
+                        IDENTITY(l.remote) AS remote_id,
+                        IDENTITY(l.hls_stream) AS hls_stream_id
                     FROM App\Entity\Listener l
                     WHERE l.station = :station
                     AND l.timestamp_start < :time_end
@@ -101,8 +105,20 @@ final class ListenersAction implements SingleActionInterface
                 DQL
             )->setParameter('station', $station)
                 ->setParameter('time_start', $start)
-                ->setParameter('time_end', $end)
-                ->toIterable([], AbstractQuery::HYDRATE_ARRAY);
+                ->setParameter('time_end', $end);
+
+            // Virtual *_id properties are not included in result of array hydration
+            // need to explicitly select them and merge back into listener row
+            $listenersIterator = (static function () use ($query) {
+                foreach ($query->toIterable([], AbstractQuery::HYDRATE_ARRAY) as $row) {
+                    yield [
+                        ...$row[0],
+                        'mount_id' => $row['mount_id'],
+                        'remote_id' => $row['remote_id'],
+                        'hls_stream_id' => $row['hls_stream_id'],
+                    ];
+                }
+            })();
         }
 
         $mountNames = $this->mountRepo->getDisplayNames($station);

--- a/backend/src/Entity/Repository/ListenerRepository.php
+++ b/backend/src/Entity/Repository/ListenerRepository.php
@@ -83,7 +83,11 @@ final class ListenerRepository extends Repository
     {
         $query = $this->em->createQuery(
             <<<'DQL'
-                SELECT l
+                SELECT
+                    l,
+                    IDENTITY(l.mount) AS mount_id,
+                    IDENTITY(l.remote) AS remote_id,
+                    IDENTITY(l.hls_stream) AS hls_stream_id
                 FROM App\Entity\Listener l
                 WHERE l.station = :station
                 AND l.timestamp_end IS NULL
@@ -91,7 +95,16 @@ final class ListenerRepository extends Repository
             DQL
         )->setParameter('station', $station);
 
-        return $query->toIterable([], $query::HYDRATE_ARRAY);
+        // Virtual *_id properties are not included in result of array hydration
+        // need to explicitly select them and merge back into listener row
+        foreach ($query->toIterable([], $query::HYDRATE_ARRAY) as $row) {
+            yield [
+                ...$row[0],
+                'mount_id' => $row['mount_id'],
+                'remote_id' => $row['remote_id'],
+                'hls_stream_id' => $row['hls_stream_id'],
+            ];
+        }
     }
 
     /**
@@ -193,7 +206,7 @@ final class ListenerRepository extends Repository
         $csvLoadQuery = sprintf(
             <<<'SQL'
                 LOAD DATA LOCAL INFILE %s IGNORE
-                INTO TABLE %s 
+                INTO TABLE %s
                 FIELDS TERMINATED BY ','
                 OPTIONALLY ENCLOSED BY '"'
                 LINES TERMINATED BY '\n'


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
I noticed that the media list was not showing the assigned playlists correctly and found that the array hydration omits or rather doesn't even care to include virtual properties in the result so this PR adjusts DQLs that are using array hydration while trying to access the `*_id` columns to fix this problem. I missed these specific parts when I refactored the entities recently.

If the comment explaining the "why" is not needed feel free to remove it, thought it was not directly obvious to a reader without knowing/remembering this caveat about doctrine array hydration.

For the download action I've opted to also apply the same optimization that the `backend/src/Controller/Api/Stations/Files/ListAction.php` was already using for fetching the custom fields and playlists for the media separately from the main query to avoid additional hydration of those entities.


