### PR TITLE
Add GH actions "workflow_dispatch" to allow manually rebuilding of images without cached layers

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -20,8 +20,14 @@ on:
       - '*'
   schedule:
     - cron: '0 2 * * 0' # Weekly on Sundays at 02:00
+  workflow_dispatch:
+    inputs:
+      no_cache:
+        description: 'Build without using cached Docker layers'
+        type: boolean
+        default: false
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -82,7 +88,7 @@ jobs:
 
       - name: Generate linting report
         run: npm run lint
-  
+
   prepare:
     name: Prepare Codebase
     needs:
@@ -92,7 +98,7 @@ jobs:
     env:
       APPLICATION_ENV: testing
       NODE_ENV: production
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@master
 
@@ -168,7 +174,7 @@ jobs:
             translations
             web/static/vite_dist
             web/static/api/openapi.yml
-  
+
   build:
     name: Build & Publish
     needs: prepare
@@ -177,7 +183,7 @@ jobs:
       id-token: write
       packages: write
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@master
 
@@ -221,6 +227,7 @@ jobs:
         with:
           context: .
           push: true
+          no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.no_cache }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
**Fixes issue:**
Related to #8468

**Proposed changes:**
This PR adds a manual trigger for the `Build, Test and Publish` GH actions workflow with an optional "no cache" flag so that we can rebuilt the docker image from scratch in order to update all dependencies.

Since I didn't find any mechanisms to achieve updating something like nginx for example without having to manually touch the script that installs it I added this trigger with the option to set the `no-cache` flag on the `depot/build-push-action` step.
