### PR TITLE
#8523 Azuracast loses its place in a sequential playlist across a restart

### DIFF
--- a/backend/src/Entity/Repository/StationPlaylistMediaRepository.php
+++ b/backend/src/Entity/Repository/StationPlaylistMediaRepository.php
@@ -331,6 +331,24 @@ final class StationPlaylistMediaRepository extends Repository
         $this->em->flush();
     }
 
+    public function markMediaPlayed(
+        StationPlaylist $playlist,
+        StationMedia $media,
+        ?int $timestamp = null
+    ): void {
+        $this->em->createQuery(
+            <<<'DQL'
+                UPDATE App\Entity\StationPlaylistMedia spm
+                SET spm.last_played = :timestamp, spm.is_queued = 0
+                WHERE spm.playlist = :playlist
+                AND spm.media = :media
+            DQL
+        )->setParameter('timestamp', $timestamp ?? Time::nowUtc()->getTimestamp())
+            ->setParameter('playlist', $playlist)
+            ->setParameter('media', $media)
+            ->execute();
+    }
+
     public function resetAllQueues(Station $station, bool $includeSequential = false): void
     {
         $now = Time::nowUtc();

--- a/backend/src/Entity/Repository/StationPlaylistMediaRepository.php
+++ b/backend/src/Entity/Repository/StationPlaylistMediaRepository.php
@@ -331,7 +331,7 @@ final class StationPlaylistMediaRepository extends Repository
         $this->em->flush();
     }
 
-    public function resetAllQueues(Station $station): void
+    public function resetAllQueues(Station $station, bool $includeSequential = false): void
     {
         $now = Time::nowUtc();
 
@@ -340,8 +340,19 @@ final class StationPlaylistMediaRepository extends Repository
                 continue;
             }
 
+            if (!$this->shouldResetPlaylistQueue($playlist, $includeSequential)) {
+                continue;
+            }
+
             $this->resetQueue($playlist, $now);
         }
+    }
+
+    public function shouldResetPlaylistQueue(
+        StationPlaylist $playlist,
+        bool $includeSequential = false
+    ): bool {
+        return $includeSequential || PlaylistOrders::Sequential !== $playlist->order;
     }
 
     /**

--- a/backend/src/Entity/Repository/StationQueueRepository.php
+++ b/backend/src/Entity/Repository/StationQueueRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Entity\Repository;
 
 use App\Entity\Interfaces\SongInterface;
+use App\Entity\Enums\PlaylistOrders;
 use App\Entity\Station;
 use App\Entity\StationMedia;
 use App\Entity\StationPlaylist;
@@ -214,6 +215,8 @@ final class StationQueueRepository extends AbstractStationBasedRepository
 
     public function clearUnplayed(?Station $station = null): void
     {
+        $this->restoreSequentialPlaylistMediaFromUnplayedQueues($station);
+
         $qb = $this->em->createQueryBuilder()
             ->delete(StationQueue::class, 'sq')
             ->where('sq.is_played = 0');
@@ -224,6 +227,46 @@ final class StationQueueRepository extends AbstractStationBasedRepository
         }
 
         $qb->getQuery()->execute();
+    }
+
+    private function restoreSequentialPlaylistMediaFromUnplayedQueues(?Station $station = null): void
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->select('sq, sp, sm')
+            ->from(StationQueue::class, 'sq')
+            ->join('sq.playlist', 'sp')
+            ->join('sq.media', 'sm')
+            ->where('sq.is_played = 0')
+            ->andWhere('sp.order = :sequential')
+            ->setParameter('sequential', PlaylistOrders::Sequential);
+
+        if (null !== $station) {
+            $qb->andWhere('sq.station = :station')
+                ->setParameter('station', $station);
+        }
+
+        $restorePlaylistMediaQuery = $this->em->createQuery(
+            <<<'DQL'
+                UPDATE App\Entity\StationPlaylistMedia spm
+                SET spm.is_queued = 1
+                WHERE spm.playlist = :playlist
+                AND spm.media = :media
+            DQL
+        );
+
+        /** @var StationQueue $queueRow */
+        foreach ($qb->getQuery()->toIterable() as $queueRow) {
+            $playlist = $queueRow->playlist;
+            $media = $queueRow->media;
+
+            if (!$playlist instanceof StationPlaylist || !$media instanceof StationMedia) {
+                continue;
+            }
+
+            $restorePlaylistMediaQuery->setParameter('playlist', $playlist)
+                ->setParameter('media', $media)
+                ->execute();
+        }
     }
 
     public function cleanup(int $daysToKeep): void

--- a/backend/src/Radio/Backend/Liquidsoap/Command/FeedbackCommand.php
+++ b/backend/src/Radio/Backend/Liquidsoap/Command/FeedbackCommand.php
@@ -6,6 +6,8 @@ namespace App\Radio\Backend\Liquidsoap\Command;
 
 use App\Cache\NowPlayingCache;
 use App\Container\EntityManagerAwareTrait;
+use App\Entity\Enums\PlaylistOrders;
+use App\Entity\Repository\StationPlaylistMediaRepository;
 use App\Entity\Repository\SongHistoryRepository;
 use App\Entity\Repository\StationQueueRepository;
 use App\Entity\Song;
@@ -23,6 +25,7 @@ final class FeedbackCommand extends AbstractCommand
 
     public function __construct(
         private readonly StationQueueRepository $queueRepo,
+        private readonly StationPlaylistMediaRepository $spmRepo,
         private readonly SongHistoryRepository $historyRepo,
         private readonly NowPlayingCache $nowPlayingCache
     ) {
@@ -130,6 +133,10 @@ final class FeedbackCommand extends AbstractCommand
             $playlist = $this->em->find(StationPlaylist::class, $payload['playlist_id']);
             if ($playlist instanceof StationPlaylist) {
                 $history->playlist = $playlist;
+
+                if (PlaylistOrders::Sequential === $playlist->order) {
+                    $this->spmRepo->markMediaPlayed($playlist, $media);
+                }
             }
         }
 

--- a/backend/src/Radio/Backend/Liquidsoap/PlaylistFileWriter.php
+++ b/backend/src/Radio/Backend/Liquidsoap/PlaylistFileWriter.php
@@ -7,9 +7,11 @@ namespace App\Radio\Backend\Liquidsoap;
 use App\Container\EntityManagerAwareTrait;
 use App\Container\LoggerAwareTrait;
 use App\Doctrine\ReadOnlyBatchIteratorAggregate;
+use App\Entity\Enums\PlaylistOrders;
 use App\Entity\Station;
 use App\Entity\StationMedia;
 use App\Entity\StationPlaylist;
+use App\Entity\StationQueue;
 use App\Event\Radio\AnnotateNextSong;
 use App\Event\Radio\WriteLiquidsoapConfiguration;
 use App\Exception;
@@ -126,30 +128,52 @@ final class PlaylistFileWriter implements EventSubscriberInterface
 
         $playlistFile = [];
 
+        $queuedMediaIds = [];
+        if (PlaylistOrders::Sequential === $playlist->order) {
+            $queuedMediaQuery = $this->em->createQuery(
+                <<<'DQL'
+                    SELECT sq, sm
+                    FROM App\Entity\StationQueue sq
+                    JOIN sq.media sm
+                    WHERE sq.playlist = :playlist
+                    AND sq.is_played = 0
+                    ORDER BY sq.sent_to_autodj DESC, sq.timestamp_cued ASC
+                DQL
+            )->setParameter('playlist', $playlist);
+
+            /** @var StationQueue $queueRow */
+            foreach (ReadOnlyBatchIteratorAggregate::fromQuery($queuedMediaQuery, 1000) as $queueRow) {
+                $mediaFile = $queueRow->media;
+                if (!$mediaFile instanceof StationMedia) {
+                    continue;
+                }
+
+                $queuedMediaIds[] = $mediaFile->id;
+                $this->appendPlaylistFileEntry($playlistFile, $station, $playlist, $mediaFile);
+            }
+        }
+
+        $playlistMediaOrder = (PlaylistOrders::Sequential === $playlist->order)
+            ? 'spm.is_queued DESC, spm.weight ASC'
+            : 'spm.weight ASC';
+
         $mediaQuery = $this->em->createQuery(
-            <<<'DQL'
+            <<<DQL
                 SELECT DISTINCT sm
                 FROM App\Entity\StationMedia sm
                 JOIN sm.playlists spm
                 WHERE spm.playlist = :playlist
-                ORDER BY spm.weight ASC
+                ORDER BY {$playlistMediaOrder}
             DQL
         )->setParameter('playlist', $playlist);
 
         /** @var StationMedia $mediaFile */
         foreach (ReadOnlyBatchIteratorAggregate::fromQuery($mediaQuery, 1000) as $mediaFile) {
-            $event = new AnnotateNextSong(
-                station: $station,
-                media: $mediaFile,
-                playlist: $playlist,
-                asAutoDj: false
-            );
-
-            try {
-                $this->eventDispatcher->dispatch($event);
-                $playlistFile[] = $event->buildAnnotations();
-            } catch (Throwable) {
+            if (in_array($mediaFile->id, $queuedMediaIds, true)) {
+                continue;
             }
+
+            $this->appendPlaylistFileEntry($playlistFile, $station, $playlist, $mediaFile);
         }
 
         $playlistFilePath = self::getPlaylistFilePath($playlist);
@@ -157,6 +181,29 @@ final class PlaylistFileWriter implements EventSubscriberInterface
             $playlistFilePath,
             implode("\n", $playlistFile)
         );
+    }
+
+    /**
+     * @param string[] $playlistFile
+     */
+    private function appendPlaylistFileEntry(
+        array &$playlistFile,
+        Station $station,
+        StationPlaylist $playlist,
+        StationMedia $mediaFile
+    ): void {
+        $event = new AnnotateNextSong(
+            station: $station,
+            media: $mediaFile,
+            playlist: $playlist,
+            asAutoDj: false
+        );
+
+        try {
+            $this->eventDispatcher->dispatch($event);
+            $playlistFile[] = $event->buildAnnotations();
+        } catch (Throwable) {
+        }
     }
 
     public static function getPlaylistFilePath(StationPlaylist $playlist): string

--- a/backend/src/Radio/Configuration.php
+++ b/backend/src/Radio/Configuration.php
@@ -77,7 +77,7 @@ final class Configuration
 
         $this->em->flush();
 
-        $this->spmRepo->resetAllQueues($station);
+        $this->spmRepo->resetAllQueues($station, includeSequential: false);
     }
 
     /**

--- a/tests/Unit/StationPlaylistMediaRepositoryPersistenceTest.php
+++ b/tests/Unit/StationPlaylistMediaRepositoryPersistenceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit;
+
+use App\Doctrine\ReloadableEntityManagerInterface;
+use App\Entity\Enums\PlaylistOrders;
+use App\Entity\Enums\StorageLocationAdapters;
+use App\Entity\Enums\StorageLocationTypes;
+use App\Entity\Repository\StationPlaylistMediaRepository;
+use App\Entity\Song;
+use App\Entity\Station;
+use App\Entity\StationMedia;
+use App\Entity\StationPlaylist;
+use App\Entity\StationPlaylistMedia;
+use App\Entity\StorageLocation;
+use App\Tests\Module;
+use Codeception\Test\Unit;
+use UnitTester;
+
+class StationPlaylistMediaRepositoryPersistenceTest extends Unit
+{
+    protected UnitTester $tester;
+
+    private ReloadableEntityManagerInterface $em;
+
+    private StationPlaylistMediaRepository $repo;
+
+    protected function _inject(Module $testsModule): void
+    {
+        $this->em = $testsModule->em;
+        $this->repo = $testsModule->container->get(StationPlaylistMediaRepository::class);
+    }
+
+    public function testMarkMediaPlayedAdvancesSequentialPlaylistCursor(): void
+    {
+        $connection = $this->em->getConnection();
+        $connection->beginTransaction();
+
+        try {
+            $this->runMarkMediaPlayedAdvancesSequentialPlaylistCursorTest();
+        } finally {
+            $connection->rollBack();
+            $this->em->clear();
+        }
+    }
+
+    private function runMarkMediaPlayedAdvancesSequentialPlaylistCursorTest(): void
+    {
+        $station = new Station();
+        $station->name = 'Station Playlist Media Repository Test';
+        $station->radio_base_dir = $station->short_name;
+        $station->media_storage_location = new StorageLocation(
+            StorageLocationTypes::StationMedia,
+            StorageLocationAdapters::Local
+        );
+        $station->recordings_storage_location = new StorageLocation(
+            StorageLocationTypes::StationRecordings,
+            StorageLocationAdapters::Local
+        );
+        $station->podcasts_storage_location = new StorageLocation(
+            StorageLocationTypes::StationPodcasts,
+            StorageLocationAdapters::Local
+        );
+
+        $playlist = new StationPlaylist($station);
+        $playlist->name = 'Sequential Playlist';
+        $playlist->order = PlaylistOrders::Sequential;
+
+        $media = new StationMedia($station->media_storage_location, 'test.mp3');
+        $media->setSong(Song::createFromText('Test Song'));
+
+        $playlistMedia = new StationPlaylistMedia($playlist, $media);
+
+        $this->em->persist($station->media_storage_location);
+        $this->em->persist($station->recordings_storage_location);
+        $this->em->persist($station->podcasts_storage_location);
+        $this->em->persist($station);
+        $this->em->persist($playlist);
+        $this->em->persist($media);
+        $this->em->persist($playlistMedia);
+        $this->em->flush();
+
+        $playlistMediaId = $playlistMedia->id;
+
+        $this->repo->markMediaPlayed($playlist, $media, 123);
+        $this->em->clear();
+
+        $playlistMedia = $this->repo->requireRecord($playlistMediaId);
+
+        self::assertFalse($playlistMedia->is_queued);
+        self::assertSame(123, $playlistMedia->last_played);
+    }
+}

--- a/tests/Unit/StationPlaylistMediaRepositoryTest.php
+++ b/tests/Unit/StationPlaylistMediaRepositoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit;
+
+use App\Entity\Enums\PlaylistOrders;
+use App\Entity\Enums\StorageLocationAdapters;
+use App\Entity\Enums\StorageLocationTypes;
+use App\Entity\Repository\StationPlaylistMediaRepository;
+use App\Entity\Station;
+use App\Entity\StationMedia;
+use App\Entity\StationPlaylist;
+use App\Entity\StationPlaylistMedia;
+use App\Entity\StorageLocation;
+use App\Tests\Module;
+use Codeception\Test\Unit;
+use UnitTester;
+
+class StationPlaylistMediaRepositoryTest extends Unit
+{
+    protected UnitTester $tester;
+
+    protected StationPlaylistMediaRepository $repo;
+
+    protected function _inject(Module $testsModule): void
+    {
+        $this->repo = $testsModule->container->get(StationPlaylistMediaRepository::class);
+    }
+
+    public function testSequentialPlaylistQueuesAreNotResetByDefault(): void
+    {
+        $station = new Station();
+        $playlist = $this->createPlaylist($station, PlaylistOrders::Sequential);
+
+        $playlistMedia = $this->createPlaylistMedia($playlist);
+        $playlistMedia->is_queued = false;
+
+        $this->repo->resetAllQueues($station);
+
+        self::assertFalse($playlistMedia->is_queued);
+    }
+
+    public function testPlaylistQueueResetPolicy(): void
+    {
+        $station = new Station();
+        $sequentialPlaylist = $this->createPlaylist($station, PlaylistOrders::Sequential);
+        $shuffledPlaylist = $this->createPlaylist($station, PlaylistOrders::Shuffle);
+        $randomPlaylist = $this->createPlaylist($station, PlaylistOrders::Random);
+
+        self::assertFalse($this->repo->shouldResetPlaylistQueue($sequentialPlaylist));
+        self::assertTrue($this->repo->shouldResetPlaylistQueue($sequentialPlaylist, includeSequential: true));
+        self::assertTrue($this->repo->shouldResetPlaylistQueue($shuffledPlaylist));
+        self::assertTrue($this->repo->shouldResetPlaylistQueue($randomPlaylist));
+    }
+
+    private function createPlaylist(
+        Station $station,
+        PlaylistOrders $order
+    ): StationPlaylist {
+        $playlist = new StationPlaylist($station);
+        $playlist->name = $order->value . ' Playlist';
+        $playlist->order = $order;
+
+        $station->playlists->add($playlist);
+
+        return $playlist;
+    }
+
+    private function createPlaylistMedia(StationPlaylist $playlist): StationPlaylistMedia
+    {
+        $storageLocation = new StorageLocation(
+            StorageLocationTypes::StationMedia,
+            StorageLocationAdapters::Local
+        );
+
+        $media = new StationMedia($storageLocation, 'test.mp3');
+        $playlistMedia = new StationPlaylistMedia($playlist, $media);
+
+        $playlist->media_items->add($playlistMedia);
+        $media->playlists->add($playlistMedia);
+
+        return $playlistMedia;
+    }
+}

--- a/tests/Unit/StationQueueRepositoryTest.php
+++ b/tests/Unit/StationQueueRepositoryTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit;
+
+use App\Doctrine\ReloadableEntityManagerInterface;
+use App\Entity\Enums\PlaylistOrders;
+use App\Entity\Enums\StorageLocationAdapters;
+use App\Entity\Enums\StorageLocationTypes;
+use App\Entity\Repository\StationPlaylistMediaRepository;
+use App\Entity\Repository\StationQueueRepository;
+use App\Entity\Song;
+use App\Entity\Station;
+use App\Entity\StationMedia;
+use App\Entity\StationPlaylist;
+use App\Entity\StationPlaylistMedia;
+use App\Entity\StationQueue;
+use App\Entity\StorageLocation;
+use App\Tests\Module;
+use Codeception\Test\Unit;
+use UnitTester;
+
+class StationQueueRepositoryTest extends Unit
+{
+    protected UnitTester $tester;
+
+    private ReloadableEntityManagerInterface $em;
+
+    private StationQueueRepository $repo;
+
+    private StationPlaylistMediaRepository $spmRepo;
+
+    protected function _inject(Module $testsModule): void
+    {
+        $this->em = $testsModule->em;
+        $this->repo = $testsModule->container->get(StationQueueRepository::class);
+        $this->spmRepo = $testsModule->container->get(StationPlaylistMediaRepository::class);
+    }
+
+    public function testClearUnplayedRestoresSequentialPlaylistMedia(): void
+    {
+        $connection = $this->em->getConnection();
+        $connection->beginTransaction();
+
+        try {
+            $this->runClearUnplayedRestoresSequentialPlaylistMediaTest();
+        } finally {
+            $connection->rollBack();
+            $this->em->clear();
+        }
+    }
+
+    private function runClearUnplayedRestoresSequentialPlaylistMediaTest(): void
+    {
+        $station = new Station();
+        $station->name = 'Station Queue Repository Test';
+        $station->radio_base_dir = $station->short_name;
+        $station->media_storage_location = new StorageLocation(
+            StorageLocationTypes::StationMedia,
+            StorageLocationAdapters::Local
+        );
+        $station->recordings_storage_location = new StorageLocation(
+            StorageLocationTypes::StationRecordings,
+            StorageLocationAdapters::Local
+        );
+        $station->podcasts_storage_location = new StorageLocation(
+            StorageLocationTypes::StationPodcasts,
+            StorageLocationAdapters::Local
+        );
+
+        $playlist = new StationPlaylist($station);
+        $playlist->name = 'Sequential Playlist';
+        $playlist->order = PlaylistOrders::Sequential;
+
+        $media = new StationMedia($station->media_storage_location, 'test.mp3');
+        $media->setSong(Song::createFromText('Queued Song'));
+
+        $playlistMedia = new StationPlaylistMedia($playlist, $media);
+        $playlistMedia->is_queued = false;
+
+        $queueRow = StationQueue::fromMedia($station, $media);
+        $queueRow->playlist = $playlist;
+        $queueRow->sent_to_autodj = true;
+
+        $this->em->persist($station->media_storage_location);
+        $this->em->persist($station->recordings_storage_location);
+        $this->em->persist($station->podcasts_storage_location);
+        $this->em->persist($station);
+        $this->em->persist($playlist);
+        $this->em->persist($media);
+        $this->em->persist($playlistMedia);
+        $this->em->persist($queueRow);
+        $this->em->flush();
+
+        $playlistMediaId = $playlistMedia->id;
+        $queueRowId = $queueRow->id;
+
+        $this->repo->clearUnplayed($station);
+        $this->em->clear();
+
+        $playlistMedia = $this->spmRepo->requireRecord($playlistMediaId);
+
+        self::assertTrue($playlistMedia->is_queued);
+        self::assertNull($this->repo->find($queueRowId));
+    }
+}


### PR DESCRIPTION
## Summary

- Preserve sequential playlist cursor state during station configuration initialization.
- Keep generated Liquidsoap playlist files aligned with the current unplayed station queue.
- Restore sequential playlist media state before clearing unplayed queues during full container startup.
- Mark sequential playlist media as played from Liquidsoap feedback when generated playlist entries do not have a queue row.

## Testing

- `docker compose exec web php vendor/bin/codecept run Unit tests/Unit/StationPlaylistMediaRepositoryTest.php --no-interaction`
- `docker compose exec web php vendor/bin/codecept run Unit tests/Unit/StationPlaylistMediaRepositoryPersistenceTest.php --no-interaction`
- `docker compose exec web php vendor/bin/codecept run Unit tests/Unit/StationQueueRepositoryTest.php --no-interaction`
- Live verification on Radio Onion Ring: Liquidsoap-only restart preserved current `audio1120480729` and next `audio1135649737`.
- Live verification on Radio Onion Ring: full container restart resumed with expected next track `audio1135649737` now playing and regenerated playlist file beginning with that track.

Note: the full unit suite still has unrelated `StationPlaylistTest` Mockery errors that are isolated on a separate general test-fixes branch.