### PR TITLE
Fix Issue #8563 - Add loading indicator to playlist import modals

### DIFF
--- a/frontend/components/Stations/Playlists/ApplyToModal.vue
+++ b/frontend/components/Stations/Playlists/ApplyToModal.vue
@@ -4,7 +4,7 @@
         ref="$modal"
         size="xl"
         centered
-        :loading="loading"
+        :busy="loading"
         :title="$gettext('Apply Playlist to Folders')"
         @hidden="clearContents"
     >
@@ -44,6 +44,7 @@
             <button
                 type="button"
                 class="btn btn-secondary"
+                :disabled="loading"
                 @click="hide"
             >
                 {{ $gettext('Close') }}
@@ -51,7 +52,7 @@
             <button
                 type="button"
                 class="btn btn-primary"
-                :disabled="selectedDirs.length === 0"
+                :disabled="selectedDirs.length === 0 || loading"
                 @click="save"
             >
                 {{ $gettext('Apply to Folders') }}
@@ -171,6 +172,8 @@ const save = async () => {
         return;
     }
 
+    loading.value = true;
+
     try {
         await axios.put(applyToUrl.value, {
             ...form.value,
@@ -179,6 +182,8 @@ const save = async () => {
 
         notifySuccess($gettext("Playlist successfully applied to folders."));
     } finally {
+        loading.value = false;
+
         hide();
         emit("relist");
     }

--- a/frontend/components/Stations/Playlists/ImportModal.vue
+++ b/frontend/components/Stations/Playlists/ImportModal.vue
@@ -4,6 +4,7 @@
         ref="$modal"
         :title="$gettext('Import from PLS/M3U')"
         size="lg"
+        :busy="loading"
         @hidden="onHidden"
     >
         <div v-if="results">
@@ -82,12 +83,14 @@
             <button
                 type="button"
                 class="btn btn-secondary"
+                :disabled="loading"
                 @click="hide"
             >
                 {{ $gettext('Close') }}
             </button>
             <button
                 v-if="!results"
+                :disabled="playlistFile === null || loading"
                 class="btn btn-primary"
                 type="submit"
                 @click="doSubmit"
@@ -122,6 +125,7 @@ const emit = defineEmits<HasRelistEmit>();
 const importPlaylistUrl = ref<string | null>(null);
 const playlistFile = ref<File | null>(null);
 const overwritePlaylist = ref(false);
+const loading = ref<boolean>(false);
 
 const results = ref<BatchImportResult | null>(null);
 
@@ -135,6 +139,7 @@ const { show, hide } = useHasModal($modal);
 const open = (newImportPlaylistUrl: string) => {
     playlistFile.value = null;
     overwritePlaylist.value = false;
+    loading.value = false;
 
     importPlaylistUrl.value = newImportPlaylistUrl;
     show();
@@ -151,18 +156,24 @@ const doSubmit = async () => {
     const formData = new FormData();
     formData.append("playlist_file", playlistFile.value);
 
-    const { data } = await axios.post<BatchImportResult>(
-        importPlaylistUrl.value,
-        formData,
-    );
+    loading.value = true;
 
-    if (data.success) {
-        results.value = data;
+    try {
+        const { data } = await axios.post<BatchImportResult>(
+            importPlaylistUrl.value,
+            formData,
+        );
 
-        notifySuccess(data.message);
-    } else {
-        notifyError(data.message);
-        hide();
+        if (data.success) {
+            results.value = data;
+
+            notifySuccess(data.message);
+        } else {
+            notifyError(data.message);
+            hide();
+        }
+    } finally {
+        loading.value = false;
     }
 };
 

--- a/frontend/components/Stations/Playlists/ImportPlaylistConfigModal.vue
+++ b/frontend/components/Stations/Playlists/ImportPlaylistConfigModal.vue
@@ -4,6 +4,7 @@
         ref="$modal"
         :title="$gettext('Import Playlist Configuration')"
         size="lg"
+        :busy="loading"
         @hidden="onHidden"
     >
         <div v-if="results">
@@ -79,13 +80,14 @@
             <button
                 type="button"
                 class="btn btn-secondary"
+                :disabled="loading"
                 @click="hide"
             >
                 {{ $gettext('Close') }}
             </button>
             <button
                 v-if="!results"
-                :disabled="playlistsConfigFile === null"
+                :disabled="playlistsConfigFile === null || loading"
                 class="btn btn-primary"
                 type="submit"
                 @click="doSubmit"
@@ -124,6 +126,7 @@ const emit = defineEmits<HasRelistEmit>();
 
 const playlistsConfigFile = ref<File | null>(null);
 const namePrefix = ref<string>("");
+const loading = ref<boolean>(false);
 
 const results = ref<ConfigImportResult | null>(null);
 
@@ -137,6 +140,7 @@ const { show, hide } = useHasModal($modal);
 const open = () => {
     playlistsConfigFile.value = null;
     namePrefix.value = "";
+    loading.value = false;
     results.value = null;
 
     show();
@@ -156,18 +160,24 @@ const doSubmit = async () => {
         formData.append("name_prefix", namePrefix.value);
     }
 
-    const { data } = await axios.post<ConfigImportResult>(
-        props.importUrl,
-        formData,
-    );
+    loading.value = true;
 
-    if (data.success) {
-        results.value = data;
+    try {
+        const { data } = await axios.post<ConfigImportResult>(
+            props.importUrl,
+            formData,
+        );
 
-        notifySuccess(data.message);
-    } else {
-        notifyError(data.message);
-        hide();
+        if (data.success) {
+            results.value = data;
+
+            notifySuccess(data.message);
+        } else {
+            notifyError(data.message);
+            hide();
+        }
+    } finally {
+        loading.value = false;
     }
 };
 


### PR DESCRIPTION
**Fixes issue:**
Fixes #8563

**Proposed changes:**
This PR adds the use of the `:busy` prop to:
- Playlist config import modal
- Playlist pls/m3u import modal
  - Added since I noticed it missing there and since it also imports potentially large dumps it might also be confusing to users when it just sits there without one

Also fixes a wrong `:loading` prop being used on the apply playlist to folders modal.
