### PR TITLE
Fix issue #8584 - Add options for resetting playlist queue at schedule start

### DIFF
--- a/backend/src/Entity/Migration/Version20260905144030.php
+++ b/backend/src/Entity/Migration/Version20260905144030.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+
+final class Version20260905144030 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add queue reset options to schedule entries.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'ALTER TABLE station_schedules ADD reset_queue_at_start TINYINT NOT NULL, ADD reset_queue_recursive TINYINT NOT NULL'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE station_schedules DROP reset_queue_at_start, DROP reset_queue_recursive');
+    }
+}

--- a/backend/src/Entity/Repository/StationScheduleRepository.php
+++ b/backend/src/Entity/Repository/StationScheduleRepository.php
@@ -60,6 +60,8 @@ final class StationScheduleRepository extends Repository
             $record->days = $item['days'] ?? [];
             $record->loop_once = $item['loop_once'] ?? false;
             $record->prevent_requests = $item['prevent_requests'] ?? false;
+            $record->reset_queue_at_start = $item['reset_queue_at_start'] ?? false;
+            $record->reset_queue_recursive = $item['reset_queue_recursive'] ?? false;
 
             $this->em->persist($record);
         }

--- a/backend/src/Entity/StationSchedule.php
+++ b/backend/src/Entity/StationSchedule.php
@@ -109,6 +109,34 @@ final class StationSchedule implements IdentifiableEntityInterface
     ]
     public bool $prevent_requests = false;
 
+    #[
+        OA\Property(
+            description: "Reset the playlist's internal queue when this schedule window becomes active.",
+            example: false
+        ),
+        ORM\Column
+    ]
+    public bool $reset_queue_at_start = false {
+        set {
+            $this->reset_queue_at_start = $value;
+
+            if (!$value) {
+                $this->reset_queue_recursive = false;
+            }
+        }
+    }
+
+    #[
+        OA\Property(
+            description: "Also reset nested playlist groups and member playlists (playlist groups only).",
+            example: false
+        ),
+        ORM\Column
+    ]
+    public bool $reset_queue_recursive = false {
+        set => $value && $this->reset_queue_at_start;
+    }
+
     public function __construct(StationPlaylist|StationStreamer $relation)
     {
         if ($relation instanceof StationPlaylist) {

--- a/backend/src/Radio/AutoDJ/Scheduler.php
+++ b/backend/src/Radio/AutoDJ/Scheduler.php
@@ -421,6 +421,11 @@ final class Scheduler
             }
         }
 
+        // Handle resetting before loop_once since it relies on queue state
+        if ($schedule->reset_queue_at_start) {
+            $this->resetQueueAtBlockStart($playlist, $dateRange, $schedule->reset_queue_recursive);
+        }
+
         // Handle "Loop Once" schedule specification.
         if (
             $schedule->loop_once
@@ -430,6 +435,75 @@ final class Scheduler
         }
 
         return true;
+    }
+
+    private function resetQueueAtBlockStart(
+        StationPlaylist $playlist,
+        DateRange $dateRange,
+        bool $recursive
+    ): void {
+        if (!in_array($playlist->source, [PlaylistSources::Songs, PlaylistSources::Playlists], true)) {
+            return;
+        }
+
+        // If playlist has been played in this window we shoudln't reset it again
+        if ($dateRange->contains($playlist->played_at)) {
+            return;
+        }
+
+        // One second before start so "queue_reset_at outside window" check still works after reset
+        $resetAt = $dateRange->start->subSecond();
+
+        if ($playlist->queue_reset_at !== null && $playlist->queue_reset_at >= $resetAt) {
+            return;
+        }
+
+        $this->logger->debug(
+            'Resetting playlist queue at schedule block start.',
+            ['reset_at' => $resetAt]
+        );
+
+        if ($playlist->source === PlaylistSources::Songs) {
+            $this->spmRepo->resetQueue($playlist, $resetAt);
+        } elseif ($recursive) {
+            $this->resetPlaylistGroupTree($playlist, $resetAt);
+        } else {
+            $this->spRepo->resetPlaylistGroupQueue($playlist, $resetAt);
+        }
+    }
+
+    /**
+     * @param int[] $visitedIds
+     */
+    private function resetPlaylistGroupTree(
+        StationPlaylist $group,
+        CarbonImmutable $resetAt,
+        array $visitedIds = []
+    ): void {
+        if (in_array($group->id, $visitedIds, true)) {
+            return;
+        }
+
+        $visitedIds[] = $group->id;
+
+        $this->spRepo->resetPlaylistGroupQueue($group, $resetAt);
+
+        foreach ($group->playlists as $membership) {
+            $member = $membership->playlist;
+
+            switch ($member->source) {
+                case PlaylistSources::Playlists:
+                    $this->resetPlaylistGroupTree($member, $resetAt, $visitedIds);
+                    break;
+
+                case PlaylistSources::Songs:
+                    if (!in_array($member->id, $visitedIds, true)) {
+                        $visitedIds[] = $member->id;
+                        $this->spmRepo->resetQueue($member, $resetAt);
+                    }
+                    break;
+            }
+        }
     }
 
     private function shouldPlaylistLoopNow(

--- a/backend/src/Service/PlaylistConfiguration/PlaylistConfigurationExporter.php
+++ b/backend/src/Service/PlaylistConfiguration/PlaylistConfigurationExporter.php
@@ -172,6 +172,8 @@ final class PlaylistConfigurationExporter
                 endDate: $schedule->end_date,
                 loopOnce: $schedule->loop_once,
                 preventRequests: $schedule->prevent_requests,
+                resetQueueAtStart: $schedule->reset_queue_at_start,
+                resetQueueRecursive: $schedule->reset_queue_recursive,
             );
         }
 

--- a/backend/src/Service/PlaylistConfiguration/PlaylistConfigurationImporter.php
+++ b/backend/src/Service/PlaylistConfiguration/PlaylistConfigurationImporter.php
@@ -320,6 +320,8 @@ final class PlaylistConfigurationImporter
             $schedule->end_date = $scheduleEntry->endDate;
             $schedule->loop_once = $scheduleEntry->loopOnce;
             $schedule->prevent_requests = $scheduleEntry->preventRequests;
+            $schedule->reset_queue_at_start = $scheduleEntry->resetQueueAtStart;
+            $schedule->reset_queue_recursive = $scheduleEntry->resetQueueRecursive;
 
             $this->em->persist($schedule);
 

--- a/backend/src/Service/PlaylistConfiguration/Schema/PlaylistScheduleEntry.php
+++ b/backend/src/Service/PlaylistConfiguration/Schema/PlaylistScheduleEntry.php
@@ -15,7 +15,9 @@ use JsonSerializable;
  *     start_date: ?string,
  *     end_date: ?string,
  *     loop_once: bool,
- *     prevent_requests: bool
+ *     prevent_requests: bool,
+ *     reset_queue_at_start: bool,
+ *     reset_queue_recursive: bool
  * }
  */
 final class PlaylistScheduleEntry implements JsonSerializable
@@ -31,6 +33,8 @@ final class PlaylistScheduleEntry implements JsonSerializable
         public readonly ?string $endDate,
         public readonly bool $loopOnce,
         public readonly bool $preventRequests,
+        public readonly bool $resetQueueAtStart = false,
+        public readonly bool $resetQueueRecursive = false,
     ) {
     }
 
@@ -47,6 +51,8 @@ final class PlaylistScheduleEntry implements JsonSerializable
             endDate: Types::stringOrNull($data['end_date'] ?? null),
             loopOnce: Types::bool($data['loop_once'] ?? null),
             preventRequests: Types::bool($data['prevent_requests'] ?? null),
+            resetQueueAtStart: Types::bool($data['reset_queue_at_start'] ?? null),
+            resetQueueRecursive: Types::bool($data['reset_queue_recursive'] ?? null),
         );
     }
 
@@ -63,6 +69,8 @@ final class PlaylistScheduleEntry implements JsonSerializable
             'end_date' => $this->endDate,
             'loop_once' => $this->loopOnce,
             'prevent_requests' => $this->preventRequests,
+            'reset_queue_at_start' => $this->resetQueueAtStart,
+            'reset_queue_recursive' => $this->resetQueueRecursive,
         ];
     }
 }

--- a/backend/src/Tests/AutoDJ/InMemoryEntityHydrator.php
+++ b/backend/src/Tests/AutoDJ/InMemoryEntityHydrator.php
@@ -290,6 +290,12 @@ final class InMemoryEntityHydrator
                 $schedule->prevent_requests = Types::bool(
                     $scheduleData['prevent_requests'] ?? $schedule->prevent_requests
                 );
+                $schedule->reset_queue_at_start = Types::bool(
+                    $scheduleData['reset_queue_at_start'] ?? $schedule->reset_queue_at_start
+                );
+                $schedule->reset_queue_recursive = Types::bool(
+                    $scheduleData['reset_queue_recursive'] ?? $schedule->reset_queue_recursive
+                );
 
                 self::setId($schedule, $this->scheduleIdSeq++);
 

--- a/frontend/components/Stations/Playlists/Form/Schedule.vue
+++ b/frontend/components/Stations/Playlists/Form/Schedule.vue
@@ -56,6 +56,8 @@ const add = () => {
         days: [],
         loop_once: false,
         prevent_requests: false,
+        reset_queue_at_start: false,
+        reset_queue_recursive: false,
     });
 };
 

--- a/frontend/components/Stations/Playlists/Form/ScheduleRow.vue
+++ b/frontend/components/Stations/Playlists/Form/ScheduleRow.vue
@@ -106,6 +106,24 @@
                     :label="$gettext('Block Request Queue While Active')"
                     :description="$gettext('While this scheduled window is active, listener requests will not be played via the automatic request queue.')"
                 />
+
+                <form-group-checkbox
+                    v-if="form.source === PlaylistSources.Songs || form.source === PlaylistSources.Playlists"
+                    :id="'edit_form_reset_queue_at_start_'+index"
+                    class="col-md-6"
+                    :field="r$.reset_queue_at_start"
+                    :label="$gettext('Reset Queue at Schedule Start')"
+                    :description="$gettext('When this scheduled window starts, restart the playlist from the beginning of its rotation instead of resuming where it was interrupted.')"
+                />
+
+                <form-group-checkbox
+                    v-if="form.source === PlaylistSources.Playlists && row.reset_queue_at_start"
+                    :id="'edit_form_reset_queue_recursive_'+index"
+                    class="col-md-6"
+                    :field="r$.reset_queue_recursive"
+                    :label="$gettext('Also Reset Nested Playlists')"
+                    :description="$gettext('Also restart every nested playlist group and member playlist from the beginning.')"
+                />
             </div>
         </div>
     </section>
@@ -137,6 +155,8 @@ interface PlaylistScheduleRow {
     days: number[];
     loop_once: boolean;
     prevent_requests: boolean;
+    reset_queue_at_start: boolean;
+    reset_queue_recursive: boolean;
 }
 
 const props = defineProps<{

--- a/frontend/entities/ApiInterfaces.ts
+++ b/frontend/entities/ApiInterfaces.ts
@@ -2740,6 +2740,16 @@ export type StationSchedule = HasAutoIncrementId & {
      * @example false
      */
     prevent_requests?: boolean;
+    /**
+     * Reset the playlist's internal queue when this schedule window becomes active.
+     * @example false
+     */
+    reset_queue_at_start?: boolean;
+    /**
+     * Also reset nested playlist groups and member playlists (playlist groups only).
+     * @example false
+     */
+    reset_queue_recursive?: boolean;
 };
 
 /** Station streamers (DJ accounts) allowed to broadcast to a station. */

--- a/tests/_data/autodj/README.md
+++ b/tests/_data/autodj/README.md
@@ -245,6 +245,8 @@ Unless noted, every item below behaves identically in-memory and in integration.
 - **Playlist `backend_options`**
   - The `interrupt` restricts a playlist to interrupting builds only (set `interrupting: true` on the step)
   - The `single_track` & schedule `loop_once` drive the scheduled-window special rules
+  - The schedule `reset_queue_at_start` resets the playlist's own queue once when its window first becomes active (`queue_reset_at` = window start minus one second)
+    - The `reset_queue_recursive` extends that to nested groups and songs members of a playlist group
   - The `merge` on a songs playlist cues the entire playlist in one build
   - The `merge` on a playlist group cues one full rotation pass as a single block per build
     - Sequential/shuffle groups keep picking until the rotation queue empties once (a `consecutive_plays` slot contributes that many tracks, a `play_full_cycle` member its whole remaining cycle; for a `Requests`-source member that cycle is the currently playable request queue)

--- a/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start-loop-once.dump.json
+++ b/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start-loop-once.dump.json
@@ -1,0 +1,200 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": false
+  },
+  "media": [
+    {
+      "ref": "m_a",
+      "path": "group-reset-queue-at-schedule-start-loop-once/m_a.mp3",
+      "unique_id": "000000000000000000000001",
+      "length": 120.0,
+      "artist": "Artist A",
+      "title": "Song A",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_b",
+      "path": "group-reset-queue-at-schedule-start-loop-once/m_b.mp3",
+      "unique_id": "000000000000000000000002",
+      "length": 120.0,
+      "artist": "Artist B",
+      "title": "Song B",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_c",
+      "path": "group-reset-queue-at-schedule-start-loop-once/m_c.mp3",
+      "unique_id": "000000000000000000000003",
+      "length": 120.0,
+      "artist": "Artist C",
+      "title": "Song C",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "a",
+      "name": "Member A",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_a",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "b",
+      "name": "Member B",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_b",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "c",
+      "name": "Member C",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_c",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "grp",
+      "name": "Reset And Loop Once Group",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [
+        {
+          "start_time": 1200,
+          "end_time": 1300,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": true,
+          "prevent_requests": false,
+          "reset_queue_at_start": true,
+          "reset_queue_recursive": false
+        }
+      ],
+      "members": [
+        {
+          "playlist_ref": "a",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "b",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "c",
+          "weight": 3,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start-loop-once.scenario.json
+++ b/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start-loop-once.scenario.json
@@ -1,0 +1,58 @@
+{
+  "description": "'reset_queue_at_start' and 'loop_once' on the same schedule entry compose: the block-start reset restarts the interrupted rotation at the first member, and because the reset is stamped one second before the window (the loop-once convention), loop_once still sees an unspent window and plays exactly one full pass before the group stops for the rest of the window.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "reset-then-one-full-pass",
+      "now": "2018-01-15T12:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp:a": {
+            "is_queued": false
+          },
+          "grp:b": {
+            "is_queued": false
+          },
+          "grp:c": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "a",
+          "media_ref": "m_a",
+          "playlist_chain_refs": [
+            "grp",
+            "a"
+          ]
+        },
+        {
+          "mode": "exact",
+          "playlist_ref": "b",
+          "media_ref": "m_b",
+          "playlist_chain_refs": [
+            "grp",
+            "b"
+          ]
+        },
+        {
+          "mode": "exact",
+          "playlist_ref": "c",
+          "media_ref": "m_c",
+          "playlist_chain_refs": [
+            "grp",
+            "c"
+          ]
+        },
+        {
+          "mode": "none"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start-nested.dump.json
+++ b/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start-nested.dump.json
@@ -1,0 +1,879 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": false
+  },
+  "media": [
+    {
+      "ref": "m_o1_rec",
+      "path": "group-reset-queue-at-schedule-start-nested/m_o1_rec.mp3",
+      "unique_id": "000000000000000000000001",
+      "length": 120.0,
+      "artist": "Opener Artist rec",
+      "title": "Opener o1 rec",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_o2_rec",
+      "path": "group-reset-queue-at-schedule-start-nested/m_o2_rec.mp3",
+      "unique_id": "000000000000000000000002",
+      "length": 120.0,
+      "artist": "Opener Artist rec",
+      "title": "Opener o2 rec",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_x_rec",
+      "path": "group-reset-queue-at-schedule-start-nested/m_x_rec.mp3",
+      "unique_id": "000000000000000000000003",
+      "length": 120.0,
+      "artist": "Leaf Artist x rec",
+      "title": "Leaf x rec",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_y_rec",
+      "path": "group-reset-queue-at-schedule-start-nested/m_y_rec.mp3",
+      "unique_id": "000000000000000000000004",
+      "length": 120.0,
+      "artist": "Leaf Artist y rec",
+      "title": "Leaf y rec",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_z_rec",
+      "path": "group-reset-queue-at-schedule-start-nested/m_z_rec.mp3",
+      "unique_id": "000000000000000000000005",
+      "length": 120.0,
+      "artist": "Leaf Artist z rec",
+      "title": "Leaf z rec",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_o1_own",
+      "path": "group-reset-queue-at-schedule-start-nested/m_o1_own.mp3",
+      "unique_id": "000000000000000000000006",
+      "length": 120.0,
+      "artist": "Opener Artist own",
+      "title": "Opener o1 own",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_o2_own",
+      "path": "group-reset-queue-at-schedule-start-nested/m_o2_own.mp3",
+      "unique_id": "000000000000000000000007",
+      "length": 120.0,
+      "artist": "Opener Artist own",
+      "title": "Opener o2 own",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_x_own",
+      "path": "group-reset-queue-at-schedule-start-nested/m_x_own.mp3",
+      "unique_id": "000000000000000000000008",
+      "length": 120.0,
+      "artist": "Leaf Artist x own",
+      "title": "Leaf x own",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_y_own",
+      "path": "group-reset-queue-at-schedule-start-nested/m_y_own.mp3",
+      "unique_id": "000000000000000000000009",
+      "length": 120.0,
+      "artist": "Leaf Artist y own",
+      "title": "Leaf y own",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_z_own",
+      "path": "group-reset-queue-at-schedule-start-nested/m_z_own.mp3",
+      "unique_id": "000000000000000000000010",
+      "length": 120.0,
+      "artist": "Leaf Artist z own",
+      "title": "Leaf z own",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_o1_off",
+      "path": "group-reset-queue-at-schedule-start-nested/m_o1_off.mp3",
+      "unique_id": "000000000000000000000011",
+      "length": 120.0,
+      "artist": "Opener Artist off",
+      "title": "Opener o1 off",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_o2_off",
+      "path": "group-reset-queue-at-schedule-start-nested/m_o2_off.mp3",
+      "unique_id": "000000000000000000000012",
+      "length": 120.0,
+      "artist": "Opener Artist off",
+      "title": "Opener o2 off",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_x_off",
+      "path": "group-reset-queue-at-schedule-start-nested/m_x_off.mp3",
+      "unique_id": "000000000000000000000013",
+      "length": 120.0,
+      "artist": "Leaf Artist x off",
+      "title": "Leaf x off",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_y_off",
+      "path": "group-reset-queue-at-schedule-start-nested/m_y_off.mp3",
+      "unique_id": "000000000000000000000014",
+      "length": 120.0,
+      "artist": "Leaf Artist y off",
+      "title": "Leaf y off",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_z_off",
+      "path": "group-reset-queue-at-schedule-start-nested/m_z_off.mp3",
+      "unique_id": "000000000000000000000015",
+      "length": 120.0,
+      "artist": "Leaf Artist z off",
+      "title": "Leaf z off",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "opener_rec",
+      "name": "Opener rec",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_o1_rec",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "m_o2_rec",
+          "weight": 2,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "x_rec",
+      "name": "Leaf x rec",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_x_rec",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "y_rec",
+      "name": "Leaf y rec",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_y_rec",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "z_rec",
+      "name": "Leaf z rec",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_z_rec",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "inner_rec",
+      "name": "Inner rec",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "x_rec",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "y_rec",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "z_rec",
+          "weight": 3,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "outer_rec",
+      "name": "Outer rec",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [
+        {
+          "start_time": 1200,
+          "end_time": 1300,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": false,
+          "prevent_requests": false,
+          "reset_queue_at_start": true,
+          "reset_queue_recursive": true
+        }
+      ],
+      "members": [
+        {
+          "playlist_ref": "opener_rec",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "inner_rec",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "opener_own",
+      "name": "Opener own",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_o1_own",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "m_o2_own",
+          "weight": 2,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "x_own",
+      "name": "Leaf x own",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_x_own",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "y_own",
+      "name": "Leaf y own",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_y_own",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "z_own",
+      "name": "Leaf z own",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_z_own",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "inner_own",
+      "name": "Inner own",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "x_own",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "y_own",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "z_own",
+          "weight": 3,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "outer_own",
+      "name": "Outer own",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [
+        {
+          "start_time": 1400,
+          "end_time": 1500,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": false,
+          "prevent_requests": false,
+          "reset_queue_at_start": true,
+          "reset_queue_recursive": false
+        }
+      ],
+      "members": [
+        {
+          "playlist_ref": "opener_own",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "inner_own",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "opener_off",
+      "name": "Opener off",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_o1_off",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "m_o2_off",
+          "weight": 2,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "x_off",
+      "name": "Leaf x off",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_x_off",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "y_off",
+      "name": "Leaf y off",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_y_off",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "z_off",
+      "name": "Leaf z off",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_z_off",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "inner_off",
+      "name": "Inner off",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [],
+      "members": [
+        {
+          "playlist_ref": "x_off",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "y_off",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "z_off",
+          "weight": 3,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "outer_off",
+      "name": "Outer off",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [
+        {
+          "start_time": 1600,
+          "end_time": 1700,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": false,
+          "prevent_requests": false,
+          "reset_queue_at_start": false,
+          "reset_queue_recursive": false
+        },
+        {
+          "start_time": 1800,
+          "end_time": 1900,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": false,
+          "prevent_requests": false,
+          "reset_queue_at_start": false,
+          "reset_queue_recursive": true
+        }
+      ],
+      "members": [
+        {
+          "playlist_ref": "opener_off",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "inner_off",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start-nested.scenario.json
+++ b/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start-nested.scenario.json
@@ -1,0 +1,199 @@
+{
+  "description": "Nested tree: a sequential outer group holds a sequential songs 'opener' and a sequential inner group of three leaves. With 'reset_queue_at_start' plus 'reset_queue_recursive' the whole tree restarts at window start (opener at its first track, inner at its first leaf). With only 'reset_queue_at_start' the outer rotation restarts but the opener's track cursor and the inner group's rotation are untouched. Without the flag everything resumes mid-rotation, and 'reset_queue_recursive' alone is a no-op.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "recursive-resets-whole-tree",
+      "now": "2018-01-15T12:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "outer_rec:opener_rec": {
+            "is_queued": false
+          },
+          "outer_rec:inner_rec": {
+            "is_queued": true
+          },
+          "inner_rec:x_rec": {
+            "is_queued": false
+          },
+          "inner_rec:y_rec": {
+            "is_queued": false
+          },
+          "inner_rec:z_rec": {
+            "is_queued": true
+          }
+        },
+        "playlist_media": {
+          "opener_rec:m_o1_rec": {
+            "is_queued": false
+          },
+          "opener_rec:m_o2_rec": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "opener_rec",
+          "media_ref": "m_o1_rec",
+          "playlist_chain_refs": [
+            "outer_rec",
+            "opener_rec"
+          ]
+        },
+        {
+          "mode": "exact",
+          "playlist_ref": "x_rec",
+          "media_ref": "m_x_rec",
+          "playlist_chain_refs": [
+            "outer_rec",
+            "inner_rec",
+            "x_rec"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "own-only-resets-top-level",
+      "now": "2018-01-15T14:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "outer_own:opener_own": {
+            "is_queued": false
+          },
+          "outer_own:inner_own": {
+            "is_queued": true
+          },
+          "inner_own:x_own": {
+            "is_queued": false
+          },
+          "inner_own:y_own": {
+            "is_queued": false
+          },
+          "inner_own:z_own": {
+            "is_queued": true
+          }
+        },
+        "playlist_media": {
+          "opener_own:m_o1_own": {
+            "is_queued": false
+          },
+          "opener_own:m_o2_own": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "opener_own",
+          "media_ref": "m_o2_own",
+          "playlist_chain_refs": [
+            "outer_own",
+            "opener_own"
+          ]
+        },
+        {
+          "mode": "exact",
+          "playlist_ref": "z_own",
+          "media_ref": "m_z_own",
+          "playlist_chain_refs": [
+            "outer_own",
+            "inner_own",
+            "z_own"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "no-flag-resumes",
+      "now": "2018-01-15T16:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "outer_off:opener_off": {
+            "is_queued": false
+          },
+          "outer_off:inner_off": {
+            "is_queued": true
+          },
+          "inner_off:x_off": {
+            "is_queued": false
+          },
+          "inner_off:y_off": {
+            "is_queued": false
+          },
+          "inner_off:z_off": {
+            "is_queued": true
+          }
+        },
+        "playlist_media": {
+          "opener_off:m_o1_off": {
+            "is_queued": false
+          },
+          "opener_off:m_o2_off": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "z_off",
+          "media_ref": "m_z_off",
+          "playlist_chain_refs": [
+            "outer_off",
+            "inner_off",
+            "z_off"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "recursive-flag-alone-is-noop",
+      "now": "2018-01-15T18:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "outer_off:opener_off": {
+            "is_queued": false
+          },
+          "outer_off:inner_off": {
+            "is_queued": true
+          },
+          "inner_off:x_off": {
+            "is_queued": false
+          },
+          "inner_off:y_off": {
+            "is_queued": false
+          },
+          "inner_off:z_off": {
+            "is_queued": true
+          }
+        },
+        "playlist_media": {
+          "opener_off:m_o1_off": {
+            "is_queued": false
+          },
+          "opener_off:m_o2_off": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "z_off",
+          "media_ref": "m_z_off",
+          "playlist_chain_refs": [
+            "outer_off",
+            "inner_off",
+            "z_off"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start.dump.json
+++ b/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start.dump.json
@@ -1,0 +1,574 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": false
+  },
+  "media": [
+    {
+      "ref": "m_on_a",
+      "path": "group-reset-queue-at-schedule-start/m_on_a.mp3",
+      "unique_id": "000000000000000000000001",
+      "length": 120.0,
+      "artist": "On Artist A",
+      "title": "On Song A",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_on_b",
+      "path": "group-reset-queue-at-schedule-start/m_on_b.mp3",
+      "unique_id": "000000000000000000000002",
+      "length": 120.0,
+      "artist": "On Artist B",
+      "title": "On Song B",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_on_c",
+      "path": "group-reset-queue-at-schedule-start/m_on_c.mp3",
+      "unique_id": "000000000000000000000003",
+      "length": 120.0,
+      "artist": "On Artist C",
+      "title": "On Song C",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_off_a",
+      "path": "group-reset-queue-at-schedule-start/m_off_a.mp3",
+      "unique_id": "000000000000000000000004",
+      "length": 120.0,
+      "artist": "Off Artist A",
+      "title": "Off Song A",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_off_b",
+      "path": "group-reset-queue-at-schedule-start/m_off_b.mp3",
+      "unique_id": "000000000000000000000005",
+      "length": 120.0,
+      "artist": "Off Artist B",
+      "title": "Off Song B",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_off_c",
+      "path": "group-reset-queue-at-schedule-start/m_off_c.mp3",
+      "unique_id": "000000000000000000000006",
+      "length": 120.0,
+      "artist": "Off Artist C",
+      "title": "Off Song C",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_night_a",
+      "path": "group-reset-queue-at-schedule-start/m_night_a.mp3",
+      "unique_id": "000000000000000000000007",
+      "length": 120.0,
+      "artist": "Night Artist A",
+      "title": "Night Song A",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_night_b",
+      "path": "group-reset-queue-at-schedule-start/m_night_b.mp3",
+      "unique_id": "000000000000000000000008",
+      "length": 120.0,
+      "artist": "Night Artist B",
+      "title": "Night Song B",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m_night_c",
+      "path": "group-reset-queue-at-schedule-start/m_night_c.mp3",
+      "unique_id": "000000000000000000000009",
+      "length": 120.0,
+      "artist": "Night Artist C",
+      "title": "Night Song C",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "on_a",
+      "name": "On Member A",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_on_a",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "on_b",
+      "name": "On Member B",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_on_b",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "on_c",
+      "name": "On Member C",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_on_c",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "grp_on",
+      "name": "On Group",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [
+        {
+          "start_time": 1200,
+          "end_time": 1300,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": false,
+          "prevent_requests": false,
+          "reset_queue_at_start": true,
+          "reset_queue_recursive": false
+        }
+      ],
+      "members": [
+        {
+          "playlist_ref": "on_a",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "on_b",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "on_c",
+          "weight": 3,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "off_a",
+      "name": "Off Member A",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_off_a",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "off_b",
+      "name": "Off Member B",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_off_b",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "off_c",
+      "name": "Off Member C",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_off_c",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "grp_off",
+      "name": "Off Group",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [
+        {
+          "start_time": 1400,
+          "end_time": 1500,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": false,
+          "prevent_requests": false,
+          "reset_queue_at_start": false,
+          "reset_queue_recursive": false
+        }
+      ],
+      "members": [
+        {
+          "playlist_ref": "off_a",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "off_b",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "off_c",
+          "weight": 3,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    },
+    {
+      "ref": "night_a",
+      "name": "Night Member A",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_night_a",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "night_b",
+      "name": "Night Member B",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_night_b",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "night_c",
+      "name": "Night Member C",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m_night_c",
+          "weight": 1,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [],
+      "members": []
+    },
+    {
+      "ref": "grp_night",
+      "name": "Night Group",
+      "config": {
+        "type": "default",
+        "source": "playlists",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [],
+      "schedules": [
+        {
+          "start_time": 2300,
+          "end_time": 100,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": false,
+          "prevent_requests": false,
+          "reset_queue_at_start": true,
+          "reset_queue_recursive": false
+        }
+      ],
+      "members": [
+        {
+          "playlist_ref": "night_a",
+          "weight": 1,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "night_b",
+          "weight": 2,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        },
+        {
+          "playlist_ref": "night_c",
+          "weight": 3,
+          "consecutive_plays": 0,
+          "allowed_requests": "any"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start.scenario.json
+++ b/tests/_data/autodj/queuing/group-reset-queue-at-schedule-start.scenario.json
@@ -1,0 +1,323 @@
+{
+  "description": "A sequential playlist group with 'reset_queue_at_start' on its schedule entry restarts its rotation from the first member when the scheduled window first becomes active, instead of resuming where a previous window left off. The reset is stamped (queue_reset_at = window start minus one second) so it fires once per window occurrence: not again once the group has played in the window, not again while the stamp is inside the window, but again on the next day's occurrence and at the start of an overnight window. An identical group without the flag resumes mid-rotation. The flag never changes schedule eligibility.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "flag-on-resets-at-block-start",
+      "now": "2018-01-15T12:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_on:on_a": {
+            "is_queued": false
+          },
+          "grp_on:on_b": {
+            "is_queued": false
+          },
+          "grp_on:on_c": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "on_a",
+          "media_ref": "m_on_a",
+          "playlist_chain_refs": [
+            "grp_on",
+            "on_a"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "flag-off-resumes-mid-rotation",
+      "now": "2018-01-15T14:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_off:off_a": {
+            "is_queued": false
+          },
+          "grp_off:off_b": {
+            "is_queued": false
+          },
+          "grp_off:off_c": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "off_c",
+          "media_ref": "m_off_c",
+          "playlist_chain_refs": [
+            "grp_off",
+            "off_c"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "flag-on-already-played-in-block",
+      "now": "2018-01-15T12:10:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_on:on_a": {
+            "is_queued": false
+          },
+          "grp_on:on_b": {
+            "is_queued": false
+          },
+          "grp_on:on_c": {
+            "is_queued": true
+          }
+        },
+        "playlists": {
+          "grp_on": {
+            "played_at": "2018-01-15T12:05:00+00:00"
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "on_c",
+          "media_ref": "m_on_c",
+          "playlist_chain_refs": [
+            "grp_on",
+            "on_c"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "flag-on-stamp-blocks-second-reset",
+      "now": "2018-01-15T12:10:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_on:on_a": {
+            "is_queued": false
+          },
+          "grp_on:on_b": {
+            "is_queued": false
+          },
+          "grp_on:on_c": {
+            "is_queued": true
+          }
+        },
+        "playlists": {
+          "grp_on": {
+            "queue_reset_at": "2018-01-15T11:59:59+00:00"
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "on_c",
+          "media_ref": "m_on_c",
+          "playlist_chain_refs": [
+            "grp_on",
+            "on_c"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "next-day-resets-again",
+      "now": "2018-01-16T12:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_on:on_a": {
+            "is_queued": false
+          },
+          "grp_on:on_b": {
+            "is_queued": false
+          },
+          "grp_on:on_c": {
+            "is_queued": true
+          }
+        },
+        "playlists": {
+          "grp_on": {
+            "queue_reset_at": "2018-01-15T11:59:59+00:00"
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "on_a",
+          "media_ref": "m_on_a",
+          "playlist_chain_refs": [
+            "grp_on",
+            "on_a"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "resets-once-then-advances",
+      "now": "2018-01-15T12:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_on:on_a": {
+            "is_queued": false
+          },
+          "grp_on:on_b": {
+            "is_queued": false
+          },
+          "grp_on:on_c": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "on_a",
+          "media_ref": "m_on_a",
+          "playlist_chain_refs": [
+            "grp_on",
+            "on_a"
+          ]
+        },
+        {
+          "mode": "exact",
+          "playlist_ref": "on_b",
+          "media_ref": "m_on_b",
+          "playlist_chain_refs": [
+            "grp_on",
+            "on_b"
+          ]
+        },
+        {
+          "mode": "exact",
+          "playlist_ref": "on_c",
+          "media_ref": "m_on_c",
+          "playlist_chain_refs": [
+            "grp_on",
+            "on_c"
+          ]
+        },
+        {
+          "now": "2018-01-15T12:45:00+00:00",
+          "mode": "exact",
+          "playlist_ref": "on_a",
+          "media_ref": "m_on_a",
+          "playlist_chain_refs": [
+            "grp_on",
+            "on_a"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "overnight-resets-at-window-start",
+      "now": "2018-01-15T23:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_night:night_a": {
+            "is_queued": false
+          },
+          "grp_night:night_b": {
+            "is_queued": false
+          },
+          "grp_night:night_c": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "night_a",
+          "media_ref": "m_night_a",
+          "playlist_chain_refs": [
+            "grp_night",
+            "night_a"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "overnight-same-block-after-midnight",
+      "now": "2018-01-16T00:30:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_night:night_a": {
+            "is_queued": false
+          },
+          "grp_night:night_b": {
+            "is_queued": false
+          },
+          "grp_night:night_c": {
+            "is_queued": true
+          }
+        },
+        "playlists": {
+          "grp_night": {
+            "played_at": "2018-01-15T23:05:00+00:00"
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "night_c",
+          "media_ref": "m_night_c",
+          "playlist_chain_refs": [
+            "grp_night",
+            "night_c"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "scheduler-gate-unaffected-inside-window",
+      "now": "2018-01-15T12:00:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_on:on_a": {
+            "is_queued": false
+          },
+          "grp_on:on_b": {
+            "is_queued": false
+          },
+          "grp_on:on_c": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_should_play": {
+        "grp_on": true,
+        "grp_off": false,
+        "grp_night": false
+      }
+    },
+    {
+      "name": "scheduler-gate-unaffected-outside-window",
+      "now": "2018-01-15T11:59:00+00:00",
+      "runtime": {
+        "group_members": {
+          "grp_on:on_a": {
+            "is_queued": false
+          },
+          "grp_on:on_b": {
+            "is_queued": false
+          },
+          "grp_on:on_c": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_should_play": {
+        "grp_on": false
+      }
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/playlist-reset-queue-at-schedule-start.dump.json
+++ b/tests/_data/autodj/queuing/playlist-reset-queue-at-schedule-start.dump.json
@@ -1,0 +1,183 @@
+{
+  "schema_version": 1,
+  "type": "station",
+  "station": {
+    "name": "Test Station",
+    "timezone": "UTC",
+    "requests_only_via_playlists": false
+  },
+  "media": [
+    {
+      "ref": "m1_on",
+      "path": "playlist-reset-queue-at-schedule-start/m1_on.mp3",
+      "unique_id": "000000000000000000000001",
+      "length": 120.0,
+      "artist": "Artist 1 on",
+      "title": "Song 1 on",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m2_on",
+      "path": "playlist-reset-queue-at-schedule-start/m2_on.mp3",
+      "unique_id": "000000000000000000000002",
+      "length": 120.0,
+      "artist": "Artist 2 on",
+      "title": "Song 2 on",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m3_on",
+      "path": "playlist-reset-queue-at-schedule-start/m3_on.mp3",
+      "unique_id": "000000000000000000000003",
+      "length": 120.0,
+      "artist": "Artist 3 on",
+      "title": "Song 3 on",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m1_off",
+      "path": "playlist-reset-queue-at-schedule-start/m1_off.mp3",
+      "unique_id": "000000000000000000000004",
+      "length": 120.0,
+      "artist": "Artist 1 off",
+      "title": "Song 1 off",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m2_off",
+      "path": "playlist-reset-queue-at-schedule-start/m2_off.mp3",
+      "unique_id": "000000000000000000000005",
+      "length": 120.0,
+      "artist": "Artist 2 off",
+      "title": "Song 2 off",
+      "album": null,
+      "genre": null
+    },
+    {
+      "ref": "m3_off",
+      "path": "playlist-reset-queue-at-schedule-start/m3_off.mp3",
+      "unique_id": "000000000000000000000006",
+      "length": 120.0,
+      "artist": "Artist 3 off",
+      "title": "Song 3 off",
+      "album": null,
+      "genre": null
+    }
+  ],
+  "playlists": [
+    {
+      "ref": "pl_on",
+      "name": "Playlist on",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m1_on",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "m2_on",
+          "weight": 2,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "m3_on",
+          "weight": 3,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [
+        {
+          "start_time": 1200,
+          "end_time": 1300,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": false,
+          "prevent_requests": false,
+          "reset_queue_at_start": true,
+          "reset_queue_recursive": false
+        }
+      ],
+      "members": []
+    },
+    {
+      "ref": "pl_off",
+      "name": "Playlist off",
+      "config": {
+        "type": "default",
+        "source": "songs",
+        "order": "sequential",
+        "weight": 3,
+        "is_enabled": true,
+        "is_jingle": false,
+        "avoid_duplicates": false,
+        "include_in_requests": false,
+        "include_in_on_demand": false,
+        "play_per_songs": 0,
+        "play_per_minutes": 0,
+        "play_per_hour_minute": 0,
+        "backend_options": [],
+        "remote_url": null,
+        "remote_type": "stream",
+        "remote_buffer": 0,
+        "description": null
+      },
+      "folders": [],
+      "media": [
+        {
+          "media_ref": "m1_off",
+          "weight": 1,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "m2_off",
+          "weight": 2,
+          "folder_ref": null
+        },
+        {
+          "media_ref": "m3_off",
+          "weight": 3,
+          "folder_ref": null
+        }
+      ],
+      "schedules": [
+        {
+          "start_time": 1400,
+          "end_time": 1500,
+          "days": [],
+          "start_date": null,
+          "end_date": null,
+          "loop_once": false,
+          "prevent_requests": false,
+          "reset_queue_at_start": false,
+          "reset_queue_recursive": false
+        }
+      ],
+      "members": []
+    }
+  ]
+}

--- a/tests/_data/autodj/queuing/playlist-reset-queue-at-schedule-start.scenario.json
+++ b/tests/_data/autodj/queuing/playlist-reset-queue-at-schedule-start.scenario.json
@@ -1,0 +1,59 @@
+{
+  "description": "'reset_queue_at_start' also applies to a standard sequential songs playlist: with the flag the window starts at the first track even though the previous window stopped after track two; without it the playlist resumes at track three.",
+  "modes": [
+    "in_memory",
+    "integration"
+  ],
+  "cases": [
+    {
+      "name": "flag-on-restarts-at-first-track",
+      "now": "2018-01-15T12:00:00+00:00",
+      "runtime": {
+        "playlist_media": {
+          "pl_on:m1_on": {
+            "is_queued": false
+          },
+          "pl_on:m2_on": {
+            "is_queued": false
+          },
+          "pl_on:m3_on": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "pl_on",
+          "media_ref": "m1_on",
+          "playlist_chain_refs": []
+        }
+      ]
+    },
+    {
+      "name": "flag-off-resumes-at-third-track",
+      "now": "2018-01-15T14:00:00+00:00",
+      "runtime": {
+        "playlist_media": {
+          "pl_off:m1_off": {
+            "is_queued": false
+          },
+          "pl_off:m2_off": {
+            "is_queued": false
+          },
+          "pl_off:m3_off": {
+            "is_queued": true
+          }
+        }
+      },
+      "expect_sequence": [
+        {
+          "mode": "exact",
+          "playlist_ref": "pl_off",
+          "media_ref": "m3_off",
+          "playlist_chain_refs": []
+        }
+      ]
+    }
+  ]
+}

--- a/web/static/openapi.yml
+++ b/web/static/openapi.yml
@@ -10525,6 +10525,14 @@ components:
               description: 'Used to suppress the global request queue while this schedule window is active.'
               type: boolean
               example: false
+            reset_queue_at_start:
+              description: "Reset the playlist's internal queue when this schedule window becomes active."
+              type: boolean
+              example: false
+            reset_queue_recursive:
+              description: 'Also reset nested playlist groups and member playlists (playlist groups only).'
+              type: boolean
+              example: false
           type: object
     StationStreamer:
       description: 'Station streamers (DJ accounts) allowed to broadcast to a station.'


### PR DESCRIPTION
**Fixes issue:**
Fixes #8584

**Proposed changes:**
This PR adds 2 new schedule entry options to control resetting of playlists internal queue at the start of the schedule:
- Reset playlists own queue at start of a schedule
- Additionally recursively reset members of a group at schedule start