### PR TITLE
Add covering index to song_history for the analytics stats query

### DIFF
--- a/backend/src/Entity/Migration/Version20260806020647.php
+++ b/backend/src/Entity/Migration/Version20260806020647.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20260806020647 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add a covering index to song_history for the analytics stats-by-time-range query.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'CREATE INDEX idx_station_timestamps ON song_history (station_id, timestamp_end, timestamp_start)'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX idx_station_timestamps ON song_history');
+    }
+}

--- a/backend/src/Entity/SongHistory.php
+++ b/backend/src/Entity/SongHistory.php
@@ -15,7 +15,8 @@ use Doctrine\ORM\Mapping as ORM;
     ORM\Index(name: 'idx_is_visible', columns: ['is_visible']),
     ORM\Index(name: 'idx_timestamp_start', columns: ['timestamp_start']),
     ORM\Index(name: 'idx_timestamp_end', columns: ['timestamp_end']),
-    ORM\Index(name: 'idx_station_visible_id', columns: ['station_id', 'is_visible', 'id'])
+    ORM\Index(name: 'idx_station_visible_id', columns: ['station_id', 'is_visible', 'id']),
+    ORM\Index(name: 'idx_station_timestamps', columns: ['station_id', 'timestamp_end', 'timestamp_start'])
 ]
 final class SongHistory implements
     Interfaces\SongInterface,


### PR DESCRIPTION
SongHistoryRepository::getStatsByTimeRange() filters on station_id, timestamp_end and timestamp_start:

    SELECT AVG(sh.listeners_end), MAX(sh.listeners_end), MIN(sh.listeners_end)
    FROM App\Entity\SongHistory sh
    WHERE sh.station = :station
      AND sh.timestamp_end >= :start
      AND sh.timestamp_start <= :end

None of the existing indexes on song_history serve that combination. idx_station_visible_id leads with station_id but continues with is_visible, which the query does not filter on, so only the station_id prefix is usable; idx_timestamp_start and idx_timestamp_end are single-column and cannot be combined with the station filter. The result is a scan of every row belonging to the station.

RunAnalyticsTask calls this once per station per hour-bucket per day when rebuilding analytics, so the cost multiplies by station count. On an installation with roughly 760k rows in song_history across 27 stations, each call examined about 86k rows and the analytics sync ran for over twenty minutes; with this index the same queries examine a few hundred rows and the sync completes in under two.

Only song_history needs this. The equivalent analytics query on the listener table, ListenerRepository::getUniqueListeners(), filters on the same three columns and is already served by the leftmost prefix of idx_station_timestamps_hash, added in Version20260408060000.

Index creation on InnoDB is an online operation, so the migration does not lock the table.
