### PR TITLE
Fix Issue #8565 - Fix accidental overwriting of resolved media in playlist config importer

### DIFF
--- a/backend/src/Service/PlaylistConfiguration/PlaylistConfigurationImporter.php
+++ b/backend/src/Service/PlaylistConfiguration/PlaylistConfigurationImporter.php
@@ -247,12 +247,12 @@ final class PlaylistConfigurationImporter
             return $summary->mediaByRef[$mediaRef];
         }
 
-        $path = $mediaEntry->path;
-
-        $media = $this->mediaRepo->findByPath($path, $storageLocation);
-        if ($media !== null && !empty($mediaEntry->uniqueId)) {
+        $media = null;
+        if (!empty($mediaEntry->uniqueId)) {
             $media = $this->mediaRepo->findByUniqueId($mediaEntry->uniqueId, $storageLocation);
         }
+
+        $media ??= $this->mediaRepo->findByPath($mediaEntry->path, $storageLocation);
 
         if ($media !== null) {
             $summary->mediaRelinked++;


### PR DESCRIPTION
**Fixes issue:**
Fixes #8565 

**Proposed changes:**

When a media was resolved by path we then unintentionally overwrote that again with the result of findByUniqueId resulting in a `null` being set on the `$media` variable. That then triggered regenerating the media via the dummy media generation.

This in itself was already broken behaviour even when it worked correctly, since I missed a flipped null / not-null comparison, one that is `$media !== null` but should have been `$media === null`...

On stations where the media has the same `uniqueId` as the dump this was not happening since the `uniqueId`'s where matching thus giving a result, but on newly created stations with a duplicated media library this caused the `uniqueId`'s to mismatch.

Since I mostly tested with dummy media or on the same station where I created my exports (and only with rather small libraries) I didn't notice this borked behavior in testing 🤦‍♀️ 