### PR TITLE
Fix issue #8486 - Add listener auth for hls and warn about sc not supporting it

### DIFF
--- a/backend/config/routes/api_internal.php
+++ b/backend/config/routes/api_internal.php
@@ -27,6 +27,13 @@ return static function (RouteCollectorProxy $group) {
                         '/listener-auth[/{api_auth}]',
                         Controller\Api\Internal\ListenerAuthAction::class
                     )->setName('api:internal:listener-auth');
+
+                    // NGINX auth_request handler for HLS
+                    $group->map(
+                        ['GET', 'POST'],
+                        '/hls-listener-auth[/{api_auth}]',
+                        Controller\Api\Internal\HlsListenerAuthAction::class
+                    )->setName('api:internal:hls-listener-auth');
                 }
             )->add(Middleware\GetStation::class);
 

--- a/backend/src/Controller/Api/Internal/HlsListenerAuthAction.php
+++ b/backend/src/Controller/Api/Internal/HlsListenerAuthAction.php
@@ -13,8 +13,9 @@ use App\Http\ServerRequest;
 use App\Radio\Frontend\Blocklist\BlocklistParser;
 use App\Utilities\Types;
 use Psr\Http\Message\ResponseInterface;
+use Throwable;
 
-final class ListenerAuthAction implements SingleActionInterface
+final class HlsListenerAuthAction implements SingleActionInterface
 {
     use LoggerAwareTrait;
 
@@ -48,18 +49,42 @@ final class ListenerAuthAction implements SingleActionInterface
             }
         }
 
-        $station = $request->getStation();
-        $listenerIp = Types::string($request->getParam('ip'));
+        try {
+            $listenerIp = $this->getListenerIp($request);
+            $userAgent = Types::stringOrNull($request->getHeaderLine('User-Agent'), true);
 
-        // RSAS has no "deny-agents" so user-agent bans must be enforced here too.
-        $userAgent = Types::stringOrNull($request->getParam('agent'), true);
+            $isAllowed = $this->blocklistParser->isAllowed($station, $listenerIp, $userAgent);
+        } catch (Throwable $exception) {
+            $this->logger->warning(
+                'Error during HLS listener authentication; allowing listener.',
+                [
+                    'station_id' => $station->id,
+                    'exception' => $exception,
+                ]
+            );
 
-        if ($this->blocklistParser->isAllowed($station, $listenerIp, $userAgent)) {
-            return $response->withHeader('icecast-auth-user', '1');
+            return $response->withStatus(200);
         }
 
-        return $response
-            ->withHeader('icecast-auth-user', '0')
-            ->withHeader('icecast-auth-message', 'geo-blocked');
+        return $response->withStatus($isAllowed ? 200 : 403);
+    }
+
+    private function getListenerIp(ServerRequest $request): string
+    {
+        $ip = $request->getSettings()->getIp($request);
+
+        if ($this->isLoopbackIp($ip)) {
+            $realIp = Types::stringOrNull($request->getHeaderLine('X-Real-IP'), true);
+            if (null !== $realIp) {
+                return $realIp;
+            }
+        }
+
+        return $ip;
+    }
+
+    private function isLoopbackIp(string $ip): bool
+    {
+        return '::1' === $ip || str_starts_with($ip, '127.');
     }
 }

--- a/backend/src/Nginx/ConfigWriter.php
+++ b/backend/src/Nginx/ConfigWriter.php
@@ -8,10 +8,16 @@ use App\Entity\Station;
 use App\Event\Nginx\WriteNginxConfiguration;
 use App\Radio\Enums\BackendAdapters;
 use App\Radio\Enums\FrontendAdapters;
+use App\Radio\Frontend\Blocklist\BlocklistParser;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class ConfigWriter implements EventSubscriberInterface
 {
+    public function __construct(
+        private readonly BlocklistParser $blocklistParser
+    ) {
+    }
+
     /**
      * @return mixed[]
      */
@@ -55,7 +61,7 @@ final class ConfigWriter implements EventSubscriberInterface
                 proxy_connect_timeout     60;
 
                 proxy_set_header Host \$host/{$listenBaseUrl};
-                
+
                 set \$args \$args&_ic2=1;
                 proxy_pass http://127.0.0.1:{$port}/\$2?\$args;
             }
@@ -99,6 +105,42 @@ final class ConfigWriter implements EventSubscriberInterface
         $hlsFolder = $station->getRadioHlsDir();
 
         $hlsLogPath = self::getHlsLogFile($station);
+
+        if ($this->blocklistParser->isEnabledForHls($station)) {
+            $stationId = $station->id;
+            $apiKey = $station->adapter_api_key;
+
+            // Explicitly only authenticating the playlist since authenticating every segment
+            // could be quite taxing and segment names are quite hard to guess anyways
+            $event->appendBlock(
+                <<<NGINX
+                # Reverse proxy the frontend broadcast.
+                location {$hlsBaseUrl} {
+                    location ~ \.m3u8$ {
+                        auth_request {$hlsBaseUrl}/auth;
+                        access_log {$hlsLogPath} hls_json;
+                    }
+
+                    add_header 'Access-Control-Allow-Origin' '*';
+                    add_header 'Cache-Control' 'no-cache';
+
+                    alias {$hlsFolder};
+                    try_files \$uri =404;
+                }
+
+                location = {$hlsBaseUrl}/auth {
+                    internal;
+                    proxy_pass http://127.0.0.1:6010/api/internal/{$stationId}/hls-listener-auth/{$apiKey};
+                    proxy_pass_request_body off;
+                    proxy_set_header Content-Length "";
+                    proxy_set_header X-Real-IP \$remote_addr;
+                    proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+                }
+                NGINX
+            );
+
+            return;
+        }
 
         $event->appendBlock(
             <<<NGINX

--- a/backend/src/Radio/Frontend/Blocklist/BlocklistParser.php
+++ b/backend/src/Radio/Frontend/Blocklist/BlocklistParser.php
@@ -18,6 +18,20 @@ final readonly class BlocklistParser
     ) {
     }
 
+    public function isEnabledForHls(Station $station): bool
+    {
+        if (FrontendAdapters::Remote === $station->frontend_type) {
+            return false;
+        }
+
+        $frontendConfig = $station->frontend_config;
+
+        return !empty($frontendConfig->banned_countries ?? [])
+            || '' !== trim($frontendConfig->allowed_ips ?? '')
+            || '' !== trim($frontendConfig->banned_ips ?? '')
+            || '' !== trim($frontendConfig->banned_user_agents ?? '');
+    }
+
     public function isAllowed(
         Station $station,
         string $ip,

--- a/frontend/components/Admin/Stations/Form/FrontendForm.vue
+++ b/frontend/components/Admin/Stations/Form/FrontendForm.vue
@@ -83,6 +83,14 @@
                 </div>
 
                 <div class="row g-3 mb-3">
+                    <div class="col">
+                        <info-card v-if="isShoutcastFrontend">
+                            {{ $gettext('The Shoutcast DNAS 2 frontend does not support the "Allowed IP Addresses" or "Banned Countries" options. These settings will be ignored for listeners through Shoutcast.') }}
+                        </info-card>
+                    </div>
+                </div>
+
+                <div class="row g-3 mb-3">
                     <div class="col-md-5">
                         <form-group-field
                             id="edit_form_frontend_banned_ips"
@@ -167,6 +175,7 @@
 
 <script setup lang="ts">
 import FormFieldset from "~/components/Form/FormFieldset.vue";
+import InfoCard from "~/components/Common/InfoCard.vue";
 import FormGroupField from "~/components/Form/FormGroupField.vue";
 import {computed} from "vue";
 import {useTranslate} from "~/vendor/gettext";


### PR DESCRIPTION
**Fixes issue:**
Closes #8486 

**Proposed changes:**
This PR implements the listener authentication mechanism we use for the allowed ips, banned countries / ips / agents in Icecast & RSAS  in our HLS streaming too.

I've opted for only adding it on the .m3u8 playlists since adding it on every segment would be counter productive for the performance and segments are generally hard to guess the exact names anyways so this compromis should be okay I think. Have documented it on the config writer too just to be sure that it's not mistakenly identified as a vulnerability.

The linked issue inspired this PR indirectly since when I was looking into listener auth for Shoutcast, which is sadly not possible as SC lacks the necessary features for it, I also stumbled upon that HLS was missing this entirely and RSAS was missing the banned agents check.

Since Shoutcast cannot support this feature I've added an info card to the section in the station broadcasting tab to warn users about this fact, which I'd argue closes the linked issue since this is the most we can do without adding a bunch of new dependencies to add IP filtering via netfilters which I think of as overkill to do just for SC.
