### PR TITLE
Map .fc and .cus extensions to audio/x-mod

### DIFF
--- a/backend/src/Media/MimeTypeExtensionMap.php
+++ b/backend/src/Media/MimeTypeExtensionMap.php
@@ -11,6 +11,8 @@ final class MimeTypeExtensionMap extends GeneratedExtensionToMimeTypeMap
     public const array ADDED_MIME_TYPES = [
         'mod' => 'audio/x-mod',
         'stm' => 'audio/x-mod',
+        'fc' => 'audio/x-mod',
+        'cus' => 'audio/x-mod',
         // Temporary Bugfix for incorrectly mapped aac mime type in library
         // @see https://github.com/thephpleague/mime-type-detection/pull/40
         'aac' => 'audio/aac',


### PR DESCRIPTION
### Summary

`audio/x-mod` is already in `MimeType::$processableTypes`, and `.mod` and `.stm` already map to it in `MimeTypeExtensionMap`. Two further Amiga module extensions are missing, so files using them are refused before they reach the media library:

| ext | format |
|---|---|
| `.fc` | Future Composer |
| `.cus` | Custom (UADE's `custom` replayer) |

### Why the extension map is the only place this can be fixed

Neither format is detectable by content. `finfo` returns `application/octet-stream` for both, so `MimeType::getMimeTypeFromFile()` falls through to `getMimeTypeFromPath()`, the extension map returns nothing, and `MetadataManager::read()` throws `CannotProcessMediaException` with *"MIME type ... is not processable"* on upload and on every media scan.

Adding the two entries is sufficient — the resulting MIME type is already accepted downstream, so nothing else changes.

### Scope

Two lines, no behaviour change for any existing format. `.mod`/`.stm` set the precedent; this just extends the same list.

### Context

These formats do play in practice — an external Liquidsoap decoder shelling out to `uade123` handles them at playout. The extension mapping was the only thing preventing the files from being catalogued in the first place, which is why this seemed worth sending upstream rather than carrying as a local patch.

Tested against 0.23.7: with these two entries, `.fc` and `.cus` files import and scan normally; without them they land in `unprocessable_media`.