### PR TITLE
Fix issue 8578 - Add support for `Merge playlist to play as a single track` to playlist groups

### DIFF
--- a/backend/src/Controller/Api/Stations/PlaylistsController.php
+++ b/backend/src/Controller/Api/Stations/PlaylistsController.php
@@ -487,7 +487,14 @@ final class PlaylistsController extends AbstractScheduledEntityController
             $data['include_in_on_demand'] = false;
             $data['include_in_requests'] = false;
             $data['is_jingle'] = false;
-            $data['backend_options'] = [];
+
+            $backendOptions = (array) ($data['backend_options'] ?? []);
+            $data['backend_options'] = (
+                $source === PlaylistSources::Playlists
+                && in_array(StationPlaylist::OPTION_MERGE, $backendOptions, true)
+            )
+                ? [StationPlaylist::OPTION_MERGE]
+                : [];
 
             $type = PlaylistTypes::tryFrom($data['type'] ?? '');
             $data['type'] = ($type === PlaylistTypes::Advanced)

--- a/backend/src/Doctrine/Repository.php
+++ b/backend/src/Doctrine/Repository.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Doctrine;
 
 use App\Container\EntityManagerAwareTrait;
+use App\Entity\Interfaces\IdentifiableEntityInterface;
 use App\Exception\NotFoundException;
 use Closure;
 use DI\Attribute\Inject;
+use Doctrine\ORM\Query;
 use Doctrine\Persistence\ObjectRepository;
 
 /**
@@ -61,6 +63,41 @@ class Repository
             throw NotFoundException::generic();
         }
         return $record;
+    }
+
+    /**
+     * Re-hydrates managed entities in the Doctrine identity map after bulk DQL
+     *
+     * @template T of IdentifiableEntityInterface
+     *
+     * @param class-string<T> $entityClass
+     * @param callable(T): bool $matcher
+     */
+    protected function resyncManagedEntities(string $entityClass, callable $matcher): void
+    {
+        $unitOfWork = $this->em->getUnitOfWork();
+
+        $staleIds = [];
+
+        /** @var T $entity */
+        foreach ($unitOfWork->getIdentityMap()[$entityClass] ?? [] as $entity) {
+            if (!$unitOfWork->isUninitializedObject($entity) && $matcher($entity)) {
+                $staleIds[] = $entity->id;
+            }
+        }
+
+        if ($staleIds === []) {
+            return;
+        }
+
+        $this->em->createQueryBuilder()
+            ->select('e')
+            ->from($entityClass, 'e')
+            ->where('e.id IN (:ids)')
+            ->setParameter('ids', $staleIds)
+            ->getQuery()
+            ->setHint(Query::HINT_REFRESH, true)
+            ->execute();
     }
 
     /**

--- a/backend/src/Entity/Repository/StationPlaylistMediaRepository.php
+++ b/backend/src/Entity/Repository/StationPlaylistMediaRepository.php
@@ -324,6 +324,11 @@ final class StationPlaylistMediaRepository extends Repository
             );
         }
 
+        $this->resyncManagedEntities(
+            StationPlaylistMedia::class,
+            static fn(StationPlaylistMedia $spm): bool => $spm->playlist === $playlist
+        );
+
         $now ??= Time::nowUtc();
 
         $playlist->queue_reset_at = $now;

--- a/backend/src/Entity/Repository/StationPlaylistRepository.php
+++ b/backend/src/Entity/Repository/StationPlaylistRepository.php
@@ -193,6 +193,11 @@ final class StationPlaylistRepository extends AbstractStationBasedRepository
             );
         }
 
+        $this->resyncManagedEntities(
+            StationPlaylistGroup::class,
+            static fn(StationPlaylistGroup $spg): bool => $spg->playlist_group === $playlist
+        );
+
         $now ??= Time::nowUtc();
 
         $playlist->queue_reset_at = $now;

--- a/backend/src/Entity/Repository/StationRequestRepository.php
+++ b/backend/src/Entity/Repository/StationRequestRepository.php
@@ -77,10 +77,18 @@ final class StationRequestRepository extends AbstractStationBasedRepository
         return ($pendingRequest > 0);
     }
 
-    public function getNextPlayableRequest(
+    /**
+     * All currently playable requests in playout order.
+     *
+     * @param mixed[] $additionalSongHistory Additional history rows that requests must not duplicate
+     *
+     * @return list<StationRequest>
+     */
+    public function getPlayableRequests(
         Station $station,
-        ?DateTimeImmutable $now = null
-    ): ?StationRequest {
+        ?DateTimeImmutable $now = null,
+        array $additionalSongHistory = []
+    ): array {
         $tz = $station->getTimezoneObject();
         $now = Time::nowInTimezone($tz, $now);
 
@@ -96,11 +104,25 @@ final class StationRequestRepository extends AbstractStationBasedRepository
         )->setParameter('station', $station)
             ->execute();
 
-        return array_find(
+        $recentlyPlayed = $this->getRecentlyPlayedTracks($station);
+
+        return array_values(array_filter(
             $requests,
-            fn(StationRequest $request) => $request->shouldPlayNow($now)
-                && !$this->hasPlayedRecently($request->track, $station)
-        );
+            fn(StationRequest $request): bool => $request->shouldPlayNow($now)
+                && !$this->isDuplicateOfPlayedTrack($request->track, $recentlyPlayed)
+                && !$this->isDuplicateOfPlayedTrack($request->track, $additionalSongHistory)
+        ));
+    }
+
+    /**
+     * @param mixed[] $additionalSongHistory Additional history rows that requests must not duplicate
+     */
+    public function getNextPlayableRequest(
+        Station $station,
+        ?DateTimeImmutable $now = null,
+        array $additionalSongHistory = []
+    ): ?StationRequest {
+        return $this->getPlayableRequests($station, $now, $additionalSongHistory)[0] ?? null;
     }
 
     /**
@@ -108,15 +130,25 @@ final class StationRequestRepository extends AbstractStationBasedRepository
      */
     public function hasPlayedRecently(StationMedia $media, Station $station): bool
     {
+        return $this->isDuplicateOfPlayedTrack($media, $this->getRecentlyPlayedTracks($station));
+    }
+
+    /**
+     * Song history rows within the station's request threshold.
+     *
+     * @return mixed[]
+     */
+    private function getRecentlyPlayedTracks(Station $station): array
+    {
         $lastPlayThresholdMins = $station->request_threshold ?? 15;
 
-        if (0 === $lastPlayThresholdMins) {
-            return false;
+        if ($lastPlayThresholdMins === 0) {
+            return [];
         }
 
         $lastPlayThreshold = Time::nowUtc()->subMinutes($lastPlayThresholdMins);
 
-        $recentTracks = $this->em->createQuery(
+        return $this->em->createQuery(
             <<<'DQL'
                 SELECT sh FROM App\Entity\SongHistory sh
                 WHERE sh.station = :station
@@ -126,6 +158,16 @@ final class StationRequestRepository extends AbstractStationBasedRepository
         )->setParameter('station', $station)
             ->setParameter('threshold', $lastPlayThreshold)
             ->getArrayResult();
+    }
+
+    /**
+     * @param mixed[] $playedTracks
+     */
+    private function isDuplicateOfPlayedTrack(StationMedia $media, array $playedTracks): bool
+    {
+        if ($playedTracks === []) {
+            return false;
+        }
 
         $eligibleTrack = new StationPlaylistQueue();
         $eligibleTrack->media_id = $media->id;
@@ -133,6 +175,6 @@ final class StationRequestRepository extends AbstractStationBasedRepository
         $eligibleTrack->title = $media->title ?? '';
         $eligibleTrack->artist = $media->artist ?? '';
 
-        return (null === $this->duplicatePrevention->getDistinctTrack([$eligibleTrack], $recentTracks));
+        return $this->duplicatePrevention->getDistinctTrack([$eligibleTrack], $playedTracks) === null;
     }
 }

--- a/backend/src/Entity/StationPlaylistGroup.php
+++ b/backend/src/Entity/StationPlaylistGroup.php
@@ -76,13 +76,7 @@ final class StationPlaylistGroup implements JsonSerializable, IdentifiableEntity
     ]
     public bool $play_full_cycle = false {
         set (bool $value) {
-            $this->play_full_cycle = $value
-                && PlaylistSources::Songs === $this->playlist->source
-                && in_array(
-                    $this->playlist->order,
-                    [PlaylistOrders::Sequential, PlaylistOrders::Shuffle],
-                    true
-                );
+            $this->play_full_cycle = $value && $this->supportsPlayFullCycle();
 
             if ($this->play_full_cycle) {
                 $this->consecutive_plays = 0;
@@ -130,6 +124,19 @@ final class StationPlaylistGroup implements JsonSerializable, IdentifiableEntity
         $this->is_queued = false;
         $this->consecutive_plays_count = 0;
         return true;
+    }
+
+    public function supportsPlayFullCycle(): bool
+    {
+        return $this->playlist->source === PlaylistSources::Requests
+            || (
+                $this->playlist->source === PlaylistSources::Songs
+                && in_array(
+                    $this->playlist->order,
+                    [PlaylistOrders::Sequential, PlaylistOrders::Shuffle],
+                    true
+                )
+            );
     }
 
     /**

--- a/backend/src/Radio/AutoDJ/QueueBuilder.php
+++ b/backend/src/Radio/AutoDJ/QueueBuilder.php
@@ -237,7 +237,7 @@ final class QueueBuilder implements EventSubscriberInterface
     }
 
     /**
-     * Given a specified playlist group, choose a song from the assigned playlists to play
+     * Given a specified playlist group, choose song(s) from the assigned playlists to play
      *
      * @param StationPlaylist $playlistGroup A playlist that is holding other playlists inside
      * @param mixed[] $recentSongHistory
@@ -245,7 +245,7 @@ final class QueueBuilder implements EventSubscriberInterface
      * @param bool $ancestorAvoidsDuplicates Indicates if an ancestor group dictates its members to avoid duplicates
      * @param list<StationPlaylist> $playlistChain Group chain up to and including this group
      *
-     * @return bool Returns true if a track has been selected and registered
+     * @return list<StationQueue> Selected queue entries, empty if no member returned a playable track
      */
     private function playSongFromPlaylistGroup(
         BuildQueue $event,
@@ -254,74 +254,38 @@ final class QueueBuilder implements EventSubscriberInterface
         bool $allowDuplicates = false,
         bool $ancestorAvoidsDuplicates = false,
         array $playlistChain = []
-    ): bool {
-        $expectedPlayTime = $event->getExpectedPlayTime();
-
+    ): array {
         $memberAvoidsDuplicates = $ancestorAvoidsDuplicates || $playlistGroup->avoid_duplicates;
 
-        foreach ($this->getPlaylistGroupQueueForOrder($playlistGroup) as $selectedStationPlaylistGroup) {
-            $selectedPlaylist = $selectedStationPlaylistGroup->playlist;
-
-            if (!$this->scheduler->shouldPlaylistPlayNow($selectedPlaylist, $expectedPlayTime)) {
-                $selectedStationPlaylistGroup->played(
-                    $expectedPlayTime->getTimestamp(),
-                    forceAdvance: true
-                );
-
-                $this->em->persist($selectedStationPlaylistGroup);
-
-                continue;
-            }
-
-            $isFullCycleMember = $selectedStationPlaylistGroup->play_full_cycle
-                && PlaylistSources::Songs === $selectedPlaylist->source
-                && in_array(
-                    $selectedPlaylist->order,
-                    [PlaylistOrders::Sequential, PlaylistOrders::Shuffle],
-                    true
-                );
-
-            $queuedBeforePlay = $isFullCycleMember
-                ? count($this->spmRepo->getQueue($selectedPlaylist))
-                : 0;
-
-            $hasRegisteredTrack = $this->playSongFromPlaylist(
+        if ($playlistGroup->backendMerge()) {
+            $blockEntries = $this->playBlockFromPlaylistGroup(
                 $event,
-                $selectedPlaylist,
+                $playlistGroup,
                 $recentSongHistory,
                 $allowDuplicates,
                 $memberAvoidsDuplicates,
                 $playlistChain
             );
 
-            if ($hasRegisteredTrack) {
-                $playlistGroup->played_at = $expectedPlayTime;
-                $this->em->persist($playlistGroup);
-
-                $keepQueued = false;
-                if ($isFullCycleMember) {
-                    if ($queuedBeforePlay === 0) {
-                        $queuedBeforePlay = $selectedPlaylist->media_items->count();
-                    }
-
-                    $keepQueued = $queuedBeforePlay > 1;
-                }
-
-                $selectedStationPlaylistGroup->played(
-                    $expectedPlayTime->getTimestamp(),
-                    keepQueued: $keepQueued
-                );
-                $this->em->persist($selectedStationPlaylistGroup);
-
-                return true;
+            if ($blockEntries !== []) {
+                return $blockEntries;
             }
+        } else {
+            foreach ($this->getPlaylistGroupQueueForOrder($playlistGroup) as $selectedStationPlaylistGroup) {
+                $memberEntries = $this->playGroupMember(
+                    $event,
+                    $playlistGroup,
+                    $selectedStationPlaylistGroup,
+                    $recentSongHistory,
+                    $allowDuplicates,
+                    $memberAvoidsDuplicates,
+                    $playlistChain
+                );
 
-            $selectedStationPlaylistGroup->played(
-                $expectedPlayTime->getTimestamp(),
-                forceAdvance: true
-            );
-
-            $this->em->persist($selectedStationPlaylistGroup);
+                if ($memberEntries !== []) {
+                    return $memberEntries;
+                }
+            }
         }
 
         $this->logger->warning(
@@ -333,7 +297,235 @@ final class QueueBuilder implements EventSubscriberInterface
             ]
         );
 
-        return false;
+        return [];
+    }
+
+    /**
+     * Try to play the given group member and update its rotation state.
+     *
+     * @param mixed[] $recentSongHistory
+     * @param list<StationPlaylist> $playlistChain Group chain up to and including this group
+     *
+     * @return list<StationQueue> Empty if the member was skipped or did not return a track
+     */
+    private function playGroupMember(
+        BuildQueue $event,
+        StationPlaylist $playlistGroup,
+        StationPlaylistGroup $selectedStationPlaylistGroup,
+        array $recentSongHistory,
+        bool $allowDuplicates,
+        bool $memberAvoidsDuplicates,
+        array $playlistChain
+    ): array {
+        $expectedPlayTime = $event->getExpectedPlayTime();
+        $selectedPlaylist = $selectedStationPlaylistGroup->playlist;
+
+        if (!$this->scheduler->shouldPlaylistPlayNow($selectedPlaylist, $expectedPlayTime)) {
+            $selectedStationPlaylistGroup->played(
+                $expectedPlayTime->getTimestamp(),
+                forceAdvance: true
+            );
+
+            $this->em->persist($selectedStationPlaylistGroup);
+
+            return [];
+        }
+
+        $isFullCycleMember = $selectedStationPlaylistGroup->play_full_cycle
+            && $selectedStationPlaylistGroup->supportsPlayFullCycle();
+
+        $isRequestsMember = $selectedPlaylist->source === PlaylistSources::Requests;
+
+        $queuedBeforePlay = 0;
+        if ($isFullCycleMember) {
+            $queuedBeforePlay = $isRequestsMember
+                ? count($this->requestRepo->getPlayableRequests(
+                    $selectedPlaylist->station,
+                    $expectedPlayTime,
+                    $recentSongHistory
+                ))
+                : count($this->spmRepo->getQueue($selectedPlaylist));
+        }
+
+        $selectedTracks = $this->selectTracksFromPlaylist(
+            $event,
+            $selectedPlaylist,
+            $recentSongHistory,
+            $allowDuplicates,
+            $memberAvoidsDuplicates,
+            $playlistChain
+        );
+
+        if ($selectedTracks instanceof StationQueue) {
+            // Apply safety last-played check that setNextSongs uses
+            $selectedTracks = ($event->getLastPlayedSongId() === $selectedTracks->song_id)
+                ? null
+                : [$selectedTracks];
+        }
+
+        if (!empty($selectedTracks)) {
+            $playlistGroup->played_at = $expectedPlayTime;
+            $this->em->persist($playlistGroup);
+
+            $keepQueued = false;
+            if ($isFullCycleMember) {
+                if (!$isRequestsMember && $queuedBeforePlay === 0) {
+                    $queuedBeforePlay = $selectedPlaylist->media_items->count();
+                }
+
+                $keepQueued = $queuedBeforePlay > 1;
+            }
+
+            $selectedStationPlaylistGroup->played(
+                $expectedPlayTime->getTimestamp(),
+                keepQueued: $keepQueued
+            );
+            $this->em->persist($selectedStationPlaylistGroup);
+
+            return $selectedTracks;
+        }
+
+        $this->logger->warning(
+            sprintf('Playlist "%s" did not return a playable track.', $selectedPlaylist->name),
+            [
+                'playlist_id' => $selectedPlaylist->id,
+                'playlist_order' => $selectedPlaylist->order->value,
+                'allow_duplicates' => $allowDuplicates,
+            ]
+        );
+
+        $selectedStationPlaylistGroup->played(
+            $expectedPlayTime->getTimestamp(),
+            forceAdvance: true
+        );
+
+        $this->em->persist($selectedStationPlaylistGroup);
+
+        return [];
+    }
+
+    /**
+     * Plays one full rotation pass of a "merge" playlist group as a single block.
+     *
+     * Sequential & shuffle pick with regular per-slot logic until internal queue is empty.
+     * Internal queue intentionally not refilled mid-block, since it would restart pass.
+     * Random groups have no rotation state, single random pass with one pick per member used instead.
+     *
+     * @param mixed[] $recentSongHistory
+     * @param list<StationPlaylist> $playlistChain Group chain up to and including this group
+     *
+     * @return list<StationQueue>
+     */
+    private function playBlockFromPlaylistGroup(
+        BuildQueue $event,
+        StationPlaylist $playlistGroup,
+        array $recentSongHistory,
+        bool $allowDuplicates,
+        bool $memberAvoidsDuplicates,
+        array $playlistChain
+    ): array {
+        $blockEntries = [];
+        $blockHistory = $recentSongHistory;
+
+        $remainingIterations = $this->getBlockIterationCap(
+            $playlistGroup,
+            $event->getExpectedPlayTime()
+        );
+
+        $slotQueue = $this->getPlaylistGroupQueueForOrder($playlistGroup);
+
+        while ($slotQueue !== []) {
+            $selectedStationPlaylistGroup = $slotQueue[0];
+
+            $memberEntries = $this->playGroupMember(
+                $event,
+                $playlistGroup,
+                $selectedStationPlaylistGroup,
+                $blockHistory,
+                $allowDuplicates,
+                $memberAvoidsDuplicates,
+                $playlistChain
+            );
+
+            if ($memberEntries !== []) {
+                $blockEntries = [
+                    ...$blockEntries,
+                    ...$memberEntries,
+                ];
+
+                foreach ($memberEntries as $memberEntry) {
+                    $blockHistory[] = [
+                        'song_id' => $memberEntry->song_id,
+                        'text' => $memberEntry->text,
+                        'artist' => $memberEntry->artist,
+                        'title' => $memberEntry->title,
+                        'timestamp_played' => $event->getExpectedPlayTime()->getTimestamp(),
+                    ];
+                }
+            }
+
+            if (--$remainingIterations <= 0) {
+                $this->logger->warning(
+                    sprintf(
+                        'Merged Playlist Group "%s" block reached its iteration cap; stopping the pass early.',
+                        $playlistGroup->name
+                    ),
+                    [
+                        'playlist_group_id' => $playlistGroup->id,
+                        'block_entries' => count($blockEntries),
+                    ]
+                );
+
+                break;
+            }
+
+            $this->em->flush();
+
+            ($playlistGroup->order === PlaylistOrders::Random)
+                ? array_shift($slotQueue)
+                : $slotQueue = $this->spRepo->getPlaylistGroupQueue($playlistGroup);
+        }
+
+        return $blockEntries;
+    }
+
+    /**
+     * Get max iterations a merged group block may use.
+     *
+     * Per slot expected pick count plus one potential skip,
+     * each iteration "consumes" one pick even if nothing actually picked.
+     *
+     * Prevents the block loop ending up with rotation state that never advances.
+     */
+    private function getBlockIterationCap(
+        StationPlaylist $playlistGroup,
+        DateTimeImmutable $expectedPlayTime
+    ): int {
+        $iterationCap = 0;
+        $playableRequestCount = null;
+
+        foreach ($playlistGroup->playlists as $member) {
+            $iterationCap++;
+
+            if (!$member->play_full_cycle) {
+                $iterationCap += max(1, $member->consecutive_plays);
+                continue;
+            }
+
+            if ($member->playlist->source === PlaylistSources::Requests) {
+                $playableRequestCount ??= count($this->requestRepo->getPlayableRequests(
+                    $playlistGroup->station,
+                    $expectedPlayTime
+                ));
+
+                $iterationCap += max(1, $playableRequestCount);
+                continue;
+            }
+
+            $iterationCap += max(1, $member->playlist->media_items->count());
+        }
+
+        return $iterationCap;
     }
 
     /**
@@ -428,7 +620,7 @@ final class QueueBuilder implements EventSubscriberInterface
     }
 
     /**
-     * Given a specified playlist, choose a song from the playlist to play
+     * Given a specified playlist, choose a song from the playlist to play and register it
      *
      * @param mixed[] $recentSongHistory
      * @param bool $allowDuplicates Whether to return a media ID even if duplicates can't be prevented.
@@ -445,6 +637,54 @@ final class QueueBuilder implements EventSubscriberInterface
         bool $ancestorAvoidsDuplicates = false,
         array $ancestorChain = []
     ): bool {
+        $selectedTracksResult = $this->selectTracksFromPlaylist(
+            $event,
+            $playlist,
+            $recentSongHistory,
+            $allowDuplicates,
+            $ancestorAvoidsDuplicates,
+            $ancestorChain
+        );
+
+        if (PlaylistSources::Requests === $playlist->source && null !== $selectedTracksResult) {
+            $event->setNextSongs($selectedTracksResult);
+            return true;
+        }
+
+        if ($event->setNextSongs($selectedTracksResult)) {
+            return true;
+        }
+
+        $this->logger->warning(
+            sprintf('Playlist "%s" did not return a playable track.', $playlist->name),
+            [
+                'playlist_id' => $playlist->id,
+                'playlist_order' => $playlist->order->value,
+                'allow_duplicates' => $allowDuplicates,
+            ]
+        );
+
+        return false;
+    }
+
+    /**
+     * Determine the track(s) the given playlist wants to register
+     *
+     * @param mixed[] $recentSongHistory
+     * @param bool $allowDuplicates Whether to return a media ID even if duplicates can't be prevented.
+     * @param bool $ancestorAvoidsDuplicates Indicates if an ancestor group dictates its members to avoid duplicates
+     * @param list<StationPlaylist> $ancestorChain Group chain this playlist was reached through
+     *
+     * @return StationQueue|list<StationQueue>|null
+     */
+    private function selectTracksFromPlaylist(
+        BuildQueue $event,
+        StationPlaylist $playlist,
+        array $recentSongHistory,
+        bool $allowDuplicates = false,
+        bool $ancestorAvoidsDuplicates = false,
+        array $ancestorChain = []
+    ): StationQueue|array|null {
         $playlistChain = [...$ancestorChain, $playlist];
         $playlistChainSnapshot = $this->snapshotPlaylistChain($playlistChain);
 
@@ -476,25 +716,12 @@ final class QueueBuilder implements EventSubscriberInterface
             PlaylistSources::Requests => $this->playSongFromRequestsPlaylist(
                 $event,
                 $playlist,
+                $recentSongHistory,
                 $playlistChainSnapshot
             ),
         };
 
-        $selectedTracksResult = $selectedTracksResult ?: null;
-        if (true === $selectedTracksResult || $event->setNextSongs($selectedTracksResult)) {
-            return true;
-        }
-
-        $this->logger->warning(
-            sprintf('Playlist "%s" did not return a playable track.', $playlist->name),
-            [
-                'playlist_id' => $playlist->id,
-                'playlist_order' => $playlist->order->value,
-                'allow_duplicates' => $allowDuplicates,
-            ]
-        );
-
-        return false;
+        return $selectedTracksResult ?: null;
     }
 
     /**
@@ -521,6 +748,8 @@ final class QueueBuilder implements EventSubscriberInterface
      * @param bool $allowDuplicates Whether to return a media ID even if duplicates can't be prevented.
      * @param bool $ancestorAvoidsDuplicates Indicates if an ancestor group dictates its members to avoid duplicates
      * @param ?list<string> $playlistChainSnapshot Name snapshot of the group chain this playlist was reached through
+     *
+     * @return StationQueue|list<StationQueue>|null
      */
     private function playSongFromSongsPlaylist(
         BuildQueue $event,
@@ -533,17 +762,19 @@ final class QueueBuilder implements EventSubscriberInterface
         if ($playlist->backendMerge()) {
             $this->spmRepo->resetQueue($playlist);
 
-            $queueEntries = array_filter(
-                array_map(
-                    function (StationPlaylistQueue $validTrack) use ($playlist, $event, $playlistChainSnapshot) {
-                        return $this->makeQueueFromApi(
-                            $validTrack,
-                            $playlist,
-                            $event->getExpectedPlayTime(),
-                            $playlistChainSnapshot
-                        );
-                    },
-                    $this->spmRepo->getQueue($playlist)
+            $queueEntries = array_values(
+                array_filter(
+                    array_map(
+                        function (StationPlaylistQueue $validTrack) use ($playlist, $event, $playlistChainSnapshot) {
+                            return $this->makeQueueFromApi(
+                                $validTrack,
+                                $playlist,
+                                $event->getExpectedPlayTime(),
+                                $playlistChainSnapshot
+                            );
+                        },
+                        $this->spmRepo->getQueue($playlist)
+                    )
                 )
             );
 
@@ -594,24 +825,27 @@ final class QueueBuilder implements EventSubscriberInterface
     }
 
     /**
+     * @param mixed[] $recentSongHistory
      * @param ?list<string> $playlistChainSnapshot Name snapshot of the group chain this playlist was reached through
      */
     private function playSongFromRequestsPlaylist(
         BuildQueue $event,
         StationPlaylist $playlist,
+        array $recentSongHistory,
         ?array $playlistChainSnapshot = null
-    ): bool {
+    ): ?StationQueue {
         if ($this->areRequestsBlockedByAncestors($playlist, $event->getExpectedPlayTime())) {
-            return false;
+            return null;
         }
 
         $request = $this->requestRepo->getNextPlayableRequest(
             $playlist->station,
-            $event->getExpectedPlayTime()
+            $event->getExpectedPlayTime(),
+            $recentSongHistory
         );
 
         if (null === $request) {
-            return false;
+            return null;
         }
 
         $this->logger->debug(sprintf(
@@ -631,8 +865,7 @@ final class QueueBuilder implements EventSubscriberInterface
         $playlist->played_at = $event->getExpectedPlayTime();
         $this->em->persist($playlist);
 
-        $event->setNextSongs($stationQueueEntry);
-        return true;
+        return $stationQueueEntry;
     }
 
     /**

--- a/backend/src/Tests/AutoDJ/InMemoryAutoDjDataProxy.php
+++ b/backend/src/Tests/AutoDJ/InMemoryAutoDjDataProxy.php
@@ -409,8 +409,16 @@ final class InMemoryAutoDjDataProxy
 
     // StationRequestRepository
 
-    public function getNextPlayableRequest(Station $station, ?DateTimeImmutable $now = null): ?StationRequest
-    {
+    /**
+     * @param mixed[] $additionalSongHistory
+     *
+     * @return list<StationRequest>
+     */
+    public function getPlayableRequests(
+        Station $station,
+        ?DateTimeImmutable $now = null,
+        array $additionalSongHistory = []
+    ): array {
         $now ??= Time::nowUtc();
 
         $unplayed = array_filter(
@@ -424,13 +432,23 @@ final class InMemoryAutoDjDataProxy
                 => [$b->skip_delay, $a->id] <=> [$a->skip_delay, $b->id]
         );
 
-        return array_find(
+        return array_values(array_filter(
             $unplayed,
-            fn(StationRequest $request): bool => (
-                $request->shouldPlayNow($now)
+            fn(StationRequest $request): bool => $request->shouldPlayNow($now)
                 && !$this->hasRequestTrackPlayedRecently($request->track, $now)
-            )
-        );
+                && !$this->isDuplicateOfPlayedTrack($request->track, $additionalSongHistory)
+        ));
+    }
+
+    /**
+     * @param mixed[] $additionalSongHistory
+     */
+    public function getNextPlayableRequest(
+        Station $station,
+        ?DateTimeImmutable $now = null,
+        array $additionalSongHistory = []
+    ): ?StationRequest {
+        return $this->getPlayableRequests($station, $now, $additionalSongHistory)[0] ?? null;
     }
 
     // Internal helpers
@@ -517,12 +535,24 @@ final class InMemoryAutoDjDataProxy
             ];
         }
 
+        return $this->isDuplicateOfPlayedTrack($media, $recentTracks);
+    }
+
+    /**
+     * @param mixed[] $playedTracks
+     */
+    private function isDuplicateOfPlayedTrack(StationMedia $media, array $playedTracks): bool
+    {
+        if ($playedTracks === []) {
+            return false;
+        }
+
         $eligibleTrack = new StationPlaylistQueue();
         $eligibleTrack->media_id = $media->id;
         $eligibleTrack->song_id = $media->song_id;
         $eligibleTrack->title = $media->title ?? '';
         $eligibleTrack->artist = $media->artist ?? '';
 
-        return $this->duplicatePrevention->getDistinctTrack([$eligibleTrack], $recentTracks) === null;
+        return $this->duplicatePrevention->getDistinctTrack([$eligibleTrack], $playedTracks) === null;
     }
 }

--- a/backend/src/Tests/AutoDJ/InMemoryAutoDjHarnessFactory.php
+++ b/backend/src/Tests/AutoDJ/InMemoryAutoDjHarnessFactory.php
@@ -191,11 +191,20 @@ final class InMemoryAutoDjHarnessFactory
     {
         $repo = Mockery::mock(StationRequestRepository::class);
 
+        $repo->allows('getPlayableRequests')->andReturnUsing(
+            static fn(
+                Station $station,
+                ?DateTimeImmutable $now = null,
+                array $additionalSongHistory = []
+            ): array => $dataProxy->getPlayableRequests($station, $now, $additionalSongHistory)
+        );
+
         $repo->allows('getNextPlayableRequest')->andReturnUsing(
             static fn(
                 Station $station,
-                ?DateTimeImmutable $now = null
-            ): ?StationRequest => $dataProxy->getNextPlayableRequest($station, $now)
+                ?DateTimeImmutable $now = null,
+                array $additionalSongHistory = []
+            ): ?StationRequest => $dataProxy->getNextPlayableRequest($station, $now, $additionalSongHistory)
         );
 
         return $repo;

--- a/backend/src/Tests/AutoDJ/Scenario/ExpectQueue.php
+++ b/backend/src/Tests/AutoDJ/Scenario/ExpectQueue.php
@@ -15,6 +15,7 @@ final class ExpectQueue
     /**
      * @param string[] $mediaAnyOf Keyed by media ref
      * @param ?string[] $playlistChainRefs Playlist refs from root to direct
+     * @param ?list<ExpectQueue> $entries Per-entry expectations for a multi-entry build; also asserts the entry count
      */
     public function __construct(
         public readonly ExpectQueueMode $mode,
@@ -25,6 +26,7 @@ final class ExpectQueue
         public readonly bool $distinct,
         public readonly ?bool $fromRequest,
         public readonly ?array $playlistChainRefs = null,
+        public readonly ?array $entries = null,
     ) {
     }
 
@@ -52,6 +54,12 @@ final class ExpectQueue
                 ? array_map(
                     static fn(mixed $ref): string => Types::string($ref),
                     Types::array($data['playlist_chain_refs'])
+                )
+                : null,
+            entries: array_key_exists('entries', $data)
+                ? array_map(
+                    static fn(mixed $entry): self => self::fromArray(Types::array($entry)),
+                    array_values(Types::array($data['entries']))
                 )
                 : null,
         );

--- a/frontend/components/Stations/Playlists/EditModal.vue
+++ b/frontend/components/Stations/Playlists/EditModal.vue
@@ -33,7 +33,7 @@
                 :items="playlistGroups"
                 @navigate="onNavigateToPlaylist"
             />
-            <form-advanced v-if="![PlaylistSources.Playlists, PlaylistSources.Requests].includes(form.source)" />
+            <form-advanced v-if="form.source !== PlaylistSources.Requests" />
         </tabs>
     </modal-form>
 </template>

--- a/frontend/components/Stations/Playlists/Form/Advanced.vue
+++ b/frontend/components/Stations/Playlists/Form/Advanced.vue
@@ -23,27 +23,41 @@ import { computed } from "vue";
 import Tab from "~/components/Common/Tab.vue";
 import FormGroupMultiCheck from "~/components/Form/FormGroupMultiCheck.vue";
 import { useStationsPlaylistsForm } from "~/components/Stations/Playlists/Form/form.ts";
+import { PlaylistSources } from "~/entities/ApiInterfaces";
 import { useFormTabClass } from "~/functions/useFormTabClass.ts";
 import { useTranslate } from "~/vendor/gettext";
 
-const { r$ } = storeToRefs(useStationsPlaylistsForm());
+const { form, r$ } = storeToRefs(useStationsPlaylistsForm());
 
 const tabClass = useFormTabClass(computed(() => r$.value.$groups.advancedTab));
 
 const { $gettext } = useTranslate();
 
-const backendOptions = [
-    {
-        value: "interrupt",
-        text: $gettext("Interrupt other songs to play at scheduled time."),
-    },
-    {
-        value: "single_track",
-        text: $gettext("Only play one track at scheduled time."),
-    },
-    {
-        value: "merge",
-        text: $gettext("Merge playlist to play as a single track."),
-    },
-];
+const backendOptions = computed(() =>
+    form.value.source === PlaylistSources.Playlists
+        ? [
+              {
+                  value: "merge",
+                  text: $gettext(
+                      "Play the group's entire rotation as a single block.",
+                  ),
+              },
+          ]
+        : [
+              {
+                  value: "interrupt",
+                  text: $gettext(
+                      "Interrupt other songs to play at scheduled time.",
+                  ),
+              },
+              {
+                  value: "single_track",
+                  text: $gettext("Only play one track at scheduled time."),
+              },
+              {
+                  value: "merge",
+                  text: $gettext("Merge playlist to play as a single track."),
+              },
+          ],
+);
 </script>

--- a/frontend/components/Stations/Playlists/PlaylistGroupingTab.vue
+++ b/frontend/components/Stations/Playlists/PlaylistGroupingTab.vue
@@ -380,7 +380,9 @@
                                             :model-value="member.play_full_cycle"
                                             @update:model-value="doUpdatePlayFullCycle(index, $event)"
                                             :input-attrs="{disabled: saving}"
-                                            :label="$gettext('Play fully before advancing')"
+                                            :label="member.source === PlaylistSources.Requests
+                                                ? $gettext('Play all available requests before advancing')
+                                                : $gettext('Play fully before advancing')"
                                         />
                                     </div>
 
@@ -888,11 +890,14 @@ const doUpdateConsecutivePlays = (
 const isFullCyclePlayable = (
     member: StationPlaylistGroupMemberEnriched,
 ): boolean => {
+    const source = member.source as PlaylistSources;
+
     return (
-        (member.source as PlaylistSources) === PlaylistSources.Songs &&
-        [PlaylistOrders.Sequential, PlaylistOrders.Shuffle].includes(
-            member.order as PlaylistOrders,
-        )
+        source === PlaylistSources.Requests ||
+        (source === PlaylistSources.Songs &&
+            [PlaylistOrders.Sequential, PlaylistOrders.Shuffle].includes(
+                member.order as PlaylistOrders,
+            ))
     );
 };
 

--- a/tests/Functional/AutoDjIntegrationCest.php
+++ b/tests/Functional/AutoDjIntegrationCest.php
@@ -221,7 +221,64 @@ final class AutoDjIntegrationCest extends CestAbstract
         }
 
         $I->assertNotEmpty($result, "[{$label}] Expected a track to be queued.");
-        $first = $result[0];
+
+        if ($expect->entries !== null) {
+            $I->assertCount(
+                count($expect->entries),
+                $result,
+                "[{$label}] Number of queued entries"
+            );
+
+            foreach ($expect->entries as $entryIndex => $entryExpect) {
+                $this->assertQueueEntry(
+                    I: $I,
+                    expect: $entryExpect,
+                    entry: $result[$entryIndex],
+                    playlistsByRef: $playlistsByRef,
+                    mediaByRef: $mediaByRef,
+                    label: "{$label} entry {$entryIndex}"
+                );
+            }
+
+            if ($expect->distinct) {
+                $mediaPaths = array_map(
+                    static fn(StationQueue $entry): ?string => $entry->media?->path,
+                    $result
+                );
+
+                $I->assertSame(
+                    array_values(array_unique($mediaPaths)),
+                    $mediaPaths,
+                    "[{$label}] media repeated within the block"
+                );
+            }
+
+            return;
+        }
+
+        $this->assertQueueEntry(
+            I: $I,
+            expect: $expect,
+            entry: $result[0],
+            playlistsByRef: $playlistsByRef,
+            mediaByRef: $mediaByRef,
+            label: $label
+        );
+    }
+
+    /**
+     * @param array<string, StationPlaylist> $playlistsByRef
+     * @param array<string, StationMedia> $mediaByRef
+     */
+    private function assertQueueEntry(
+        FunctionalTester $I,
+        ExpectQueue $expect,
+        StationQueue $entry,
+        array $playlistsByRef,
+        array $mediaByRef,
+        string $label
+    ): void {
+        $first = $entry;
 
         if ($expect->fromRequest === true) {
             $I->assertNotNull(
@@ -292,7 +349,12 @@ final class AutoDjIntegrationCest extends CestAbstract
         array $seenMediaPaths,
         string $label
     ): array {
-        if (!$expect->distinct || $selectedPath === null) {
+        // Multi-entry steps assert distinctness within their own block
+        if (
+            !$expect->distinct
+            || $selectedPath === null
+            || $expect->entries !== null
+        ) {
             return $seenMediaPaths;
         }
 

--- a/tests/Unit/AutoDJ/QueueBuilderCasesTest.php
+++ b/tests/Unit/AutoDJ/QueueBuilderCasesTest.php
@@ -109,7 +109,56 @@ final class QueueBuilderCasesTest extends Unit
 
         self::assertNotEmpty($nextSongs, "[{$label}] Expected a track to be queued.{$logTrace}");
 
-        $first = $nextSongs[0];
+        if ($expect->entries !== null) {
+            self::assertCount(
+                count($expect->entries),
+                $nextSongs,
+                "[{$label}] Number of queued entries{$logTrace}"
+            );
+
+            foreach ($expect->entries as $entryIndex => $entryExpect) {
+                $this->assertQueueEntry(
+                    autoDjHarness: $autoDjHarness,
+                    expect: $entryExpect,
+                    entry: $nextSongs[$entryIndex],
+                    label: "{$label} entry {$entryIndex}",
+                    logTrace: $logTrace
+                );
+            }
+
+            if ($expect->distinct) {
+                $mediaPaths = array_map(
+                    static fn(StationQueue $entry): ?string => $entry->media?->path,
+                    $nextSongs
+                );
+
+                self::assertSame(
+                    array_values(array_unique($mediaPaths)),
+                    $mediaPaths,
+                    "[{$label}] media repeated within the block{$logTrace}"
+                );
+            }
+
+            return;
+        }
+
+        $this->assertQueueEntry(
+            autoDjHarness: $autoDjHarness,
+            expect: $expect,
+            entry: $nextSongs[0],
+            label: $label,
+            logTrace: $logTrace
+        );
+    }
+
+    private function assertQueueEntry(
+        InMemoryAutoDjHarness $autoDjHarness,
+        ExpectQueue $expect,
+        StationQueue $entry,
+        string $label,
+        string $logTrace
+    ): void {
+        $first = $entry;
 
         if ($expect->fromRequest === true) {
             self::assertNotNull(
@@ -179,7 +228,12 @@ final class QueueBuilderCasesTest extends Unit
         array $seenMediaPaths,
         string $label
     ): array {
-        if (!$expect->distinct || $selectedPath === null) {
+        // Multi-entry steps assert distinctness within their own block
+        if (
+            !$expect->distinct
+            || $selectedPath === null
+            || $expect->entries !== null
+        ) {
             return $seenMediaPaths;
         }
 

--- a/tests/_data/autodj/README.md
+++ b/tests/_data/autodj/README.md
@@ -111,6 +111,12 @@ For a quick reference example of the scenario format see the following .json str
           "playlist_chain_refs": [
             "<rootRef>",
             "<directRef>"
+          ],
+          "entries": [
+            {
+              "playlist_ref": "<playlistRef>",
+              "media_ref": "<mediaRef>"
+            }
           ]
         }
       ]
@@ -147,6 +153,12 @@ For a quick reference example of the scenario format see the following .json str
     - `distinct` (media must not repeat within a shuffle cycle)
     - `from_request` (assert the pick did / did not come from a request)
     - `playlist_chain_refs` (assert the entry's playlist chain, root to direct)
+    - `entries` (assert all entries of a multi-entry build, e.g. a merged block)
+      - a list of per-entry objects supporting `mode`, `playlist_ref`, `media_ref`, `media_any_of`, `from_request` and `playlist_chain_refs`
+      - also asserts the build's entry count
+      - `distinct: true` changes its meaning on a step with `entries`:
+        - it asserts that no media repeats among the entries of this single build
+        - the usual cross-step meaning (no repeats within a shuffle cycle) does not apply to such a step
 - `queue_history`
   - entries take `media_ref` (or a raw `song_id` / `artist` / `title` for a track not in
   the dump)
@@ -216,6 +228,10 @@ Unless noted, every item below behaves identically in-memory and in integration.
     - The `station.requests_only_via_playlists` routes between the two:
       - When `true` the global queue is disabled and only a due `Requests`-source playlist serves requests
       - When `false` a due `Requests`-source playlist still preempts the global queue, with the global queue as the fallback outside that playlist's schedule
+  - A `Requests`-source member inside a merged group serves multiple requests per block:
+    - A `consecutive_plays: N` member serves up to N requests back to back
+    - A `play_full_cycle` member drains all currently playable requests before advancing
+  - Playlist-served request picks skip any request whose track duplicates the recent history (including the in-progress block's picks); the skipped request stays pending and untouched
 - **Requestable rule**
   - A track is only requestable if it sits on at least one enabled playlist with `include_in_requests`
   - The integration importer only generates playlist-referenced media
@@ -225,6 +241,11 @@ Unless noted, every item below behaves identically in-memory and in integration.
 - **Playlist `backend_options`**
   - The `interrupt` restricts a playlist to interrupting builds only (set `interrupting: true` on the step)
   - The `single_track` & schedule `loop_once` drive the scheduled-window special rules
+  - The `merge` on a songs playlist cues the entire playlist in one build
+  - The `merge` on a playlist group cues one full rotation pass as a single block per build
+    - Sequential/shuffle groups keep picking until the rotation queue empties once (a `consecutive_plays` slot contributes that many tracks, a `play_full_cycle` member its whole remaining cycle; for a `Requests`-source member that cycle is the currently playable request queue)
+    - Random groups take one randomized pass with one pick per eligible member (a `play_full_cycle` `Requests`-source member therefore serves only one request per random pass)
+    - Assert blocks with the step-level `entries` list
 - **Remote stream playlists are excluded from queueing**
   - A playlist may set `config.source: "remote_url"` with `config.remote_type`
   - A `stream` (or `other`) remote is filtered out before it reaches the scheduler

--- a/tests/_data/autodj/queuing/group-merge-block.dump.json
+++ b/tests/_data/autodj/queuing/group-merge-block.dump.json
@@ -1,0 +1,257 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": false
+  },
+  "media": [
+    {
+      "ref": "mJ",
+      "path": "gmb/jingle.mp3",
+      "unique_id": "gmergeblk000000000000001",
+      "length": 5.0,
+      "artist": "Jingle",
+      "title": "Station Jingle",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mA1",
+      "path": "gmb/a1.mp3",
+      "unique_id": "gmergeblk000000000000002",
+      "length": 120.0,
+      "artist": "Artist A1",
+      "title": "Song A1",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mA2",
+      "path": "gmb/a2.mp3",
+      "unique_id": "gmergeblk000000000000003",
+      "length": 120.0,
+      "artist": "Artist A2",
+      "title": "Song A2",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mA3",
+      "path": "gmb/a3.mp3",
+      "unique_id": "gmergeblk000000000000004",
+      "length": 120.0,
+      "artist": "Artist A3",
+      "title": "Song A3",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mB1",
+      "path": "gmb/b1.mp3",
+      "unique_id": "gmergeblk000000000000005",
+      "length": 120.0,
+      "artist": "Artist B1",
+      "title": "Song B1",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mB2",
+      "path": "gmb/b2.mp3",
+      "unique_id": "gmergeblk000000000000006",
+      "length": 120.0,
+      "artist": "Artist B2",
+      "title": "Song B2",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mB3",
+      "path": "gmb/b3.mp3",
+      "unique_id": "gmergeblk000000000000007",
+      "length": 120.0,
+      "artist": "Artist B3",
+      "title": "Song B3",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "grp",
+      "name": "Merged Once Per 20 Minutes Group",
+      "config": {
+        "type": "once_per_x_minutes",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 20,
+        "play_per_hour_minute": 0,
+        "backend_options": [
+          "merge"
+        ],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "jingle",
+          "weight": 1,
+          "consecutive_plays": 1,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "songs-a",
+          "weight": 2,
+          "consecutive_plays": 2,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "jingle",
+          "weight": 3,
+          "consecutive_plays": 1,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "songs-b",
+          "weight": 4,
+          "consecutive_plays": 0,
+          "play_full_cycle": true,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "jingle",
+      "name": "Jingle",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mJ",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "songs-a",
+      "name": "Songs A",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mA1",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mA2",
+          "weight": 2,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mA3",
+          "weight": 3,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "songs-b",
+      "name": "Songs B",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mB1",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mB2",
+          "weight": 2,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mB3",
+          "weight": 3,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-merge-block.scenario.json
+++ b/tests/_data/autodj/queuing/group-merge-block.scenario.json
@@ -1,0 +1,97 @@
+{
+  "description": "A sequential Once-Per-20-Minutes group with the 'merge' backend option cues one full rotation pass as a single block per firing: a consecutive_plays=2 slot contributes two tracks back to back, a play_full_cycle slot contributes its whole remaining media cycle, and the block gates the group for the following X minutes. The next firing starts a fresh pass from where each member's own queue left off.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "block-per-firing-with-consecutive-and-full-cycle-slots",
+      "now": "2026-06-01T12:00:00+00:00",
+      "expect_sequence": [
+        {
+          "now": "2026-06-01T12:00:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "jingle",
+              "media_ref": "mJ",
+              "playlist_chain_refs": [
+                "grp",
+                "jingle"
+              ]
+            },
+            {
+              "playlist_ref": "songs-a",
+              "media_ref": "mA1",
+              "playlist_chain_refs": [
+                "grp",
+                "songs-a"
+              ]
+            },
+            {
+              "playlist_ref": "songs-a",
+              "media_ref": "mA2"
+            },
+            {
+              "playlist_ref": "jingle",
+              "media_ref": "mJ"
+            },
+            {
+              "playlist_ref": "songs-b",
+              "media_ref": "mB1",
+              "playlist_chain_refs": [
+                "grp",
+                "songs-b"
+              ]
+            },
+            {
+              "playlist_ref": "songs-b",
+              "media_ref": "mB2"
+            },
+            {
+              "playlist_ref": "songs-b",
+              "media_ref": "mB3"
+            }
+          ]
+        },
+        {
+          "now": "2026-06-01T12:10:00+00:00",
+          "mode": "none"
+        },
+        {
+          "now": "2026-06-01T12:25:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "jingle",
+              "media_ref": "mJ"
+            },
+            {
+              "playlist_ref": "songs-a",
+              "media_ref": "mA3"
+            },
+            {
+              "playlist_ref": "songs-a",
+              "media_ref": "mA1"
+            },
+            {
+              "playlist_ref": "jingle",
+              "media_ref": "mJ"
+            },
+            {
+              "playlist_ref": "songs-b",
+              "media_ref": "mB1"
+            },
+            {
+              "playlist_ref": "songs-b",
+              "media_ref": "mB2"
+            },
+            {
+              "playlist_ref": "songs-b",
+              "media_ref": "mB3"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-merge-media-requeue.dump.json
+++ b/tests/_data/autodj/queuing/group-merge-media-requeue.dump.json
@@ -1,0 +1,156 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": false
+  },
+  "media": [
+    {
+      "ref": "mC1",
+      "path": "gmm/c1.mp3",
+      "unique_id": "gmergemedia0000000000001",
+      "length": 120.0,
+      "artist": "Artist C1",
+      "title": "Song C1",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mC2",
+      "path": "gmm/c2.mp3",
+      "unique_id": "gmergemedia0000000000002",
+      "length": 120.0,
+      "artist": "Artist C2",
+      "title": "Song C2",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mE",
+      "path": "gmm/e.mp3",
+      "unique_id": "gmergemedia0000000000003",
+      "length": 120.0,
+      "artist": "Artist E",
+      "title": "Song E",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "grp-m",
+      "name": "Merged Media Requeue Group",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [
+          "merge"
+        ],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "songs-c",
+          "weight": 1,
+          "consecutive_plays": 3,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "ender",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "songs-c",
+      "name": "Songs C",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mC1",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mC2",
+          "weight": 2,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "ender",
+      "name": "Ender",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mE",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-merge-media-requeue.scenario.json
+++ b/tests/_data/autodj/queuing/group-merge-media-requeue.scenario.json
@@ -1,0 +1,57 @@
+{
+  "description": "Regression test for the identity-map resync in StationPlaylistMediaRepository::resetQueue: inside a merged block, a consecutive_plays=3 slot over a two-track sequential member re-picks its first track right after a mid-build media queue reset. Without the resync, that pick's played() state silently fails to persist (the bulk reset desynced the already-managed row), so the next block would wrongly start with the first track again instead of the remaining second track. The in-memory harness is immune (its fakes mutate state directly); the integration run is the actual regression.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "post-reset-play-persists-across-blocks",
+      "now": "2026-06-01T12:00:00+00:00",
+      "expect_sequence": [
+        {
+          "now": "2026-06-01T12:00:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "songs-c",
+              "media_ref": "mC1"
+            },
+            {
+              "playlist_ref": "songs-c",
+              "media_ref": "mC2"
+            },
+            {
+              "playlist_ref": "songs-c",
+              "media_ref": "mC1"
+            },
+            {
+              "playlist_ref": "ender",
+              "media_ref": "mE"
+            }
+          ]
+        },
+        {
+          "now": "2026-06-01T12:05:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "songs-c",
+              "media_ref": "mC2"
+            },
+            {
+              "playlist_ref": "songs-c",
+              "media_ref": "mC1"
+            },
+            {
+              "playlist_ref": "songs-c",
+              "media_ref": "mC2"
+            },
+            {
+              "playlist_ref": "ender",
+              "media_ref": "mE"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-merge-nested.dump.json
+++ b/tests/_data/autodj/queuing/group-merge-nested.dump.json
@@ -1,0 +1,273 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": false
+  },
+  "media": [
+    {
+      "ref": "mX",
+      "path": "gmn/x.mp3",
+      "unique_id": "gmergenst000000000000001",
+      "length": 120.0,
+      "artist": "Artist X",
+      "title": "Song X",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mAdv",
+      "path": "gmn/adv.mp3",
+      "unique_id": "gmergenst000000000000002",
+      "length": 120.0,
+      "artist": "Artist Adv",
+      "title": "Song Adv",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mY",
+      "path": "gmn/y.mp3",
+      "unique_id": "gmergenst000000000000003",
+      "length": 120.0,
+      "artist": "Artist Y",
+      "title": "Song Y",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mF",
+      "path": "gmn/f.mp3",
+      "unique_id": "gmergenst000000000000004",
+      "length": 120.0,
+      "artist": "Artist F",
+      "title": "Song F",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "outer",
+      "name": "Outer Group",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "inner",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "fallback",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "inner",
+      "name": "Inner Merged Group",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [
+          "merge"
+        ],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "leaf-x",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "leaf-adv",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "leaf-y",
+          "weight": 3,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "leaf-x",
+      "name": "Leaf X",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mX",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "leaf-adv",
+      "name": "Leaf Advanced",
+      "config": {
+        "type": "custom",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mAdv",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "leaf-y",
+      "name": "Leaf Y",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mY",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "fallback",
+      "name": "Fallback",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mF",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-merge-nested.scenario.json
+++ b/tests/_data/autodj/queuing/group-merge-nested.scenario.json
@@ -1,0 +1,61 @@
+{
+  "description": "A merged group nested inside a non-merged sequential group contributes its whole block as that slot's contribution: build one yields the inner group's two-entry block (its Advanced-type member is force-advanced mid-pass), build two advances the outer rotation by exactly one slot to the fallback member, and build three starts the cycle over with a fresh inner block.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "nested-merged-group-block-as-slot-contribution",
+      "now": "2026-06-01T12:00:00+00:00",
+      "expect_sequence": [
+        {
+          "now": "2026-06-01T12:00:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "leaf-x",
+              "media_ref": "mX",
+              "playlist_chain_refs": [
+                "outer",
+                "inner",
+                "leaf-x"
+              ]
+            },
+            {
+              "playlist_ref": "leaf-y",
+              "media_ref": "mY",
+              "playlist_chain_refs": [
+                "outer",
+                "inner",
+                "leaf-y"
+              ]
+            }
+          ]
+        },
+        {
+          "now": "2026-06-01T12:05:00+00:00",
+          "mode": "exact",
+          "playlist_ref": "fallback",
+          "media_ref": "mF",
+          "playlist_chain_refs": [
+            "outer",
+            "fallback"
+          ]
+        },
+        {
+          "now": "2026-06-01T12:10:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "leaf-x",
+              "media_ref": "mX"
+            },
+            {
+              "playlist_ref": "leaf-y",
+              "media_ref": "mY"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-merge-random.dump.json
+++ b/tests/_data/autodj/queuing/group-merge-random.dump.json
@@ -1,0 +1,190 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": false
+  },
+  "media": [
+    {
+      "ref": "mRA",
+      "path": "gmr/a.mp3",
+      "unique_id": "gmergernd000000000000001",
+      "length": 120.0,
+      "artist": "Artist RA",
+      "title": "Song RA",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mRB",
+      "path": "gmr/b.mp3",
+      "unique_id": "gmergernd000000000000002",
+      "length": 120.0,
+      "artist": "Artist RB",
+      "title": "Song RB",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mRC",
+      "path": "gmr/c.mp3",
+      "unique_id": "gmergernd000000000000003",
+      "length": 120.0,
+      "artist": "Artist RC",
+      "title": "Song RC",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "grp-r",
+      "name": "Merged Random Group",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "random",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [
+          "merge"
+        ],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "leaf-ra",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "leaf-rb",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "leaf-rc",
+          "weight": 3,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "leaf-ra",
+      "name": "Leaf RA",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mRA",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "leaf-rb",
+      "name": "Leaf RB",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mRB",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "leaf-rc",
+      "name": "Leaf RC",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mRC",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-merge-random.scenario.json
+++ b/tests/_data/autodj/queuing/group-merge-random.scenario.json
@@ -1,0 +1,44 @@
+{
+  "description": "A random-order group with the 'merge' backend option has no rotation state, so one merged build takes a single randomized pass with exactly one pick per member: three one-track members yield a three-entry block containing each member's track exactly once, in nondeterministic order.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "random-order-block-one-pick-per-member",
+      "now": "2026-06-01T12:00:00+00:00",
+      "expect_sequence": [
+        {
+          "distinct": true,
+          "entries": [
+            {
+              "mode": "membership",
+              "media_any_of": [
+                "mRA",
+                "mRB",
+                "mRC"
+              ]
+            },
+            {
+              "mode": "membership",
+              "media_any_of": [
+                "mRA",
+                "mRB",
+                "mRC"
+              ]
+            },
+            {
+              "mode": "membership",
+              "media_any_of": [
+                "mRA",
+                "mRB",
+                "mRC"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/requests/request-merge-consecutive.dump.json
+++ b/tests/_data/autodj/requests/request-merge-consecutive.dump.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": true
+  },
+  "media": [
+    {
+      "ref": "mJ",
+      "path": "rmc/jingle.mp3",
+      "unique_id": "reqmrgcons00000000000001",
+      "length": 5.0,
+      "artist": "Jingle",
+      "title": "Station Jingle",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mR1",
+      "path": "rmc/r1.mp3",
+      "unique_id": "reqmrgcons00000000000002",
+      "length": 120.0,
+      "artist": "Request Artist One",
+      "title": "Requested One",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mR2",
+      "path": "rmc/r2.mp3",
+      "unique_id": "reqmrgcons00000000000003",
+      "length": 120.0,
+      "artist": "Request Artist Two",
+      "title": "Requested Two",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mR3",
+      "path": "rmc/r3.mp3",
+      "unique_id": "reqmrgcons00000000000004",
+      "length": 120.0,
+      "artist": "Request Artist Three",
+      "title": "Requested Three",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "grp",
+      "name": "Merged Request Group",
+      "config": {
+        "type": "once_per_x_minutes",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 20,
+        "play_per_hour_minute": 0,
+        "backend_options": [
+          "merge"
+        ],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "jingle",
+          "weight": 1,
+          "consecutive_plays": 1,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "reqpl",
+          "weight": 2,
+          "consecutive_plays": 2,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "jingle",
+      "name": "Jingle",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mJ",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "reqpl",
+      "name": "Requests Playlist",
+      "config": {
+        "type": "default",
+        "source": "requests",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "lib",
+      "name": "Requestable Library",
+      "config": {
+        "type": "custom",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 1,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": true,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mR1",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mR2",
+          "weight": 2,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mR3",
+          "weight": 3,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    }
+  ]
+}

--- a/tests/_data/autodj/requests/request-merge-consecutive.scenario.json
+++ b/tests/_data/autodj/requests/request-merge-consecutive.scenario.json
@@ -1,0 +1,73 @@
+{
+  "description": "A Requests-source member with consecutive_plays=2 inside a merged group serves up to two pending requests back to back within one block. The remaining request is served by the next block once the group fires again.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "two-consecutive-requests-per-block",
+      "now": "2026-06-01T12:00:00+00:00",
+      "runtime": {
+        "requests": [
+          {
+            "media_ref": "mR1",
+            "skip_delay": true
+          },
+          {
+            "media_ref": "mR2",
+            "skip_delay": true
+          },
+          {
+            "media_ref": "mR3",
+            "skip_delay": true
+          }
+        ]
+      },
+      "expect_sequence": [
+        {
+          "now": "2026-06-01T12:00:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "jingle",
+              "media_ref": "mJ",
+              "playlist_chain_refs": [
+                "grp",
+                "jingle"
+              ],
+              "from_request": false
+            },
+            {
+              "playlist_ref": "reqpl",
+              "media_ref": "mR1",
+              "playlist_chain_refs": [
+                "grp",
+                "reqpl"
+              ],
+              "from_request": true
+            },
+            {
+              "playlist_ref": "reqpl",
+              "media_ref": "mR2",
+              "from_request": true
+            }
+          ]
+        },
+        {
+          "now": "2026-06-01T12:25:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "jingle",
+              "media_ref": "mJ"
+            },
+            {
+              "playlist_ref": "reqpl",
+              "media_ref": "mR3",
+              "from_request": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/requests/request-merge-duplicate-prevention.dump.json
+++ b/tests/_data/autodj/requests/request-merge-duplicate-prevention.dump.json
@@ -1,0 +1,184 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": true
+  },
+  "media": [
+    {
+      "ref": "mA",
+      "path": "rmd/a.mp3",
+      "unique_id": "reqmrgdupe00000000000001",
+      "length": 120.0,
+      "artist": "Duplicate Artist",
+      "title": "Requested Duplicate",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mB",
+      "path": "rmd/b.mp3",
+      "unique_id": "reqmrgdupe00000000000002",
+      "length": 120.0,
+      "artist": "Other Artist",
+      "title": "Requested Other",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mS1",
+      "path": "rmd/s1.mp3",
+      "unique_id": "reqmrgdupe00000000000003",
+      "length": 120.0,
+      "artist": "Filler Artist",
+      "title": "Filler Song",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "grp",
+      "name": "Merged Request Group",
+      "config": {
+        "type": "once_per_x_minutes",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 20,
+        "play_per_hour_minute": 0,
+        "backend_options": [
+          "merge"
+        ],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "reqpl",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "play_full_cycle": true,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "filler",
+          "weight": 2,
+          "consecutive_plays": 1,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "reqpl",
+      "name": "Requests Playlist",
+      "config": {
+        "type": "default",
+        "source": "requests",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "filler",
+      "name": "Filler",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mS1",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "lib",
+      "name": "Requestable Library",
+      "config": {
+        "type": "custom",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 1,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": true,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mA",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mB",
+          "weight": 2,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    }
+  ]
+}

--- a/tests/_data/autodj/requests/request-merge-duplicate-prevention.scenario.json
+++ b/tests/_data/autodj/requests/request-merge-duplicate-prevention.scenario.json
@@ -1,0 +1,65 @@
+{
+  "description": "Two pending requests for the same track cannot both queue within one merged block: the first is served, the duplicate is skipped (stays pending) and the next distinct request is served in the same pick. The skipped duplicate is also not served by later blocks while its track remains in the recent history.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "duplicate-request-skipped-within-block",
+      "now": "2026-06-01T12:00:00+00:00",
+      "runtime": {
+        "requests": [
+          {
+            "media_ref": "mA",
+            "skip_delay": true
+          },
+          {
+            "media_ref": "mA",
+            "skip_delay": true
+          },
+          {
+            "media_ref": "mB",
+            "skip_delay": true
+          }
+        ]
+      },
+      "expect_sequence": [
+        {
+          "now": "2026-06-01T12:00:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "reqpl",
+              "media_ref": "mA",
+              "playlist_chain_refs": [
+                "grp",
+                "reqpl"
+              ],
+              "from_request": true
+            },
+            {
+              "playlist_ref": "reqpl",
+              "media_ref": "mB",
+              "from_request": true
+            },
+            {
+              "playlist_ref": "filler",
+              "media_ref": "mS1",
+              "from_request": false
+            }
+          ]
+        },
+        {
+          "now": "2026-06-01T12:25:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "filler",
+              "media_ref": "mS1",
+              "from_request": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/requests/request-merge-full-cycle.dump.json
+++ b/tests/_data/autodj/requests/request-merge-full-cycle.dump.json
@@ -1,0 +1,199 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": true
+  },
+  "media": [
+    {
+      "ref": "mR1",
+      "path": "rmf/r1.mp3",
+      "unique_id": "reqmrgfull00000000000001",
+      "length": 120.0,
+      "artist": "Request Artist One",
+      "title": "Requested One",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mR2",
+      "path": "rmf/r2.mp3",
+      "unique_id": "reqmrgfull00000000000002",
+      "length": 120.0,
+      "artist": "Request Artist Two",
+      "title": "Requested Two",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mR3",
+      "path": "rmf/r3.mp3",
+      "unique_id": "reqmrgfull00000000000003",
+      "length": 120.0,
+      "artist": "Request Artist Three",
+      "title": "Requested Three",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "mS1",
+      "path": "rmf/s1.mp3",
+      "unique_id": "reqmrgfull00000000000004",
+      "length": 120.0,
+      "artist": "Outro Artist",
+      "title": "Outro Song",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "grp",
+      "name": "Merged Request Group",
+      "config": {
+        "type": "once_per_x_minutes",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 20,
+        "play_per_hour_minute": 0,
+        "backend_options": [
+          "merge"
+        ],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "reqpl",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "play_full_cycle": true,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "outro",
+          "weight": 2,
+          "consecutive_plays": 1,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "reqpl",
+      "name": "Requests Playlist",
+      "config": {
+        "type": "default",
+        "source": "requests",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "outro",
+      "name": "Outro",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mS1",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "lib",
+      "name": "Requestable Library",
+      "config": {
+        "type": "custom",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 1,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": true,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "mR1",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mR2",
+          "weight": 2,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "mR3",
+          "weight": 3,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    }
+  ]
+}

--- a/tests/_data/autodj/requests/request-merge-full-cycle.scenario.json
+++ b/tests/_data/autodj/requests/request-merge-full-cycle.scenario.json
@@ -1,0 +1,74 @@
+{
+  "description": "A Requests-source member with play_full_cycle inside a merged group drains all currently playable requests within one block before advancing. Once the request queue is empty, the next block skips the member without an entry.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "full-cycle-drains-request-queue",
+      "now": "2026-06-01T12:00:00+00:00",
+      "runtime": {
+        "requests": [
+          {
+            "media_ref": "mR1",
+            "skip_delay": true
+          },
+          {
+            "media_ref": "mR2",
+            "skip_delay": true
+          },
+          {
+            "media_ref": "mR3",
+            "skip_delay": true
+          }
+        ]
+      },
+      "expect_sequence": [
+        {
+          "now": "2026-06-01T12:00:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "reqpl",
+              "media_ref": "mR1",
+              "playlist_chain_refs": [
+                "grp",
+                "reqpl"
+              ],
+              "from_request": true
+            },
+            {
+              "playlist_ref": "reqpl",
+              "media_ref": "mR2",
+              "from_request": true
+            },
+            {
+              "playlist_ref": "reqpl",
+              "media_ref": "mR3",
+              "from_request": true
+            },
+            {
+              "playlist_ref": "outro",
+              "media_ref": "mS1",
+              "playlist_chain_refs": [
+                "grp",
+                "outro"
+              ],
+              "from_request": false
+            }
+          ]
+        },
+        {
+          "now": "2026-06-01T12:25:00+00:00",
+          "entries": [
+            {
+              "playlist_ref": "outro",
+              "media_ref": "mS1",
+              "from_request": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Fixes issue:**
Fixes #8578

**Proposed changes:**
This PR implements the `Merge playlist to play as a single track` advanced playlist option for playlist groups.

Also ensured that request playlist members of groups can now be set to play up to x (or all available) requests when part of a merged group.

Additionally while building the test cases for the merged groups I encountered a bug in our queue resetting that seems to have been there for quite a while:

In the `StationPlaylistMediaRepository::resetQueue` & `StationPlaylistRepository::resetPlaylistGroupQueue` we bulk update entries in the DB via DQL, this causes the DB state and Doctrines entity map to be out of sync, basicall leaving the identitiy map stale for all entries the DQL updated and that were already in the map before the DQL. When we then call `StationPlaylistMedia::played` or `StationPlaylistGroup::played` Doctrine sees that the identity map already has `0` for the `is_queued` and registers it as an empty change set, thus not triggering a DB write.

The AutoDJ build multiple queue entries per run in one process without clearing the entitiy manager in between. Whenever a sequential or shuffle resets its queue in a build run, all entries that were selected before the reset (and were thus managed already) then went stale. The rotation would then repeat its first track or group member instead of advancing, until the next build run with a new entity manager.

The in-memory harness can't detect this since there we don't involve Doctrines entity manager, but the functional suit can detect it so I've added a regression test case for this in `group-merge-media-requeue.scenario.json`.

To fix this bug I've added a `resyncManagedEntities` method to the `backend/src/Doctrine/Repository.php` that builds a list of the stale entities and refetches them with a `Query::HINT_REFRESH` to ensure we use the current DB state.