### PR TITLE
fix(api): refresh scheduled entity after flush before serialization

### DIFF
--- a/backend/src/Controller/Api/Stations/AbstractScheduledEntityController.php
+++ b/backend/src/Controller/Api/Stations/AbstractScheduledEntityController.php
@@ -67,6 +67,7 @@ abstract class AbstractScheduledEntityController extends AbstractStationApiCrudC
 
         $this->em->persist($record);
         $this->em->flush();
+        $this->em->refresh($record);
 
         if (null !== $scheduleItems) {
             $this->scheduleRepo->setScheduleItems($record, $scheduleItems);


### PR DESCRIPTION
When creating StationPlaylist/StationStreamer records, Doctrine flush may leave DB-managed scalar fields uninitialized on the in-memory entity (e.g. StationPlaylist::$station_id).

The API immediately serializes the entity in the same request, which can trigger: Typed property App\Entity\StationPlaylist::$station_id must not be accessed before initialization.

Call EntityManager::refresh($record) right after flush in AbstractScheduledEntityController::editRecord() so the entity is fully hydrated before response serialization.

<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:**
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:**
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
