### PR TITLE
Fix Issue #8572 - Add playlist members to supported content for duplicate playlist feature

### DIFF
--- a/backend/src/Controller/Api/Stations/Playlists/AbstractClonableAction.php
+++ b/backend/src/Controller/Api/Stations/Playlists/AbstractClonableAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller\Api\Stations\Playlists;
 
 use App\Container\EntityManagerAwareTrait;
+use App\Entity\Enums\PlaylistSources;
 use App\Entity\Repository\StationPlaylistRepository;
 use App\Entity\StationPlaylist;
 
@@ -21,7 +22,8 @@ abstract class AbstractClonableAction
         StationPlaylist $record,
         ?string $newName = null,
         bool $cloneSchedules = true,
-        bool $cloneMedia = false
+        bool $cloneMedia = false,
+        bool $cloneMembers = false
     ): StationPlaylist {
         $this->em->detach($record);
 
@@ -56,6 +58,17 @@ abstract class AbstractClonableAction
                 $newMediaItem = clone $oldMediaItem;
                 $newMediaItem->playlist = $newRecord;
                 $this->em->persist($newMediaItem);
+            }
+        }
+
+        if ($cloneMembers && $record->source === PlaylistSources::Playlists) {
+            foreach ($record->playlists as $oldMember) {
+                $this->em->detach($oldMember);
+
+                $newMember = clone $oldMember;
+                $newMember->playlist_group = $newRecord;
+
+                $this->em->persist($newMember);
             }
         }
 

--- a/backend/src/Controller/Api/Stations/Playlists/CloneAction.php
+++ b/backend/src/Controller/Api/Stations/Playlists/CloneAction.php
@@ -33,6 +33,7 @@ use Psr\Http\Message\ResponseInterface;
                         enum: [
                             'schedule',
                             'media',
+                            'members',
                         ]
                     ),
                 ),
@@ -76,7 +77,8 @@ final class CloneAction extends AbstractClonableAction implements SingleActionIn
             $record,
             $data['name'],
             in_array('schedule', $toClone, true),
-            in_array('media', $toClone, true)
+            in_array('media', $toClone, true),
+            in_array('members', $toClone, true)
         );
 
         $this->em->flush();

--- a/frontend/components/Stations/Playlists.vue
+++ b/frontend/components/Stations/Playlists.vue
@@ -308,7 +308,7 @@
                                     <button
                                         type="button"
                                         class="btn btn-sm btn-secondary"
-                                        @click="doClone(item.name, item.links.clone)"
+                                        @click="doClone(item.name, item.links.clone, item.source === 'playlists')"
                                     >
                                         {{ $gettext('Duplicate') }}
                                     </button>
@@ -566,8 +566,8 @@ const doImportPlaylistConfig = () => {
 
 const $cloneModal = useTemplateRef("$cloneModal");
 
-const doClone = (name: string, url: string) => {
-    $cloneModal.value?.open(name, url);
+const doClone = (name: string, url: string, isGroup: boolean) => {
+    $cloneModal.value?.open(name, url, isGroup);
 };
 
 const $applyToModal = useTemplateRef("$applyToModal");

--- a/frontend/components/Stations/Playlists/CloneModal.vue
+++ b/frontend/components/Stations/Playlists/CloneModal.vue
@@ -29,7 +29,7 @@
 
 <script setup lang="ts">
 import { required } from "@regle/rules";
-import { ref, useTemplateRef } from "vue";
+import { computed, ref, useTemplateRef } from "vue";
 import ModalForm from "~/components/Common/ModalForm.vue";
 import { useNotify } from "~/components/Common/Toasts/useNotify.ts";
 import FormGroupField from "~/components/Form/FormGroupField.vue";
@@ -45,6 +45,7 @@ const emit = defineEmits<{
 }>();
 
 const cloneUrl = ref<string | null>(null);
+const isGroup = ref<boolean>(false);
 
 const { record: form, reset: resetForm } = useResettableRef({
     name: "",
@@ -62,29 +63,40 @@ const { r$ } = useAppRegle(
 
 const clearContents = () => {
     cloneUrl.value = null;
+    isGroup.value = false;
     resetForm();
     r$.$reset();
 };
 
 const { $gettext } = useTranslate();
 
-const copyOptions = [
-    {
-        value: "media",
-        text: $gettext("Copy associated media and folders."),
-    },
+const copyOptions = computed(() => [
+    ...(isGroup.value
+        ? [
+              {
+                  value: "members",
+                  text: $gettext("Copy associated playlists."),
+              },
+          ]
+        : [
+              {
+                  value: "media",
+                  text: $gettext("Copy associated media and folders."),
+              },
+          ]),
     {
         value: "schedule",
         text: $gettext("Copy scheduled playback times."),
     },
-];
+]);
 
 const $modal = useTemplateRef("$modal");
 
-const open = (name: string, newCloneUrl: string) => {
+const open = (name: string, newCloneUrl: string, newIsGroup: boolean) => {
     clearContents();
 
     cloneUrl.value = newCloneUrl;
+    isGroup.value = newIsGroup;
     form.value.name = $gettext("%{name} - Copy", { name: name });
 
     $modal.value?.show();

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -3483,7 +3483,7 @@ paths:
                 clone:
                   description: 'Which parts of the original playlist to clone.'
                   type: array
-                  items: { type: string, enum: [schedule, media] }
+                  items: { type: string, enum: [schedule, media, members] }
               type: object
       responses:
         '200':


### PR DESCRIPTION
**Fixes issue:**
Fixes #8572

**Proposed changes:**
This PR adds the option to copy playlist members when copying a playlist group and also hides the media option for playlist groups in the duplicate modal since they cannot have media assinged to them directly.
