### PR TITLE
Fix issue #8454 - Use syncRef to keep playlists for Music Files playlists dropdown reactively updated with the Vue Query cache

### DIFF
--- a/frontend/components/Stations/Media.vue
+++ b/frontend/components/Stations/Media.vue
@@ -267,7 +267,7 @@ import {
 } from "~/entities/ApiInterfaces.ts";
 import {useApiItemProvider} from "~/functions/dataTable/useApiItemProvider.ts";
 import {QueryKeys, queryKeyWithStation} from "~/entities/Queries.ts";
-import {syncRef, toRef} from "@vueuse/core";
+import {useQueryClient} from "@tanstack/vue-query";
 import MediaPlaylists from "~/components/Stations/Media/MediaPlaylists.vue";
 import {useStationData} from "~/functions/useStationQuery.ts";
 import {FileListRequired, StationsVueFilesPropsRequired} from "~/entities/StationMedia.ts";
@@ -414,8 +414,7 @@ const fields = computed<DataTableField<MediaRow>[]>(() => {
     return fields;
 });
 
-const playlists = ref<MediaInitialPlaylist[]>(props.initialPlaylists.slice());
-syncRef(toRef(props, 'initialPlaylists'), playlists, {direction: 'ltr'});
+const playlists = computed(() => props.initialPlaylists);
 
 const selectedItems = ref<MediaSelectedItems>({
     all: [],
@@ -453,8 +452,11 @@ const onTriggerRelist = () => {
     $quota.value?.update();
 };
 
-const onAddPlaylist = (row: MediaInitialPlaylist) => {
-    playlists.value.push(row);
+const queryClient = useQueryClient();
+const propsQueryKey = queryKeyWithStation([QueryKeys.StationMedia, 'props']);
+
+const onAddPlaylist = () => {
+    void queryClient.invalidateQueries({queryKey: propsQueryKey});
 };
 
 const onFiltered = (newFilter: string) => {

--- a/frontend/components/Stations/Media.vue
+++ b/frontend/components/Stations/Media.vue
@@ -267,6 +267,7 @@ import {
 } from "~/entities/ApiInterfaces.ts";
 import {useApiItemProvider} from "~/functions/dataTable/useApiItemProvider.ts";
 import {QueryKeys, queryKeyWithStation} from "~/entities/Queries.ts";
+import {syncRef, toRef} from "@vueuse/core";
 import MediaPlaylists from "~/components/Stations/Media/MediaPlaylists.vue";
 import {useStationData} from "~/functions/useStationQuery.ts";
 import {FileListRequired, StationsVueFilesPropsRequired} from "~/entities/StationMedia.ts";
@@ -414,6 +415,8 @@ const fields = computed<DataTableField<MediaRow>[]>(() => {
 });
 
 const playlists = ref<MediaInitialPlaylist[]>(props.initialPlaylists.slice());
+syncRef(toRef(props, 'initialPlaylists'), playlists, {direction: 'ltr'});
+
 const selectedItems = ref<MediaSelectedItems>({
     all: [],
     files: [],


### PR DESCRIPTION
**Fixes issue:**
Fixes #8454

**Proposed changes:**
This PR ensures the playlists copy for the "Music Files" playlists dropdown stays reactively updated with the Vue Query cache. Without it the dropdown is not receiving any changes to the playlists (added, edited or removed ones) without having to reload the page.

**Edit:**
Having 2 parts (cache vs ref copy) fighting over who actually is telling the truth about which playlists are available here was making this more complex than needed and actually caused the on-the-fly created playlists via the media toolbar from beeing missing after adding the sync ref.

I've thus further refactored this part to just use a computed instead of a ref copy so that the Vue Query cache is the single source for this data and just invalidate the cache for the props accordingly in the `onAddPlaylist` so it correctly refetches the currently available playlists.
