### PR TITLE
Disable chunked transfer encoding for generated listener proxy locati…

### DIFF
--- a/backend/src/Nginx/ConfigWriter.php
+++ b/backend/src/Nginx/ConfigWriter.php
@@ -53,6 +53,7 @@ final class ConfigWriter implements EventSubscriberInterface
 
             location ~ ^({$listenBaseUrlForRegex}|/radio/{$port})/(.*)\$ {
                 include proxy_params;
+                chunked_transfer_encoding off;
 
                 proxy_intercept_errors    on;
                 proxy_next_upstream       error timeout invalid_header;

--- a/tests/Unit/NginxConfigWriterTest.php
+++ b/tests/Unit/NginxConfigWriterTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit;
+
+use App\Entity\Station;
+use App\Event\Nginx\WriteNginxConfiguration;
+use App\Nginx\ConfigWriter;
+use App\Tests\Module;
+use Codeception\Test\Unit;
+use UnitTester;
+
+final class NginxConfigWriterTest extends Unit
+{
+    protected UnitTester $tester;
+
+    private ConfigWriter $configWriter;
+
+    protected function _inject(Module $testsModule): void
+    {
+        $this->configWriter = $testsModule->container->get(ConfigWriter::class);
+    }
+
+    public function testRadioProxyDisablesChunkedTransferEncoding(): void
+    {
+        $station = new Station();
+        $station->name = 'Test Station';
+
+        $frontendConfig = $station->frontend_config;
+        $frontendConfig->port = 8000;
+        $station->frontend_config = $frontendConfig;
+
+        $event = new WriteNginxConfiguration($station, false);
+
+        $this->configWriter->writeRadioSection($event);
+
+        $configuration = $event->buildConfiguration();
+
+        self::assertStringContainsString(
+            'chunked_transfer_encoding off;',
+            $configuration
+        );
+
+        self::assertStringContainsString(
+            'location ~ ^(/listen/test_station|/radio/8000)/(.*)$',
+            $configuration
+        );
+
+        self::assertStringContainsString(
+            'proxy_pass http://127.0.0.1:8000/$2?$args;',
+            $configuration
+        );
+    }
+}


### PR DESCRIPTION
Some streaming clients, such as TuneIn, reject proxied streams when nginx uses Transfer-Encoding: chunked.  Disabling chunked transfer encoding allows those clients to consume the stream successfully.

Also added a regression test covering the generated nginx configuration.

I initially determined that I was able to connect to the stream on the direct IceCast port 9000, but connecting to any proxied connection refused to work with the error "Cannot decode stream".  Upon closer inspection, I found that the Icecast stream did not include the headers "Transfer-Encoding: chunked" and "Connection: keep-alive", but the proxied connections did.  Nothing in the code suggested that it was being added on purpose.  So, I experimented with adding "chunked_transfer_encoding off;" in a fresh installation of Azuracast on an isolated server.  I could then test whether the endpoints continued to work for traditional clients as well as TuneIn.  Satisfied that I hadn't inadvertently added a regression, I added a new unit test to cover this condition.  I have also run the suite of unit tests with 100% passing.  I was not able to run all of the functional tests, because I do not have a complete development environment.  (Perhaps, if I do any more contributions, I will make that effort, but for the purposes of this change, I didn't feel it was a necessary use of time.)

**Fixes issue:**
Fixes #8543

I also noted that Issue #7983 seemed to have something to do with TuneIn, but I could not validate that it was the same issue.  I reference it here for completeness only.

**Proposed changes:**
A single line change to the backend Nginix ConfigWriter.php class will force the stream header to not be "chunked" and leave Connection as close.