### PR TITLE
Apply the station's public API setting to the static Now Playing files

### DIFF
--- a/backend/src/VueComponent/NowPlayingComponent.php
+++ b/backend/src/VueComponent/NowPlayingComponent.php
@@ -40,6 +40,10 @@ final readonly class NowPlayingComponent implements VueComponentInterface
         $station = $request->getStation();
         $customization = $request->getCustomization();
 
+        // Stations with a disabled public API have neither a static JSON file nor a websocket channel,
+        // so fall back to the (authenticated) API endpoint for them.
+        $useStatic = $customization->useStaticNowPlaying() && $station->enable_public_api;
+
         return new NowPlayingProps(
             stationShortName: $station->short_name,
             useStatic: $customization->useStaticNowPlaying(),

--- a/backend/src/VueComponent/NowPlayingComponent.php
+++ b/backend/src/VueComponent/NowPlayingComponent.php
@@ -46,8 +46,8 @@ final readonly class NowPlayingComponent implements VueComponentInterface
 
         return new NowPlayingProps(
             stationShortName: $station->short_name,
-            useStatic: $customization->useStaticNowPlaying(),
-            useSse: $customization->useStaticNowPlaying() && $this->centrifugo->isSupported()
+            useStatic: $useStatic,
+            useSse: $useStatic && $this->centrifugo->isSupported()
         );
     }
 }

--- a/backend/src/Webhook/LocalWebhookHandler.php
+++ b/backend/src/Webhook/LocalWebhookHandler.php
@@ -57,6 +57,14 @@ final class LocalWebhookHandler
         $npStaticFile = $staticNpDir . '/' . $station->short_name . '.txt';
 
         $fsUtils->dumpFile($npFile, $npText);
+
+        $staticNpPath = $staticNpDir . '/' . $station->short_name . '.json';
+
+        if (!$station->enable_public_api) {
+            $fsUtils->remove([$staticNpPath, $npStaticFile]);
+            return;
+        }
+
         $fsUtils->dumpFile($npStaticFile, $npText);
 
         // Write JSON file to disk so nginx can serve it without calling the PHP stack at all.

--- a/backend/src/Webhook/LocalWebhookHandler.php
+++ b/backend/src/Webhook/LocalWebhookHandler.php
@@ -70,7 +70,6 @@ final class LocalWebhookHandler
         // Write JSON file to disk so nginx can serve it without calling the PHP stack at all.
         $this->logger->debug('Writing static nowplaying text file...');
 
-        $staticNpPath = $staticNpDir . '/' . $station->short_name . '.json';
         $fsUtils->dumpFile(
             $staticNpPath,
             json_encode($np, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?: ''


### PR DESCRIPTION
When a station has both public pages and the public API disabled, /api/nowplaying/{station} correctly returns a 404 for unauthenticated requests. The static equivalent, /api/nowplaying_static/{short_name}.json, stays fully readable by anyone: nginx serves it straight from www_tmp/nowplaying, so no PHP check ever runs. The same applies to the .txt file next to it and to the Centrifugo channel behind /api/live/nowplaying/sse, which is also unauthenticated.

LocalWebhookHandler now writes those files (and publishes to Centrifugo) only when $station->enable_public_api is true, and removes any file left over from when the station was still public.

NowPlayingComponent is the necessary counterpart: with static updates enabled globally, the station profile page would otherwise keep requesting a file that no longer exists. For stations without a public API it now falls back to the authenticated /api/nowplaying/{station} endpoint.

**Fixes issue:**
#8603

**Proposed changes:**
- LocalWebhookHandler writes www_tmp/nowplaying/<short_name>.json and the matching .txt only when the station's public API is enabled, and deletes both if they are already there from when the station was still public.
- The same condition now guards the Centrifugo publish, so the unauthenticated SSE channel (/api/live/nowplaying/sse) no longer carries data for those stations either.
- NowPlayingComponent reports useStatic and useSse only when the station's public API is enabled; for other stations the frontend falls back to /api/nowplaying/{station}, which still works for authenticated users such as the station profile page.
- Nothing changes for stations that have public pages or the public API enabled, since enable_public_api already returns true whenever enable_public_page is true.