### PR TITLE
Fix issue #8466 - Stop caching now_playing REST responses and recalculate elapsed before SSE/webhook dispatch

### DIFF
--- a/backend/config/routes/api_public.php
+++ b/backend/config/routes/api_public.php
@@ -51,7 +51,6 @@ return static function (RouteCollectorProxy $group) {
         '/nowplaying',
         Controller\Api\NowPlayingAction::class
     )->setName('api:nowplaying:index')
-        ->add(new Middleware\Cache\SetCache(15))
         ->add(Middleware\GetStation::class);
 
     $group->get('/stations', Controller\Api\Stations\IndexController::class . ':listAction')

--- a/backend/config/routes/api_station.php
+++ b/backend/config/routes/api_station.php
@@ -15,8 +15,7 @@ return static function (RouteCollectorProxy $group) {
             $group->get(
                 '',
                 Controller\Api\NowPlayingAction::class
-            )->setName('api:nowplaying:station')
-                ->add(new Middleware\Cache\SetCache(15));
+            )->setName('api:nowplaying:station');
 
             $group->get(
                 '/art[/{timestamp}.jpg]',

--- a/backend/src/Webhook/LocalWebhookHandler.php
+++ b/backend/src/Webhook/LocalWebhookHandler.php
@@ -30,6 +30,8 @@ final class LocalWebhookHandler
         NowPlaying $np,
         array $triggers
     ): void {
+        $np->update();
+
         $fsUtils = new Filesystem();
 
         $staticNpDir = $this->environment->getTempDirectory() . '/nowplaying';


### PR DESCRIPTION
## Problem

`now_playing.elapsed` appears frozen for ~15-20s at a time, then jumps, on
**both** `GET /api/nowplaying/{station}` and the SSE (Centrifugo) push path.

## Root causes

1. **REST**: the nowplaying routes carried a 15s `SetCache` middleware. Combined
   with nginx's `fastcgi_cache` (enabled on the front-controller location, driven
   by the `X-Accel-Expires` header the middleware sets — no `fastcgi_cache_valid`
   is configured anywhere), the entire JSON response gets cached server-side for
   15s. On a cache hit, PHP never runs, so `NowPlayingAction`'s live
   `$np->update()` call never executes. The browser's own `Cache-Control` header
   compounds this for repeat polling from the same client.

2. **SSE/webhook**: `NowPlaying::update()` (which recalculates `elapsed`/
   `remaining` from `played_at`) is only called once, at sync-task build time,
   inside `NowPlayingApiGenerator`. The same object is later dispatched
   asynchronously to `LocalWebhookHandler::dispatch()`, which publishes it to
   Centrifugo without recalculating again — so the pushed `elapsed` is stale by
   however long the object spent in the build → dispatch → message-bus → handler
   pipeline.

## Fix

1. Removed `SetCache(15)` from the `/nowplaying` and `/nowplaying/{station_id}`
   routes (station art route untouched — no `elapsed` field, rarely changes).
2. Added `$np->update()` as the first statement in
   `LocalWebhookHandler::dispatch()`, before static files are written and before
   the Centrifugo publish.

## Tradeoffs

- REST: every request now reaches PHP-FPM instead of being served from nginx
  cache. Backed by an in-memory/Redis cache read (NowPlayingCache), not a DB
  query — expected negligible.
- No change to sync-task cadence or webhook dispatch frequency in either fix —
  only correctness of `elapsed` at the moment of delivery.
- `played_at` untouched in both fixes; only derived fields recalculated.

Fixes #8466